### PR TITLE
Retire the brand purple onto the one accent the design system already…

### DIFF
--- a/.changeset/tidy-moons-shake.md
+++ b/.changeset/tidy-moons-shake.md
@@ -6,3 +6,11 @@ Retire the brand purple: every accent now resolves through the design system's
 `accent` / `accent-hover` tokens instead of the off-system `--color-bevel*`
 block, which is deleted. One accent colour where there used to be two competing
 for the same job.
+
+Both accent tokens are darkened by 5 points of HSL lightness as part of the
+move — `accent` #2383e2 → #1b76d0, `accent-hover` #1b74cb → #1867b4. The retired
+purple cleared WCAG AA under `text-white` (5.14:1) and the prototype's blue did
+not (3.88:1), so consolidating onto it would have taken those controls below the
+4.5:1 their text-xs/text-sm labels need. The new value is 4.62:1 and also lifts
+`text-accent` links, which sit on the same pair against white. Hue and
+saturation are unchanged, as is the accent→hover gap.

--- a/.changeset/tidy-moons-shake.md
+++ b/.changeset/tidy-moons-shake.md
@@ -1,0 +1,8 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Retire the brand purple: every accent now resolves through the design system's
+`accent` / `accent-hover` tokens instead of the off-system `--color-bevel*`
+block, which is deleted. One accent colour where there used to be two competing
+for the same job.

--- a/packages/core-frontend/src/index.css
+++ b/packages/core-frontend/src/index.css
@@ -11,15 +11,12 @@
 @import './shared/theme/index.css';
 @plugin "@tailwindcss/typography";
 
