### PR TITLE
Fix/skills sidebar context menu

### DIFF
--- a/.changeset/olive-donkeys-listen.md
+++ b/.changeset/olive-donkeys-listen.md
@@ -1,0 +1,30 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Right-click works in the Library nav, the way it already did in Knowledge's file
+tree. It answered nothing before — no `onContextMenu` existed anywhere in
+`GroupsSidebar`, so the gesture fell through to the browser's own menu on the
+one surface that most looks like it should have its own.
+
+The BEHAVIOUR is the file tree's, deliberately: the panel opens at the pointer,
+an outside click or Escape closes it, and Escape hands focus back to the row it
+came from — the same `useDismissableMenu` wiring, since `MenuPanel` is
+presentation only and provides none of it. Two sidebars in one frame should not
+answer the same gesture two different ways.
+
+The ITEMS are the Library's own, because a group is not a file. A group row gets
+`Add a skill or tool` · `New group` · `Copy link` · `Manage access`; a LENS row
+("Owned by me", your own space) gets only the two that a slice of the catalog
+can answer, since there is no folder and therefore no `access.md` behind a
+slice — the same call `PageActions` already makes when it hides `Share` on the
+personal page. The nav's empty space gets `New group` alone. Rename, Delete and
+Download are deliberately absent: no endpoint stands behind any of them for a
+group, and a menu item that cannot do its job is worse than one that is not
+there.
+
+`Manage access` stays ungated on `canWrite`, exactly as the group page's `Share`
+is — for a non-writer the dialog renders read-only, which is precisely what "who
+is this shared with?" should answer, and for an admin locked out of a group it
+is the self-service way back in. Locked rows get the full menu for the same
+reason they get the same click: a group you are not in is still a place.

