### PR TITLE
Let a Docker deployment sign in, and stop it fighting itself for port 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,24 @@ pnpm build
 
 # 3. Configure
 cp .env.example .env   # then fill in at least: DATABASE_URL, JWT_SECRET,
-                       # TEST_PASSWORD, KB_REPO_URL, GIT_TOKEN, SECRETS_ENC_KEY,
-                       # SEED_ADMIN_EMAILS (for an empty KB repo)
+                       # ADMIN_EMAIL + ADMIN_PASSWORD (your way in before any
+                       # account exists), KB_REPO_URL, GIT_TOKEN,
+                       # SECRETS_ENC_KEY, SEED_ADMIN_EMAILS (for an empty KB repo)
 
 # 4. Run (backend :3001 + Vite dev server :5173)
 pnpm dev
 ```
 
 Or run the whole thing in Docker: `docker compose up` (Postgres + the app serving
-the built SPA on :3001).
+the built SPA on :3001). Use `APP_PORT=8080 docker compose up` for a different
+host port.
+
+**Behind a reverse proxy** (Coolify, Traefik, nginx), deploy with an explicit
+`-f docker-compose.yml`. That skips `docker-compose.override.yml`, so the app
+publishes no host port and the proxy reaches it on port 3001 over the compose
+network. Publishing a fixed host port instead makes every redeploy fail with
+`port is already allocated`, because the replacement container starts while the
+outgoing one still holds it.
 
 ## Environment variables (core subset)
 
@@ -46,7 +55,7 @@ the built SPA on :3001).
 | --- | --- | --- |
 | `DATABASE_URL` | yes | Postgres connection string |
 | `JWT_SECRET` | yes | Signs login sessions + OAuth state |
-| `TEST_PASSWORD` | yes* | Shared password for password login (`LOGIN_PASSWORD=false` disables the method) |
+| `ADMIN_EMAIL` / `ADMIN_PASSWORD` | first boot | Bootstrap admin sign-in, checked against the env and never stored — the only way into a deployment with no accounts yet. Unset either to revoke it |
 | `KB_REPO_URL` | yes | https clone/push URL of the knowledge-base repo (any git host) |
 | `GIT_TOKEN` / `GIT_USERNAME` | yes | Git credential (Basic password / host-specific username) |
 | `SECRETS_ENC_KEY` | yes | 32-byte key (base64/hex) encrypting vault secrets + MCP OAuth tokens |
@@ -57,6 +66,9 @@ the built SPA on :3001).
 | `PUBLIC_BACKEND_URL` / `PUBLIC_FRONTEND_URL` | prod | Public origins for OAuth redirects + bounces |
 | `TENANT_ID` | no | Slug branding every credential prefix (default `bevel`) |
 | `ALLOWED_EMAIL_DOMAINS` | no | Email-domain allow-list for login |
+| `LOGIN_PASSWORD` | no | `false` hides password login and rejects `/api/auth/login` |
+| `OIDC_ISSUER_URL` / `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` | no | Generic OIDC single sign-on; the method appears once all three are set |
+| `TRUST_PROXY` | behind a proxy | Reverse-proxy hop count, so `req.ip` and the per-IP login rate limit see the real client |
 | `KB_TEMPLATE_DIR` | no | Overrides the packaged KB seed template |
 | `ONTOLOGY_SESSION_BLOCK` | no | Ontology-session touch tracking toggle (default on) |
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,18 @@
+# Local convenience, merged automatically by `docker compose up` when no `-f`
+# is given. It exists so the standalone quickstart still lands the app on
+# http://localhost:3001 while `docker-compose.yml` itself publishes nothing.
+#
+# WHY THE SPLIT: a published host port is a resource exactly one container can
+# hold. Orchestrators (Coolify, Portainer, Swarm, plain `docker compose up -d`
+# on a redeploy) start the replacement container before retiring the outgoing
+# one, so a fixed host port in the base file makes every redeploy fail with
+# "Bind for 0.0.0.0:3001 failed: port is already allocated". Those callers pass
+# an explicit `-f docker-compose.yml`, which tells Compose to skip this file —
+# they get the container reachable over the network by their proxy, and no host
+# port to collide on.
+#
+# To publish a different host port locally: APP_PORT=8080 docker compose up
+services:
+  app:
+    ports:
+      - "${APP_PORT:-3001}:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,19 @@ services:
         # checks match the bundled frontend.
         DEFAULT_BRANCH: ${DEFAULT_BRANCH:-}
         PROTECTED_BRANCHES: ${PROTECTED_BRANCHES:-}
-    ports:
-      - "3001:3001"
+    # NO host port is published here, deliberately. A reverse proxy (Coolify,
+    # Traefik, nginx) reaches the container on this port over the compose
+    # network, and publishing a FIXED host port alongside that breaks every
+    # redeploy: the replacement container starts while the outgoing one still
+    # holds the port, and Docker refuses it with "port is already allocated".
+    #
+    # `docker compose up` with no `-f` still publishes it — that is what
+    # `docker-compose.override.yml` is for, and Compose merges it
+    # automatically. Passing `-f docker-compose.yml` (as orchestrators do)
+    # skips the override and leaves the container unpublished, which is
+    # exactly the split we want.
+    expose:
+      - "3001"
     environment:
       - NODE_ENV=production
       - PORT=3001
@@ -52,7 +63,21 @@ services:
       - GIT_TOKEN=${GIT_TOKEN}
       - GIT_USERNAME=${GIT_USERNAME:-}
       - JWT_SECRET=${JWT_SECRET}
-      - TEST_PASSWORD=${TEST_PASSWORD}
+      # Bootstrap admin — the ONLY way into a deployment whose KB has no
+      # accounts yet. Checked against the environment at login time and never
+      # stored, so unsetting either variable revokes it immediately.
+      - ADMIN_EMAIL=${ADMIN_EMAIL:-}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+      # Generic OIDC single sign-on; the method appears once all three are set.
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}
+      - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}
+      - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
+      - OIDC_SCOPES=${OIDC_SCOPES:-}
+      - OIDC_PROVIDER_LABEL=${OIDC_PROVIDER_LABEL:-}
+      # Reverse-proxy hop count. Required behind a proxy (Coolify, Traefik,
+      # nginx) or every request looks like it came from the proxy — which
+      # collapses the per-IP login rate limit onto one bucket.
+      - TRUST_PROXY=${TRUST_PROXY:-}
       # Tenant slug branded into every credential prefix. Default `bevel`
       # keeps pre-existing keys/tokens valid — change it only for a fresh deploy.
       - TENANT_ID=${TENANT_ID:-bevel}


### PR DESCRIPTION
Two deployment bugs, one of which was hiding the other.

## A Docker deployment could not sign in

`TEST_PASSWORD` was removed from the code by the auth overhaul (8157f59) but left behind in `docker-compose.yml` and the README. Dead on its own — and looking for it turned up what replaced it.

The app now reads `ADMIN_EMAIL` + `ADMIN_PASSWORD`: the bootstrap credential checked against the environment at login time, and **the only way into a deployment whose KB has no accounts yet**. Compose never passed either into the container. Nor `OIDC_*`, nor `TRUST_PROXY`. `.env.example` was updated by that overhaul; `docker-compose.yml` was not.

`TRUST_PROXY` is worth calling out separately: without it, behind a proxy every request appears to come from the proxy, so the per-IP login rate limit buckets all users together.

All of them are forwarded now, and the stale name is gone from both files.

## Every redeploy fought itself for port 3001

```
Container app-…-112043776601  Starting
Error response from daemon: driver failed programming external connectivity …
Bind for 0.0.0.0:3001 failed: port is already allocated
```

`ports: "3001:3001"` claims a resource exactly one container can hold, and orchestrators start the replacement before retiring the outgoing one.

The base file now publishes nothing and only `expose`s 3001 — which is what a reverse proxy connects to over the compose network. The host publish moves to `docker-compose.override.yml`, which Compose merges automatically for a bare `docker compose up` and **skips when `-f` is given explicitly** — the form orchestrators use, Coolify included.

So the quickstart still lands on `localhost:3001` (`APP_PORT=8080` to move it), and the proxied deploy has no host port to collide on.

## Verification

Resolved the file both ways rather than assuming the override semantics:

| Command | Published ports |
| --- | --- |
| `docker compose config` | `3001` (`8080` with `APP_PORT=8080`) |
| `docker compose -f docker-compose.yml config` | none, and the new env keys present |

## Not fixed by this PR

A container from the failed deploy is still holding 3001 on the host and has to be removed once (`docker ps --filter publish=3001`). Redeploys stop colliding after that.

Before the next deploy, set `ADMIN_EMAIL`, `ADMIN_PASSWORD` and `TRUST_PROXY=1` in Coolify — they are new passthroughs, so they are not carried over from the current config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded quickstart guidance for required setup variables, Docker port configuration, and reverse-proxy deployments.
  - Added documentation for admin bootstrap, password login, OIDC, and trusted-proxy settings.

- **New Features**
  - Local Docker Compose runs now publish the application on a configurable host port.
  - Added configuration support for initial administrator setup, authentication providers, and reverse-proxy environments.

- **Configuration**
  - Updated container settings to use the new authentication and deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->