-/* Brand purple. Not part of the design system: the prototype has no purple,
-   and the fate of these 46 call sites is an open decision (T21). Kept here,
-   outside `shared/theme/`, so the token module stays free of undecided
-   values. */
-@theme {
-  --color-bevel: #863bff;
-  --color-bevel-deep: #7e14ff;
-  --color-bevel-soft: #ede6ff;
-}
+/* T21 is resolved: the brand purple is retired. Every call site now uses the
+   design system's `accent` / `accent-hover`, so the app has ONE accent colour
+   instead of a blue token and a purple one competing for the same job. The
+   `--color-bevel*` tokens are deliberately not kept as aliases — an alias
+   would let new purple call sites appear without anyone re-opening the
+   decision. */
 
 /* Tailwind Typography ships dark <pre> backgrounds by default; the app is
    light-only, so retheme prose code blocks onto the design tokens.

--- a/packages/core-frontend/src/lib/utils.ts
+++ b/packages/core-frontend/src/lib/utils.ts
@@ -60,10 +60,6 @@ const twMerge = extendTailwindMerge({
         'mark-del',
         'mark-ins',
         'scrim',
-        // brand purple — outside the design system, fate pending (T21)
-        'bevel',
-        'bevel-deep',
-        'bevel-soft',
       ],
       shadow: ['overlay', 'card'],
     },

--- a/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
@@ -321,7 +321,7 @@ function NewRoleControl({
         <button
           type="button"
           onClick={submit}
-          className="px-2 py-1 text-xs rounded bg-bevel hover:bg-bevel-deep text-white disabled:opacity-50 flex items-center gap-1"
+          className="px-2 py-1 text-xs rounded bg-accent hover:bg-accent-hover text-white disabled:opacity-50 flex items-center gap-1"
         >
           Add
         </button>
@@ -930,7 +930,7 @@ function ConfirmDialog({
             onClick={onConfirm}
             disabled={busy}
             className={`px-3 py-1.5 text-xs rounded text-white disabled:opacity-50 flex items-center gap-1 ${
-              danger ? 'bg-red-600 hover:bg-red-700' : 'bg-bevel hover:bg-bevel-deep'
+              danger ? 'bg-red-600 hover:bg-red-700' : 'bg-accent hover:bg-accent-hover'
             }`}
           >
             {busy && <Loader2 size={12} className="animate-spin" />}

--- a/packages/core-frontend/src/modules/admin/components/UserAccountsPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/UserAccountsPage.tsx
@@ -260,7 +260,7 @@ export function UserAccountsPage() {
             <button
               type="submit"
               disabled={adding}
-              className="rounded-md bg-bevel text-white text-sm font-medium px-3 py-1.5 hover:bg-bevel-deep disabled:opacity-60 disabled:cursor-not-allowed"
+              className="rounded-md bg-accent text-white text-sm font-medium px-3 py-1.5 hover:bg-accent-hover disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {adding ? 'Adding…' : 'Add account'}
             </button>
@@ -286,7 +286,7 @@ export function UserAccountsPage() {
             <button
               onClick={confirmSetPassword}
               disabled={savingPassword || newPassword.length === 0}
-              className="px-3 py-1.5 text-sm rounded-sm bg-bevel hover:bg-bevel-deep text-white disabled:opacity-50"
+              className="px-3 py-1.5 text-sm rounded-sm bg-accent hover:bg-accent-hover text-white disabled:opacity-50"
             >
               {savingPassword ? 'Saving…' : 'Set password'}
             </button>

--- a/packages/core-frontend/src/modules/auth/components/AccountPage.tsx
+++ b/packages/core-frontend/src/modules/auth/components/AccountPage.tsx
@@ -102,7 +102,7 @@ export function AccountPage() {
           <button
             type="submit"
             disabled={submitting}
-            className="rounded-md bg-bevel text-white text-sm font-medium px-4 py-2 hover:bg-bevel-deep disabled:opacity-60 disabled:cursor-not-allowed"
+            className="rounded-md bg-accent text-white text-sm font-medium px-4 py-2 hover:bg-accent-hover disabled:opacity-60 disabled:cursor-not-allowed"
           >
             {submitting ? 'Saving…' : 'Change password'}
           </button>

--- a/packages/core-frontend/src/modules/auth/components/LoginScreen.tsx
+++ b/packages/core-frontend/src/modules/auth/components/LoginScreen.tsx
@@ -100,7 +100,7 @@ export function LoginScreen() {
             <button
               type="submit"
               disabled={submitting}
-              className="w-full rounded-md bg-bevel text-white text-sm font-medium py-2 hover:bg-bevel-deep disabled:opacity-60 disabled:cursor-not-allowed"
+              className="w-full rounded-md bg-accent text-white text-sm font-medium py-2 hover:bg-accent-hover disabled:opacity-60 disabled:cursor-not-allowed"
             >
               {submitting ? 'Signing in…' : 'Sign in'}
             </button>

--- a/packages/core-frontend/src/modules/layout/components/MaintenanceOverlay.tsx
+++ b/packages/core-frontend/src/modules/layout/components/MaintenanceOverlay.tsx
@@ -89,7 +89,7 @@ export function MaintenanceOverlay() {
 
   return (
     <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center gap-4 bg-white/95 backdrop-blur-sm text-center px-6">
-      <Loader2 size={32} className="animate-spin text-bevel" />
+      <Loader2 size={32} className="animate-spin text-accent" />
       <div>
         <p className="text-lg font-medium text-ink">
           We&rsquo;re installing an update

--- a/packages/core-frontend/src/modules/layout/components/ResizableThreePaneLayout.tsx
+++ b/packages/core-frontend/src/modules/layout/components/ResizableThreePaneLayout.tsx
@@ -23,7 +23,7 @@ import type { PaneDef } from '../../../core/registry';
 
 const LAYOUT_ID = 'bevel-shell-v1';
 const SEPARATOR_CLASS =
-  'w-px bg-sunken hover:bg-bevel-deep/60 data-[dragging=true]:bg-bevel-deep transition-colors outline-none focus-visible:bg-bevel-deep cursor-col-resize';
+  'w-px bg-sunken hover:bg-accent-hover/60 data-[dragging=true]:bg-accent-hover transition-colors outline-none focus-visible:bg-accent-hover cursor-col-resize';
 
 function getSafeLocalStorage(): Storage | undefined {
   if (typeof window === 'undefined') return undefined;

--- a/packages/core-frontend/src/modules/pr/components/PrFileRow.tsx
+++ b/packages/core-frontend/src/modules/pr/components/PrFileRow.tsx
@@ -21,7 +21,7 @@ function KindIcon({ status }: { status: PullRequestFile['status'] }) {
     case 'added': return <FilePlus2 size={size} className="text-emerald-600" />;
     case 'removed': return <FileX2 size={size} className="text-red-600" />;
     case 'renamed':
-    case 'copied': return <ArrowRightLeft size={size} className="text-bevel" />;
+    case 'copied': return <ArrowRightLeft size={size} className="text-accent" />;
     case 'modified':
     case 'changed': return <FileEdit size={size} className="text-amber-600" />;
     default: return <FileQuestion size={size} className="text-ink-muted" />;

--- a/packages/core-frontend/src/modules/pr/components/PrViewer.tsx
+++ b/packages/core-frontend/src/modules/pr/components/PrViewer.tsx
@@ -27,7 +27,7 @@ type CommentScope = 'file' | 'all';
 const PR_LAYOUT_ID = 'bevel-pr-viewer-v1';
 const PR_PANEL_IDS = ['files', 'diff', 'comments'];
 const SEPARATOR_CLASS =
-  'w-px bg-sunken hover:bg-bevel-deep/60 data-[dragging=true]:bg-bevel-deep transition-colors outline-none focus-visible:bg-bevel-deep cursor-col-resize';
+  'w-px bg-sunken hover:bg-accent-hover/60 data-[dragging=true]:bg-accent-hover transition-colors outline-none focus-visible:bg-accent-hover cursor-col-resize';
 
 function getSafeLocalStorage(): Storage | undefined {
   if (typeof window === 'undefined') return undefined;

--- a/packages/core-frontend/src/modules/review/components/ReviewFileRow.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewFileRow.tsx
@@ -24,7 +24,7 @@ function KindIcon({ kind }: { kind: PendingChange['kind'] }) {
   switch (kind) {
     case 'added': return <FilePlus2 size={size} className="text-emerald-600" />;
     case 'deleted': return <FileX2 size={size} className="text-red-600" />;
-    case 'renamed': return <ArrowRightLeft size={size} className="text-bevel" />;
+    case 'renamed': return <ArrowRightLeft size={size} className="text-accent" />;
     case 'modified': return <FileEdit size={size} className="text-amber-600" />;
   }
 }

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -181,7 +181,7 @@ export function ExternalAgentAccessPage() {
               onClick={() => setTab(id)}
               className={`px-3 py-2 text-xs font-medium border-b-2 -mb-px ${
                 tab === id
-                  ? 'border-bevel text-ink'
+                  ? 'border-accent text-ink'
                   : 'border-transparent text-ink-muted hover:text-ink'
               }`}
             >
@@ -285,7 +285,7 @@ export function ExternalAgentAccessPage() {
                 <button
                   onClick={handleCreate}
                   disabled={!canSubmit}
-                  className="px-3 py-1.5 text-sm rounded bg-bevel hover:bg-bevel-deep text-white disabled:opacity-50 disabled:hover:bg-bevel"
+                  className="px-3 py-1.5 text-sm rounded bg-accent hover:bg-accent-hover text-white disabled:opacity-50 disabled:hover:bg-accent"
                 >
                   {creating ? 'Creating…' : 'Create key'}
                 </button>
@@ -344,7 +344,7 @@ export function ExternalAgentAccessPage() {
                               </div>
                               <div className="mt-0.5 h-1 rounded bg-sunken overflow-hidden">
                                 <div
-                                  className={`h-full ${overCap ? 'bg-red-500' : 'bg-bevel'}`}
+                                  className={`h-full ${overCap ? 'bg-red-500' : 'bg-accent'}`}
                                   style={{ width: `${pct}%` }}
                                 />
                               </div>
@@ -507,7 +507,7 @@ export function ExternalAgentAccessPage() {
             <div className="flex justify-end px-4 py-3 border-t border-line">
               <button
                 onClick={() => setReveal(null)}
-                className="px-3 py-1.5 text-sm rounded bg-bevel hover:bg-bevel-deep text-white"
+                className="px-3 py-1.5 text-sm rounded bg-accent hover:bg-accent-hover text-white"
               >
                 Done — I've saved it
               </button>

--- a/packages/core-frontend/src/modules/workspace/components/renderers/KbMarkdownView.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/KbMarkdownView.tsx
@@ -106,7 +106,7 @@ function FrontmatterValue({
           e.preventDefault();
           onOpenFile(href);
         }}
-        className="text-bevel hover:text-bevel-deep hover:underline cursor-pointer"
+        className="text-accent hover:text-accent-hover hover:underline cursor-pointer"
       >
         {label}
       </a>

--- a/packages/core-frontend/src/shared/theme/__tests__/accent-contrast.test.ts
+++ b/packages/core-frontend/src/shared/theme/__tests__/accent-contrast.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The accent tokens must stay legible under white.
+ *
+ * Why a test and not a review habit: a contrast ratio is invisible to every
+ * gate the repo already has. Tailwind compiles `bg-accent` and `text-accent`
+ * whatever the value is, tsc has no opinion on hex, and the design-system
+ * ratchet counts OFF-system values — `bg-accent` is the on-system answer, so
+ * it stays silent no matter how light the token drifts. Nothing errors; the
+ * label just gets harder to read. Only measuring catches it.
+ *
+ * The accent is the one token where this matters, because it is the only one
+ * carrying both roles against the same white:
+ *
+ *   bg-accent + text-white   Button's primary variant and every control
+ *                            ported onto it (the prototype's `.btn.primary`)
+ *   text-accent on canvas    links, tab underlines, checkmarks, dirty dots
+ *
+ * Both are `--color-accent` vs `#ffffff`, so one ratio governs both and a
+ * single token edit is what fixes them. Threshold is WCAG AA for normal text
+ * (4.5:1), not large text (3:1), because these labels are text-xs/text-sm.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Resolved off this file rather than `process.cwd()` so the test does not
+// care which directory vitest was launched from. Deliberately NOT written as
+// `new URL('../tokens.css', import.meta.url)`: Vite rewrites that exact
+// pattern into an asset URL, and the http-scheme result fails fileURLToPath.
+const TOKENS = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'tokens.css'),
+  'utf8',
+);
+
+/** Reads a token's literal off its declaration, ignoring hex in comments. */
+function token(name: string): string {
+  const match = TOKENS.match(
+    new RegExp(`^\\s*--color-${name}:\\s*(#[0-9a-fA-F]{6})\\s*;`, 'm'),
+  );
+  if (!match) throw new Error(`--color-${name} not found in tokens.css`);
+  return match[1];
+}
+
+/** WCAG 2.1 relative luminance. */
+function luminance(hex: string): number {
+  const channels = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+  const [r, g, b] = channels.map((c) =>
+    c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const WHITE = '#ffffff';
+const AA_NORMAL_TEXT = 4.5;
+
+describe('accent contrast', () => {
+  // Self-check: the formula reproduces two published ratios, so a failure
+  // below is the token moving rather than the maths rotting.
+  it('computes known WCAG ratios', () => {
+    expect(contrast('#000000', WHITE)).toBeCloseTo(21, 5);
+    expect(contrast(WHITE, WHITE)).toBeCloseTo(1, 5);
+  });
+
+  it.each(['accent', 'accent-hover'])(
+    '--color-%s clears AA against white',
+    (name) => {
+      expect(contrast(token(name), WHITE)).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+    },
+  );
+
+  // The hover step is an affordance: it has to be visible, and it has to go
+  // the same direction the prototype's did (darker, never lighter). Equal
+  // ratios would pass the check above while rendering as no feedback at all.
+  it('accent-hover is perceptibly darker than accent', () => {
+    expect(luminance(token('accent-hover'))).toBeLessThan(luminance(token('accent')));
+    expect(contrast(token('accent'), token('accent-hover'))).toBeGreaterThan(1.1);
+  });
+});

--- a/packages/core-frontend/src/shared/theme/tokens.css
+++ b/packages/core-frontend/src/shared/theme/tokens.css
@@ -43,9 +43,26 @@
 
   /* ── interactive ──────────────────────────────────────────────────────
      Exactly ONE interactive colour. If something is blue it is clickable
-     and primary; everything else earns attention through weight, not hue. */
-  --color-accent: #2383e2;
-  --color-accent-hover: #1b74cb;
+     and primary; everything else earns attention through weight, not hue.
+
+     Both values are the prototype's blues darkened by the same 5 points of
+     HSL lightness; hue (209.8°) and saturation (76.7%) are untouched, as is
+     the 6.1-point accent→hover gap, so the hover step feels identical.
+
+     The darkening is a CONTRAST fix, not a taste one. The accent carries
+     both roles — `bg-accent` under `text-white` (Button's primary variant,
+     ported from the prototype's `.btn.primary`) and `text-accent` on the
+     white canvas — and both are the same colour pair against #ffffff. The
+     prototype's #2383e2 gives 3.88:1 there, under the 4.5:1 that WCAG AA
+     asks for the text-xs/text-sm labels these controls use. #1b76d0 gives
+     4.62:1 and fixes both roles at once, which is why this is an edit here
+     rather than a foreground change at the call sites.
+
+     `__tests__/accent-contrast.test.ts` parses these two lines and fails if
+     either drops below 4.5:1 — the ratio is invisible to the build, exactly
+     like the palette counts the design-system ratchet guards.             */
+  --color-accent: #1b76d0;
+  --color-accent-hover: #1867b4;
 
   /* ── status ───────────────────────────────────────────────────────────
      `wait` is the text/icon colour; `wait-dot` is the saturated fill used


### PR DESCRIPTION
… had

T21 asked what to do with `--color-bevel`, a purple kept deliberately outside `shared/theme/` because the prototype has none. The answer is that it had no job: `--color-accent` was already blue and already semantic, so the app was carrying two accents that competed for the same role.

Every call site moves to `accent` / `accent-hover` — which is, character for character, what `Button`'s `primary` variant already rendered. The tokens themselves are deleted rather than aliased: an alias would let new purple appear without anyone re-opening the decision.

Not touched: `application/x-bevel-tab-path` and the `x-bevel-session` header. Those share the prefix and nothing else; a blind rename would have broken tab drag-and-drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated buttons, links, icons, progress indicators, spinners, and interactive separators to use the design system’s accent colors.
  * Removed legacy purple brand styling across the interface.
  * Standardized hover, focus, dragging, and active states with accent and accent-hover colors.
  * Applied the updated styling across authentication, administration, workspace, code review, and external access screens.
  * Improved accent color contrast for clearer, more accessible text and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->