--- a/packages/core-frontend/src/modules/library/__tests__/GroupsSidebar.contextmenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/GroupsSidebar.contextmenu.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import { GroupsSidebar, type GroupsSidebarProps } from '../components/GroupsSidebar';
+
+/**
+ * Right-click in the Library nav, which has to answer the gesture the way
+ * Knowledge's file tree does — the same one the platform has had since the tree
+ * shipped (`FileExplorer.tsx:532`).
+ *
+ * The sidebar itself only REPORTS the click: it suppresses the browser menu,
+ * reads the pointer and the row synchronously, and hands both up. Everything
+ * about which verbs are true for a given row lives in `LibraryLayout`, because
+ * that is where the group summaries are — so that is where those assertions
+ * live too.
+ */
+
+function renderSidebar(over: Partial<GroupsSidebarProps> = {}) {
+  const onContextMenu = vi.fn();
+  const onSelect = vi.fn();
+  const props: GroupsSidebarProps = {
+    filter: { kind: 'all' },
+    onSelect,
+    groups: [
+      { group: 'Engineering', count: 4, attention: 0 },
+      { group: 'GTM', count: 3, attention: 2 },
+    ],
+    lockedGroups: ['Finance'],
+    ownedCount: 2,
+    ownedAttention: 0,
+    personalGroupLabel: "Juan's Group",
+    ungroupedCount: 1,
+    attentionCount: 2,
+    onFinishSetup: vi.fn(),
+    onCreateGroup: vi.fn(),
+    onContextMenu,
+    ...over,
+  };
+  render(<GroupsSidebar {...props} />);
+  return { onContextMenu, onSelect };
+}
+
+const nav = () => screen.getByRole('navigation', { name: 'Library groups' });
+const rightClick = (el: Element, at = { clientX: 120, clientY: 240 }) =>
+  fireEvent.contextMenu(el, at);
+
+describe('GroupsSidebar — right-click', () => {
+  it('reports a group row with its filter, its name and the pointer', () => {
+    const { onContextMenu } = renderSidebar();
+    const gtm = screen.getByRole('button', { name: /^GTM/ });
+    rightClick(gtm, { clientX: 88, clientY: 310 });
+
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    expect(onContextMenu).toHaveBeenCalledWith({
+      filter: { kind: 'group', group: 'GTM' },
+      label: 'GTM',
+      x: 88,
+      y: 310,
+      // The row itself, so Escape can hand focus back to it.
+      row: gtm,
+    });
+  });
+
+  it('reports a lens row by the filter it navigates to, not by its label', () => {
+    const { onContextMenu } = renderSidebar();
+    rightClick(screen.getByRole('button', { name: /^Owned by me/ }));
+    expect(onContextMenu.mock.calls[0][0]).toMatchObject({
+      filter: { kind: 'owned' },
+      label: 'Owned by me',
+    });
+
+    rightClick(screen.getByRole('button', { name: /^Juan's Group/ }));
+    expect(onContextMenu.mock.calls[1][0]).toMatchObject({
+      filter: { kind: 'ungrouped' },
+      label: "Juan's Group",
+    });
+  });
+
+  /**
+   * A locked row emits the same `{ kind: 'group' }` target a readable one does,
+   * for the same reason its CLICK does: a group you are not in is still a place.
+   * The label drops the "(locked)" suffix — that is the accessible name, not the
+   * group's name, and the menu titles itself with the latter.
+   */
+  it('reports a locked row exactly like a readable group', () => {
+    const { onContextMenu } = renderSidebar();
+    rightClick(screen.getByRole('button', { name: 'Finance (locked)' }));
+    expect(onContextMenu.mock.calls[0][0]).toMatchObject({
+      filter: { kind: 'group', group: 'Finance' },
+      label: 'Finance',
+    });
+  });
+
+  it('reports the empty nav space as a target with no filter and no row', () => {
+    const { onContextMenu } = renderSidebar();
+    rightClick(nav());
+    expect(onContextMenu).toHaveBeenCalledWith({
+      filter: null,
+      label: 'Library',
+      x: 120,
+      y: 240,
+      row: null,
+    });
+  });
+
+  /**
+   * The nav wraps every row, so without `stopPropagation` a right-click on a
+   * group would report the group AND then the empty space — and the layout
+   * would render the empty-space menu, since the last call wins.
+   */
+  it('does not also report the nav when the click landed on a row', () => {
+    const { onContextMenu } = renderSidebar();
+    rightClick(screen.getByRole('button', { name: /^Engineering/ }));
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+    expect(onContextMenu.mock.calls[0][0].filter).toEqual({ kind: 'group', group: 'Engineering' });
+  });
+
+  it('suppresses the browser menu when the click is being handled', () => {
+    renderSidebar();
+    const gtm = screen.getByRole('button', { name: /^GTM/ });
+    const event = createEvent.contextMenu(gtm);
+    fireEvent(gtm, event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  /**
+   * With nobody listening there is nothing to open, and swallowing the gesture
+   * would leave the user with no menu at all — worse than the browser's.
+   */
+  it("leaves the browser's own menu alone when no handler is wired", () => {
+    renderSidebar({ onContextMenu: undefined });
+    const gtm = screen.getByRole('button', { name: /^GTM/ });
+    const event = createEvent.contextMenu(gtm);
+    fireEvent(gtm, event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('still navigates on a left click — the menu changes nothing about selection', () => {
+    const { onSelect, onContextMenu } = renderSidebar();
+    fireEvent.click(screen.getByRole('button', { name: /^GTM/ }));
+    expect(onSelect).toHaveBeenCalledWith({ kind: 'group', group: 'GTM' });
+    expect(onContextMenu).not.toHaveBeenCalled();
+  });
+
+  it('marks the current row from the target it navigates to', () => {
+    renderSidebar({ filter: { kind: 'group', group: 'GTM' } });
+    expect(screen.getByRole('button', { name: /^GTM/ })).toHaveAttribute('aria-current', 'true');
+    expect(screen.getByRole('button', { name: /^Engineering/ })).toHaveAttribute(
+      'aria-current',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: /^Owned by me/ })).toHaveAttribute(
+      'aria-current',
+      'false',
+    );
+  });
+});

--- a/packages/core-frontend/src/modules/library/__tests__/GroupsSidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/GroupsSidebarMenu.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { GroupsSidebarMenu, type GroupsSidebarMenuProps } from '../components/GroupsSidebarMenu';
+
+/**
+ * The Library nav's right-click menu.
+ *
+ * Two things are under test and they are not the same thing. The ITEMS are the
+ * Library's own — a group is not a file, so this menu says `New group` where
+ * the tree says `New folder` — but the BEHAVIOUR has to be the file tree's,
+ * because a right-click that dismisses one way in Knowledge and another way in
+ * Skills is two products in one window. Outside click closes, Escape closes,
+ * Escape returns focus to the row (`useDismissableMenu`).
+ */
+
+function renderMenu(over: Partial<GroupsSidebarMenuProps> = {}) {
+  const onClose = vi.fn();
+  const props: GroupsSidebarMenuProps = {
+    x: 140,
+    y: 260,
+    label: 'GTM',
+    onClose,
+    onAdd: vi.fn(),
+    onCreateGroup: vi.fn(),
+    onCopyLink: vi.fn(),
+    onManageAccess: vi.fn(),
+    ...over,
+  };
+  render(<GroupsSidebarMenu {...props} />);
+  return { ...props, onClose };
+}
+
+const menu = () => screen.getByRole('menu');
+const items = () =>
+  within(menu())
+    .getAllByRole('menuitem')
+    .map((i) => i.textContent);
+
+describe('GroupsSidebarMenu', () => {
+  it('names itself after the row it was opened from', () => {
+    renderMenu();
+    expect(screen.getByRole('menu', { name: 'Actions for GTM' })).toBeInTheDocument();
+  });
+
+  it('opens at the pointer', () => {
+    renderMenu();
+    // The panel is presentation only, so the fixed wrapper is the caller's.
+    const wrapper = menu().parentElement!;
+    expect(wrapper).toHaveStyle({ left: '140px', top: '260px' });
+  });
+
+  /**
+   * Create verbs first, copy next, access below the rule — the file tree's
+   * order (`FileExplorer.tsx:232-287`), so the two menus have the same shape
+   * even where they do not have the same words.
+   */
+  it('orders a full group menu the way the file tree orders its own', () => {
+    renderMenu();
+    expect(items()).toEqual(['Add a skill or tool', 'New group', 'Copy link', 'Manage access']);
+  });
+
+  it('renders only the verbs it was given — an absent one is not a disabled one', () => {
+    // What a lens row gets: no folder behind it, so nothing to add to and no
+    // access to manage.
+    renderMenu({ onAdd: undefined, onManageAccess: undefined });
+    expect(items()).toEqual(['New group', 'Copy link']);
+  });
+
+  it('keeps New group on the empty-space menu, where it is the only verb', () => {
+    renderMenu({
+      label: 'Library',
+      onAdd: undefined,
+      onCopyLink: undefined,
+      onManageAccess: undefined,
+    });
+    expect(items()).toEqual(['New group']);
+  });
+
+  it.each([
+    ['Add a skill or tool', 'onAdd'],
+    ['New group', 'onCreateGroup'],
+    ['Copy link', 'onCopyLink'],
+    ['Manage access', 'onManageAccess'],
+  ] as const)('runs %s and then closes', (name, key) => {
+    const props = renderMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name }));
+    expect(props[key]).toHaveBeenCalledTimes(1);
+    // A menu that stayed open behind the sheet it just opened would be a second
+    // thing to dismiss.
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on an outside click', () => {
+    const { onClose } = renderMenu();
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays open when the click is inside it', () => {
+    const { onClose } = renderMenu();
+    fireEvent.mouseDown(menu());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on Escape and hands focus back to the row', () => {
+    const row = document.createElement('button');
+    document.body.appendChild(row);
+    const ref = createRef<HTMLElement>() as React.RefObject<HTMLElement | null>;
+    ref.current = row;
+
+    const { onClose } = renderMenu({ returnFocusTo: ref });
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // Otherwise focus is left on a node that just unmounted and the next Tab
+    // starts from the top of the document.
+    expect(document.activeElement).toBe(row);
+    row.remove();
+  });
+});

--- a/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
@@ -270,9 +270,14 @@ describe('Library sidebar — right-click, end to end', () => {
     await openMenuOn(/^GTM/);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Copy link' }));
 
-    expect(
-      await screen.findByText("Couldn't copy — open the group and copy its address."),
-    ).toBeInTheDocument();
+    // The pill itself, not `getByRole('status')` — the tree carries a second
+    // live region (the route announcer), so the role alone is ambiguous.
+    const pill = await screen.findByText("Couldn't copy — open the group and copy its address.");
+    expect(pill).toBeInTheDocument();
+    // And it has to LOOK like a failure. A refusal rendered on the same ink
+    // plate as a confirmation is the silent no-op this test exists to prevent,
+    // one step removed — the user reads "copied" from the colour and stops.
+    expect(pill).toHaveClass('bg-danger');
     vi.unstubAllGlobals();
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
@@ -272,7 +272,7 @@ describe('Library sidebar — right-click, end to end', () => {
 
     // The pill itself, not `getByRole('status')` — the tree carries a second
     // live region (the route announcer), so the role alone is ambiguous.
-    const pill = await screen.findByText("Couldn't copy — open the group and copy its address.");
+    const pill = await screen.findByText("Couldn't copy — open the row and copy its address.");
     expect(pill).toBeInTheDocument();
     // And it has to LOOK like a failure. A refusal rendered on the same ink
     // plate as a confirmation is the silent no-op this test exists to prevent,

--- a/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import {
+  WorkspaceContext,
+  type WorkspaceContextValue,
+} from '../../workspace/state/workspace.context';
+import { AdminContext } from '../../admin/state/admin.context';
+import type { LibraryData } from '../hooks/useLibraryData';
+import type { GroupSummary } from '../services/groups.api';
+
+/**
+ * The Library nav's right-click menu, wired up for real.
+ *
+ * `GroupsSidebar.contextmenu` proves the nav REPORTS the gesture and
+ * `GroupsSidebarMenu` proves the panel behaves; neither can prove the thing
+ * that actually matters, which is that the layout hands each kind of row the
+ * verbs that are true of it. That decision needs the group summaries and the
+ * workspace's KB dir, so it only exists once the whole surface is mounted —
+ * hence this file.
+ *
+ * Same seams as `LibraryRoutes.test.tsx`: the catalog is mocked at its hook and
+ * the group index at its API, because what is under test is the menu, not the
+ * fetching.
+ */
+
+const dataMock = vi.hoisted(() => ({ useLibraryData: vi.fn() }));
+vi.mock('../hooks/useLibraryData', () => ({ useLibraryData: dataMock.useLibraryData }));
+
+const groupsMock = vi.hoisted(() => ({ listGroups: vi.fn(), listJoinRequests: vi.fn() }));
+vi.mock('../services/groups.api', () => ({
+  listGroups: groupsMock.listGroups,
+  listJoinRequests: groupsMock.listJoinRequests,
+  reconcileJoinRequest: vi.fn(),
+  requestGroupAccess: vi.fn(),
+  AlreadyReadableError: class AlreadyReadableError extends Error {},
+}));
+
+// `Manage access` opens a dialog that fetches the verdict. Stub it so the sheet
+// can actually mount without waiting on a refused connection.
+vi.mock('../../access/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../access/api')>();
+  return {
+    ...actual,
+    fetchFileAccess: vi.fn().mockResolvedValue({
+      canRead: true,
+      canWrite: true,
+      canDownload: false,
+      canOwner: false,
+      eligible: { roles: [], users: [] },
+      readers: { restricted: true, roles: [], users: [] },
+      owners: { roles: [], users: [] },
+      downloaders: { roles: [], users: [] },
+      sources: {},
+    }),
+    fetchAccessOverrides: vi.fn().mockResolvedValue({ overrides: [], truncated: false }),
+  };
+});
+
+import { LibraryRoutes } from '../routes/LibraryRoutes';
+import { withAuth, TEST_PERSONAL_GROUP } from './auth-harness';
+
+const CATALOG: LibraryData = {
+  loading: false,
+  error: null,
+  skills: [
+    { name: 'outreach', description: 'Runs the GTM outreach.', path: 'Groups/GTM/outreach' },
+    { name: 'scratch', description: 'A skill in no group.', path: 'Skills/scratch' },
+  ],
+  tools: [],
+  ownedSkills: new Set(['outreach']),
+  allowedToolsBySkill: new Map(),
+  crs: [],
+  myCrNumbers: new Set(),
+  reload: vi.fn(),
+};
+
+const summary = (over: Partial<GroupSummary>): GroupSummary => ({
+  name: 'GTM',
+  folders: ['Groups/GTM'],
+  canRead: true,
+  canWrite: true,
+  skillCount: 1,
+  toolCount: 0,
+  owners: { roles: [], users: [] },
+  writers: { roles: [], users: [] },
+  readers: { restricted: true, roles: [], users: [] },
+  hasRequested: false,
+  requestNumber: null,
+  ...over,
+});
+
+const GROUPS: GroupSummary[] = [
+  summary({}),
+  // Not readable and not writable, and no item of it reaches the catalog — the
+  // sidebar's locked half.
+  summary({ name: 'Finance', folders: ['Groups/Finance'], canRead: false, canWrite: false }),
+];
+
+function wrap(children: ReactNode) {
+  const adminValue = {
+    isAdmin: false,
+    unreadCount: 0,
+    lastSeen: null,
+    markSeen: vi.fn(),
+    refresh: vi.fn(),
+    rolesConfigCorrupted: false,
+    rolesConfigErrors: [],
+    runRolesRecovery: vi.fn(),
+  };
+  const workspaceValue = {
+    workspaceId: 'target-company-state',
+    kbDirName: 'knowledge-base',
+  } as unknown as WorkspaceContextValue;
+
+  return (
+    <AdminContext.Provider value={adminValue}>
+      <WorkspaceContext.Provider value={workspaceValue}>
+        {withAuth(children)}
+      </WorkspaceContext.Provider>
+    </AdminContext.Provider>
+  );
+}
+
+function renderLibrary(path = '/skills-and-tools') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      {wrap(
+        <Routes>
+          <Route path="/skills-and-tools/*" element={<LibraryRoutes />} />
+        </Routes>,
+      )}
+    </MemoryRouter>,
+  );
+}
+
+const nav = () => screen.getByRole('navigation', { name: 'Library groups' });
+const menuItems = () =>
+  within(screen.getByRole('menu'))
+    .getAllByRole('menuitem')
+    .map((i) => i.textContent);
+
+/** Right-click a row and wait for the menu the layout renders in response. */
+async function openMenuOn(name: RegExp | string) {
+  const row = await screen.findByRole('button', { name });
+  fireEvent.contextMenu(row, { clientX: 60, clientY: 180 });
+  await screen.findByRole('menu');
+  return row;
+}
+
+describe('Library sidebar — right-click, end to end', () => {
+  beforeEach(() => {
+    dataMock.useLibraryData.mockReturnValue(CATALOG);
+    groupsMock.listGroups.mockResolvedValue(GROUPS);
+    groupsMock.listJoinRequests.mockResolvedValue([]);
+  });
+
+  // Only the globals this file stubs — NOT `restoreAllMocks`, which would strip
+  // the resolved values off the module mocks above and leave `fetchFileAccess`
+  // returning undefined for whichever test happens to run next.
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('gives a group row the full menu, titled after the group', async () => {
+    renderLibrary();
+    await openMenuOn(/^GTM/);
+    expect(screen.getByRole('menu', { name: 'Actions for GTM' })).toBeInTheDocument();
+    expect(menuItems()).toEqual(['Add a skill or tool', 'New group', 'Copy link', 'Manage access']);
+  });
+
+  /**
+   * A lens is a slice of the catalog, not a folder — there is nothing to add a
+   * skill TO and no `access.md` behind it. The same call the group page's
+   * `PageActions` makes when it hides `Share` on the personal page.
+   */
+  it('gives a lens row only the verbs a slice of the catalog can answer', async () => {
+    renderLibrary();
+    await openMenuOn(/^Owned by me/);
+    expect(menuItems()).toEqual(['New group', 'Copy link']);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+
+    await openMenuOn(new RegExp(`^${TEST_PERSONAL_GROUP}`));
+    expect(menuItems()).toEqual(['New group', 'Copy link']);
+  });
+
+  /**
+   * `Manage access` is UNGATED on `canWrite`, exactly as the group page's
+   * `Share` is: for a non-writer the dialog renders read-only, which is
+   * precisely what "who is this shared with?" should answer — and for an admin
+   * locked out of a group it is the self-service way back in.
+   */
+  it('offers Manage access on a locked group too', async () => {
+    renderLibrary();
+    await openMenuOn('Finance (locked)');
+    expect(screen.getByRole('menu', { name: 'Actions for Finance' })).toBeInTheDocument();
+    expect(menuItems()).toContain('Manage access');
+  });
+
+  it('gives the empty nav space the one verb that belongs to the nav itself', async () => {
+    renderLibrary();
+    await screen.findByRole('button', { name: /^GTM/ });
+    fireEvent.contextMenu(nav(), { clientX: 40, clientY: 400 });
+    await screen.findByRole('menu');
+    expect(menuItems()).toEqual(['New group']);
+  });
+
+  it('opens the new-group dialog from the menu', async () => {
+    renderLibrary();
+    await openMenuOn(/^GTM/);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'New group' }));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('opens the add dialog for the group that was clicked, not the page you are on', async () => {
+    renderLibrary('/skills-and-tools/owned');
+    await openMenuOn(/^GTM/);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add a skill or tool' }));
+    // The dialog titles itself with its group — proof the layout captured the
+    // ROW's group, and not the route it happened to be sitting on.
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Add a skill or tool to GTM')).toBeInTheDocument();
+  });
+
+  it('opens Manage access on the group folder, under the KB dir', async () => {
+    const access = await import('../../access/api');
+    renderLibrary();
+    await openMenuOn(/^GTM/);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Manage access' }));
+
+    await waitFor(() => expect(access.fetchFileAccess).toHaveBeenCalled());
+    /**
+     * The whole round trip, in one assertion. The layout hands the dialog a
+     * WORKSPACE path (`<kbDirName>/<folder>`), the dialog strips that prefix
+     * back off, and what reaches the resolver is the REPO-relative folder —
+     * which is the only address `access.md` is written at. Get either half
+     * wrong and this is `undefined/Groups/GTM` or `knowledge-base/Groups/GTM`,
+     * and the dialog silently resolves a folder that does not exist. It is the
+     * same handoff `GroupPage` makes, which is why it has to match exactly.
+     */
+    expect(vi.mocked(access.fetchFileAccess).mock.calls[0][1]).toBe('Groups/GTM');
+  });
+
+  it("copies the clicked row's own URL, not the one you are standing on", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+
+    renderLibrary('/skills-and-tools/owned');
+    await openMenuOn(/^GTM/);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy link' }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/skills-and-tools/groups/GTM`,
+      ),
+    );
+    expect(await screen.findByText('Link copied.')).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
+  it('says so when the clipboard refuses, instead of a silent no-op', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('not allowed')) },
+    });
+
+    renderLibrary();
+    await openMenuOn(/^GTM/);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Copy link' }));
+
+    expect(
+      await screen.findByText("Couldn't copy — open the group and copy its address."),
+    ).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
+  it('closes on an outside click, and a left click still navigates', async () => {
+    renderLibrary();
+    await openMenuOn(/^GTM/);
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+
+    fireEvent.click(screen.getByRole('button', { name: /^GTM/ }));
+    expect(await screen.findByRole('heading', { name: 'GTM', level: 1 })).toBeInTheDocument();
+  });
+
+  it('hands focus back to the row on Escape', async () => {
+    renderLibrary();
+    const row = await openMenuOn(/^GTM/);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+    expect(document.activeElement).toBe(row);
+  });
+});

--- a/packages/core-frontend/src/modules/library/components/GroupsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/GroupsSidebar.tsx
@@ -1,7 +1,25 @@
-import type { ReactNode } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 import { cn } from '../../../lib/utils';
 import type { LibraryFilter } from '../utils/status';
 import { LockGlyph } from './LockGlyph';
+
+/**
+ * Where a right-click landed in the nav, and everything the layout needs to
+ * answer it — so the sidebar can report the event without owning a menu.
+ *
+ * The coordinates and the row element are read from the event SYNCHRONOUSLY
+ * here, because `currentTarget` is only itself for the duration of the handler.
+ */
+export interface SidebarContextTarget {
+  /** The row's filter — `null` when the click landed on the nav's empty space. */
+  filter: LibraryFilter | null;
+  /** What was clicked, by name. The menu uses it for its accessible name. */
+  label: string;
+  x: number;
+  y: number;
+  /** The row itself, so Escape can hand focus back to it. `null` for empty space. */
+  row: HTMLElement | null;
+}
 
 export interface GroupsSidebarProps {
   /** What the URL has selected, or null on a page with no gallery filter. */
@@ -30,6 +48,16 @@ export interface GroupsSidebarProps {
   onFinishSetup(): void;
   /** Start a new group. The layout owns the dialog; this is only the intent. */
   onCreateGroup(): void;
+  /**
+   * A row — or the nav's empty space — was right-clicked. Like every other
+   * handler here this is an INTENT, not a menu: the layout owns the popup,
+   * because the verbs in it (add to this group, manage its access) need the
+   * group summaries and the workspace, and the sidebar knows neither.
+   *
+   * Omitted, the nav does nothing on right-click and the browser's own menu
+   * appears — which is the honest default for a view with no actions wired.
+   */
+  onContextMenu?(target: SidebarContextTarget): void;
 }
 
 /**
@@ -62,6 +90,7 @@ export function GroupsSidebar({
   attentionCount,
   onFinishSetup,
   onCreateGroup,
+  onContextMenu,
 }: GroupsSidebarProps) {
   const rowClass = (selected: boolean) =>
     cn(
@@ -69,19 +98,47 @@ export function GroupsSidebar({
       selected ? 'bg-hover font-semibold text-ink' : 'text-ink-muted hover:bg-hover hover:text-ink',
     );
 
+  /**
+   * Whether a row's filter is the one the URL has selected. Derived from the
+   * row's OWN target rather than restated at each call site, so a row cannot
+   * light up for a filter it does not navigate to.
+   */
+  const isCurrent = (target: LibraryFilter) =>
+    target.kind === 'group'
+      ? filter?.kind === 'group' && filter.group === target.group
+      : filter?.kind === target.kind;
+
+  /**
+   * Report a right-click upward. `preventDefault` only when somebody is
+   * listening — with no handler the browser's own menu is the right answer.
+   * `stopPropagation` is what keeps a row's click from also reaching the nav
+   * behind it, which would open the empty-space menu instead.
+   */
+  const openMenu = (
+    e: MouseEvent<HTMLElement>,
+    target: LibraryFilter | null,
+    label: string,
+    row: HTMLElement | null,
+  ) => {
+    if (!onContextMenu) return;
+    e.preventDefault();
+    e.stopPropagation();
+    onContextMenu({ filter: target, label, x: e.clientX, y: e.clientY, row });
+  };
+
   const row = (
     label: string,
-    selected: boolean,
-    onClick: () => void,
+    target: LibraryFilter,
     count: number,
     tone: 'count' | 'pending' = 'count',
   ) => (
     <button
       key={label}
       type="button"
-      aria-current={selected}
-      className={rowClass(selected)}
-      onClick={onClick}
+      aria-current={isCurrent(target)}
+      className={rowClass(isCurrent(target))}
+      onClick={() => onSelect(target)}
+      onContextMenu={(e) => openMenu(e, target, label, e.currentTarget)}
     >
       <span className="truncate">{label}</span>
       {/* An empty count is not a count — show nothing rather than a grey 0. */}
@@ -109,27 +166,40 @@ export function GroupsSidebar({
    * (a non-member has nothing to fix). The accessible name carries the state in
    * words, so the glyph itself can stay decorative.
    */
-  const lockedRow = (name: string) => (
-    <button
-      key={`locked:${name}`}
-      type="button"
-      aria-label={`${name} (locked)`}
-      aria-current={filter?.kind === 'group' && filter.group === name}
-      className={rowClass(filter?.kind === 'group' && filter.group === name)}
-      onClick={() => onSelect({ kind: 'group', group: name })}
-    >
-      <span className="truncate">{name}</span>
-      <span className="flex h-4.5 shrink-0 basis-5.5 items-center justify-center text-ink-faint">
-        <LockGlyph className="size-3" />
-      </span>
-    </button>
-  );
+  const lockedRow = (name: string) => {
+    const target: LibraryFilter = { kind: 'group', group: name };
+    return (
+      <button
+        key={`locked:${name}`}
+        type="button"
+        aria-label={`${name} (locked)`}
+        aria-current={isCurrent(target)}
+        className={rowClass(isCurrent(target))}
+        onClick={() => onSelect(target)}
+        // A locked row gets the SAME menu as a readable one, for the same
+        // reason it gets the same click: a group you are not in is still a
+        // place, and `Manage access` is exactly the item an admin locked out of
+        // one needs. Which verbs are actually true is the layout's call.
+        onContextMenu={(e) => openMenu(e, target, name, e.currentTarget)}
+      >
+        <span className="truncate">{name}</span>
+        <span className="flex h-4.5 shrink-0 basis-5.5 items-center justify-center text-ink-faint">
+          <LockGlyph className="size-3" />
+        </span>
+      </button>
+    );
+  };
 
   return (
     <>
         <nav
           aria-label="Library groups"
           className="flex min-h-0 flex-1 flex-col gap-px overflow-y-auto"
+          // The nav's empty space is a target too — Knowledge's tree gives its
+          // ROOT row a menu holding the create verbs, and this is where the
+          // Library's equivalent click lands. Rows stop the event before it
+          // reaches here, so this only ever fires on the gaps between them.
+          onContextMenu={(e) => openMenu(e, null, 'Library', null)}
         >
           {/* "Owned by me" is a LENS — the whole catalog, sliced to yours —
               which is exactly what the group rows below are not. Naming the
@@ -144,8 +214,7 @@ export function GroupsSidebar({
               this page that is supposed to mean "look here". */}
           {row(
             'Owned by me',
-            filter?.kind === 'owned',
-            () => onSelect({ kind: 'owned' }),
+            { kind: 'owned' },
             ownedAttention > 0 ? ownedAttention : ownedCount,
             ownedAttention > 0 ? 'pending' : 'count',
           )}
@@ -153,19 +222,13 @@ export function GroupsSidebar({
 
           {/* Your own space leads the groups, as in the prototype (line 2487):
               it is the one you are always in. */}
-          {row(
-            personalGroupLabel,
-            filter?.kind === 'ungrouped',
-            () => onSelect({ kind: 'ungrouped' }),
-            ungroupedCount,
-          )}
+          {row(personalGroupLabel, { kind: 'ungrouped' }, ungroupedCount)}
           {groups.map(({ group, count, attention }) =>
             // Amber wins the count slot: a group that needs setup is telling you
             // something, and how many items it holds is not the news.
             row(
               group,
-              filter?.kind === 'group' && filter.group === group,
-              () => onSelect({ kind: 'group', group }),
+              { kind: 'group', group },
               attention > 0 ? attention : count,
               attention > 0 ? 'pending' : 'count',
             ),

--- a/packages/core-frontend/src/modules/library/components/GroupsSidebarMenu.tsx
+++ b/packages/core-frontend/src/modules/library/components/GroupsSidebarMenu.tsx
@@ -1,0 +1,135 @@
+import type { RefObject } from 'react';
+import { FilePlus, FolderPlus, Link2, Users } from 'lucide-react';
+import { MenuItem, MenuPanel, useDismissableMenu } from '../../../shared/components';
+
+/**
+ * The Library sidebar's right-click menu — Knowledge's `ContextMenu`
+ * (`FileExplorer.tsx:126`) with the Library's verbs in it.
+ *
+ * The two navs are one frame holding two lists (see `GroupsSidebar`'s
+ * docstring), so a right-click has to BEHAVE the same in both: the panel opens
+ * at the pointer, an outside click or Escape closes it, and Escape hands focus
+ * back to the row it came from. None of that is `MenuPanel`'s job — its own
+ * docstring says it is presentation only — so the wiring is `useDismissableMenu`
+ * and the fixed wrapper is the caller's, exactly as in the file tree.
+ *
+ * The ITEMS differ, because the things differ. A group is not a file: there is
+ * no Rename, no Delete and no Download here, because no endpoint stands behind
+ * any of the three for a group, and a menu item that cannot do its job is worse
+ * than one that is not there (the same call `PageActions` already makes about
+ * Leave/Delete subscription). What carries over is the pairing that matters —
+ * a create verb, a copy verb, and access below the rule — wearing the SAME
+ * lucide glyphs the file tree gives each, so the two menus read as one product
+ * rather than two.
+ *
+ * Every action is optional, and an absent one is simply not rendered — the same
+ * contract `ContextMenu` uses for `onCreateFile` / `onDownload`. That is what
+ * lets one component serve a group row, a lens row and the nav's empty space
+ * with no `kind` switch inside it: the layout is the one that knows which verbs
+ * are true for what was clicked, and it says so by passing them.
+ */
+export interface GroupsSidebarMenuProps {
+  x: number;
+  y: number;
+  /** What was right-clicked, by name — the menu's accessible name. */
+  label: string;
+  onClose(): void;
+  /** Opens "Add a skill or tool to {label}". Absent for a lens or empty space. */
+  onAdd?(): void;
+  /** The one verb every target has: the nav's own create affordance. */
+  onCreateGroup(): void;
+  /** Copies a link to the row's page. Absent on the nav's empty space. */
+  onCopyLink?(): void;
+  /** Absent when there is no folder behind the row to manage. */
+  onManageAccess?(): void;
+  /** The row this menu was opened from — Escape hands focus back to it. */
+  returnFocusTo?: RefObject<HTMLElement | null>;
+}
+
+export function GroupsSidebarMenu({
+  x,
+  y,
+  label,
+  onClose,
+  onAdd,
+  onCreateGroup,
+  onCopyLink,
+  onManageAccess,
+  returnFocusTo,
+}: GroupsSidebarMenuProps) {
+  const ref = useDismissableMenu<HTMLDivElement>({ open: true, onClose, returnFocusTo });
+
+  return (
+    // Positioning stays with the caller — `MenuPanel` is presentation only, so
+    // the fixed-to-the-pointer wrapper is ours and the panel inside is the
+    // shared one. Same shape as the file tree's.
+    <div
+      ref={ref}
+      className="fixed z-50"
+      style={{ left: x, top: y }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <MenuPanel role="menu" aria-label={`Actions for ${label}`} className="min-w-[180px]">
+        {onAdd && (
+          <MenuItem
+            role="menuitem"
+            onClick={() => {
+              onAdd();
+              onClose();
+            }}
+          >
+            <span className="flex items-center gap-2">
+              <FilePlus size={14} />
+              Add a skill or tool
+            </span>
+          </MenuItem>
+        )}
+        <MenuItem
+          role="menuitem"
+          onClick={() => {
+            onCreateGroup();
+            onClose();
+          }}
+        >
+          <span className="flex items-center gap-2">
+            <FolderPlus size={14} />
+            New group
+          </span>
+        </MenuItem>
+        {onCopyLink && (
+          <MenuItem
+            role="menuitem"
+            onClick={() => {
+              onCopyLink();
+              onClose();
+            }}
+          >
+            <span className="flex items-center gap-2">
+              <Link2 size={14} />
+              Copy link
+            </span>
+          </MenuItem>
+        )}
+        {onManageAccess && (
+          <>
+            {/* Access sits below a rule in the file tree's menu too — it is the
+                item that changes who else can be here, not what is here. */}
+            <div className="my-1 border-t border-line" />
+            <MenuItem
+              role="menuitem"
+              onClick={() => {
+                onManageAccess();
+                onClose();
+              }}
+            >
+              <span className="flex items-center gap-2">
+                <Users size={14} />
+                Manage access
+              </span>
+            </MenuItem>
+          </>
+        )}
+      </MenuPanel>
+    </div>
+  );
+}

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -9,7 +9,7 @@ import { libraryFilterForPath, pathForLibraryFilter } from '../routes/library-pa
 import { groupCounts, type LibraryFilter } from '../utils/status';
 import { primaryFolderOf } from '../utils/group-summary';
 import { LINK_COPIED_TOAST, LINK_COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
-import { useLibraryToast } from '../state/toast';
+import { useLibraryToast } from '../state/toast.context';
 import { useSidebar } from '../../layout/state/sidebar';
 import { SidebarFrame } from '../../layout/components/SidebarFrame';
 import { useWorkspace } from '../../workspace/state/workspace.context';
@@ -152,7 +152,7 @@ export function LibraryLayout() {
   const copyLink = useCallback(
     async (target: LibraryFilter) => {
       const ok = await copyToClipboard(`${window.location.origin}${pathForLibraryFilter(target)}`);
-      toast(ok ? LINK_COPIED_TOAST : LINK_COPY_FAILED_TOAST);
+      toast(ok ? LINK_COPIED_TOAST : LINK_COPY_FAILED_TOAST, ok ? 'neutral' : 'danger');
     },
     [toast],
   );

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { cn } from '../../../lib/utils';
 import { DOCUMENT_COLUMN, documentGutters } from '../../../shared/theme/measure';
@@ -6,11 +6,18 @@ import { useAuth } from '../../auth/state/auth.context';
 import { attentionOf, useLibrary } from '../state/library-data';
 import { personalGroupName } from '../utils/personal-group';
 import { libraryFilterForPath, pathForLibraryFilter } from '../routes/library-paths';
-import { groupCounts } from '../utils/status';
+import { groupCounts, type LibraryFilter } from '../utils/status';
+import { primaryFolderOf } from '../utils/group-summary';
+import { LINK_COPIED_TOAST, LINK_COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
+import { useLibraryToast } from '../state/toast';
 import { useSidebar } from '../../layout/state/sidebar';
 import { SidebarFrame } from '../../layout/components/SidebarFrame';
+import { useWorkspace } from '../../workspace/state/workspace.context';
+import { ManageAccessDialog } from '../../access/components/ManageAccessDialog';
 import { ConnectAgentPill } from '../../onboarding/components/ConnectAgentPill';
-import { GroupsSidebar } from './GroupsSidebar';
+import { GroupsSidebar, type SidebarContextTarget } from './GroupsSidebar';
+import { GroupsSidebarMenu } from './GroupsSidebarMenu';
+import { AddToGroupDialog } from './AddToGroupDialog';
 import { NewGroupDialog } from './NewGroupDialog';
 
 /**
@@ -27,7 +34,35 @@ export function LibraryLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const { user } = useAuth();
+  const { kbDirName } = useWorkspace();
+  const toast = useLibraryToast();
   const [newGroupOpen, setNewGroupOpen] = useState(false);
+  /**
+   * The sidebar's right-click menu, and the two sheets it can open. All three
+   * live HERE rather than in `GroupsSidebar` because the verbs need the group
+   * summaries and the workspace's KB dir — the sidebar is handed a list of
+   * names and counts and knows neither. The sidebar reports the click; this
+   * decides what is true about what was clicked.
+   */
+  const [menu, setMenu] = useState<SidebarContextTarget | null>(null);
+  /**
+   * Captured whole at pick time, not looked up at render time: the menu closes
+   * as it hands over, so by the time the dialog paints there is no `menu` left
+   * to re-derive the group from.
+   */
+  const [addTo, setAddTo] = useState<{
+    name: string;
+    primaryPath: string;
+    canWrite: boolean;
+  } | null>(null);
+  const [manageFolder, setManageFolder] = useState<string | null>(null);
+  /**
+   * The row the open menu came from. A ref, not state, because
+   * `useDismissableMenu` wants a stable `RefObject` to return focus INTO on
+   * Escape — re-rendering the menu to tell it about the row would defeat the
+   * point.
+   */
+  const menuRow = useRef<HTMLElement | null>(null);
   /**
    * Whether the nav is hidden. The state lives in a module store because the
    * button that flips it sits in the top bar, outside this layout's tree —
@@ -78,6 +113,50 @@ export function LibraryLayout() {
     [items],
   );
 
+  /**
+   * What the open menu is pointing at.
+   *
+   * A group row resolves to its summary, which is where the folder behind it
+   * lives — and therefore whether `Add a skill or tool` and `Manage access`
+   * have anything to act on at all. A LENS row resolves to nothing, because
+   * neither lens is a folder: "Owned by me" and your own space are slices of
+   * the catalog, and there is no `access.md` behind a slice. That is the same
+   * call the group page's `PageActions` already makes when it hides `Share` on
+   * the personal page, and the menu has to make it the same way or the two
+   * surfaces disagree about what a lens is.
+   *
+   * `Manage access` stays UNGATED on `canWrite`, exactly as `Share` is: for a
+   * non-writer the dialog renders read-only, which is precisely what "who is
+   * this shared with?" should answer.
+   */
+  const menuFilter = menu?.filter ?? null;
+  const menuGroup = menuFilter?.kind === 'group' ? menuFilter.group : null;
+  const menuSummary = useMemo(
+    () => (menuGroup ? groupSummaries.find((g) => g.name === menuGroup) : undefined),
+    [groupSummaries, menuGroup],
+  );
+  const menuFolder = menuSummary ? primaryFolderOf(menuSummary) : null;
+
+  const openContextMenu = useCallback((target: SidebarContextTarget) => {
+    menuRow.current = target.row;
+    setMenu(target);
+  }, []);
+
+  /**
+   * A link to a row's page — origin + the row's own route, so it is the URL
+   * that row navigates to and not the one you happen to be standing on. The
+   * clipboard can refuse outright (a non-secure origin, an unfocused document),
+   * and a silent no-op is the worst possible answer to "copy this" — so the
+   * toast tells the truth either way.
+   */
+  const copyLink = useCallback(
+    async (target: LibraryFilter) => {
+      const ok = await copyToClipboard(`${window.location.origin}${pathForLibraryFilter(target)}`);
+      toast(ok ? LINK_COPIED_TOAST : LINK_COPY_FAILED_TOAST);
+    },
+    [toast],
+  );
+
   return (
     <div className="flex h-full min-h-0 bg-canvas text-ink">
       {/* The connect-your-agent CTA sits above the group list — the one row
@@ -102,8 +181,63 @@ export function LibraryLayout() {
           attentionCount={attentionCount}
           onFinishSetup={() => navigate('/connect')}
           onCreateGroup={() => setNewGroupOpen(true)}
+          onContextMenu={openContextMenu}
         />
       </SidebarFrame>
+
+      {/* The nav's right-click menu — Knowledge's file tree has had one since it
+          shipped, and two sidebars in one app should not answer the same
+          gesture two different ways. Rendered HERE, outside the frame, because
+          it is fixed to the pointer rather than laid out in the column. */}
+      {menu && (
+        <GroupsSidebarMenu
+          x={menu.x}
+          y={menu.y}
+          label={menu.label}
+          onClose={() => setMenu(null)}
+          onAdd={
+            menuGroup && menuFolder && menuSummary
+              ? () =>
+                  setAddTo({
+                    name: menuGroup,
+                    primaryPath: menuFolder,
+                    canWrite: menuSummary.canWrite,
+                  })
+              : undefined
+          }
+          onCreateGroup={() => setNewGroupOpen(true)}
+          onCopyLink={menuFilter ? () => void copyLink(menuFilter) : undefined}
+          onManageAccess={menuFolder && kbDirName ? () => setManageFolder(menuFolder) : undefined}
+          returnFocusTo={menuRow}
+        />
+      )}
+
+      {addTo && (
+        <AddToGroupDialog
+          name={addTo.name}
+          primaryPath={addTo.primaryPath}
+          canWrite={addTo.canWrite}
+          onClose={() => setAddTo(null)}
+        />
+      )}
+
+      {manageFolder && kbDirName && (
+        <ManageAccessDialog
+          entry={{
+            name: manageFolder.split('/').pop() ?? manageFolder,
+            relativePath: `${kbDirName}/${manageFolder}`,
+            type: 'directory',
+          }}
+          onClose={() => {
+            setManageFolder(null);
+            // Granting through the dialog can settle a pending join request —
+            // refresh the roster and the catalog together, exactly as the group
+            // page does when its copy of this dialog closes.
+            reloadGroups();
+            reload();
+          }}
+        />
+      )}
 
       {newGroupOpen && (
         <NewGroupDialog

--- a/packages/core-frontend/src/modules/library/utils/clipboard.ts
+++ b/packages/core-frontend/src/modules/library/utils/clipboard.ts
@@ -30,4 +30,4 @@ export const COPY_FAILED_TOAST = "Couldn't copy — select the prompt text inste
  * open the row and copy from the address bar.
  */
 export const LINK_COPIED_TOAST = 'Link copied.';
-export const LINK_COPY_FAILED_TOAST = "Couldn't copy — open the group and copy its address.";
+export const LINK_COPY_FAILED_TOAST = "Couldn't copy — open the row and copy its address.";

--- a/packages/core-frontend/src/modules/library/utils/clipboard.ts
+++ b/packages/core-frontend/src/modules/library/utils/clipboard.ts
@@ -22,3 +22,12 @@ export async function copyToClipboard(text: string): Promise<boolean> {
 /** What a copy button tells the user, either way. */
 export const COPIED_TOAST = 'Prompt copied.';
 export const COPY_FAILED_TOAST = "Couldn't copy — select the prompt text instead.";
+
+/**
+ * The same pair for a LINK — the sidebar's `Copy link`. Separate strings
+ * because the recovery differs: a prompt is on screen to be selected by hand,
+ * a link to a row you are not standing on is not, so the honest advice is to
+ * open the row and copy from the address bar.
+ */
+export const LINK_COPIED_TOAST = 'Link copied.';
+export const LINK_COPY_FAILED_TOAST = "Couldn't copy — open the group and copy its address.";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click menus across the Library sidebar for groups, lenses, and empty navigation space.
  * Users can create groups, add items, copy links, and manage access directly from the sidebar.
  * Menus appear at the pointer location and close with outside click or Escape, restoring focus afterward.

* **Bug Fixes**
  * Improved handling for locked rows and selection state.
  * Copy-link actions now show clearer success and failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->