### PR TITLE
Fix/per file change requests

### DIFF
--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -35,7 +35,10 @@ the second unproposable and writing any proposal on it into the first file's
 request. The digest is taken before sanitising, so the two stay apart. The
 readable slug is now also truncated to fit git's 255-character ceiling on a
 ref, which nothing upstream had bounded; the digest survives the truncation, so
-two long paths sharing a prefix still get their own branches.
+two long paths sharing a prefix still get their own branches. A skill name long
+enough to be truncated itself carries the same digest for the same reason —
+otherwise two skills alike for as far as the ref could hold them would share a
+branch, and so share a change request.
 
 The owner's change-request dock gets the two things that per-file requests made
 necessary: a `»` control that folds it to a slim tab on the viewport edge (it

--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -7,9 +7,9 @@ file used to hide "Propose changes" on every other file of that skill until the
 first proposal was withdrawn or decided — the editor was gated on the caller
 having any open change request touching the skill folder, so a pending edit to
 SKILL.md locked the whole bundle. Each file now carries its own suggestion
-branch (`suggestions/<user>/<skill>--<file>`) and opens its own change request,
-titled with the file so the owner's dock can tell several apart, and each is
-approved or declined on its own.
+branch (`suggestions/<user>/<skill>--<file>-<digest>`) and opens its own change
+request, titled with the file so the owner's dock can tell several apart, and
+each is approved or declined on its own.
 
 The file lands flattened into the last branch segment (`--<file>`) rather than
 nested under the skill (`/<file>`): a skill-level branch from before files were
@@ -25,6 +25,17 @@ collapses `..` and rewrites a trailing `.lock` — both are rejected outright by
 the backend's branch-name validator, and a skill shipping a `deps.lock` beside
 its SKILL.md would otherwise have been unproposable with only a bare 400 to
 explain it.
+
+Because that sanitising is lossy, the branch also carries a short digest of the
+path it came from. Every character git will not take becomes `-`, so
+`reference/DESIGN-SYSTEM.md` and `reference-design-system.md` reduced to the
+same branch — and since a request is matched to the file on screen by branch,
+the first file's pending request was served to the second as its own, leaving
+the second unproposable and writing any proposal on it into the first file's
+request. The digest is taken before sanitising, so the two stay apart. The
+readable slug is now also truncated to fit git's 255-character ceiling on a
+ref, which nothing upstream had bounded; the digest survives the truncation, so
+two long paths sharing a prefix still get their own branches.
 
 The owner's change-request dock gets the two things that per-file requests made
 necessary: a `»` control that folds it to a slim tab on the viewport edge (it

--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -1,0 +1,34 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+One open proposal per person per FILE, not per skill. Proposing a change to one
+file used to hide "Propose changes" on every other file of that skill until the
+first proposal was withdrawn or decided — the editor was gated on the caller
+having any open change request touching the skill folder, so a pending edit to
+SKILL.md locked the whole bundle. Each file now carries its own suggestion
+branch (`suggestions/<user>/<skill>--<file>`) and opens its own change request,
+titled with the file so the owner's dock can tell several apart, and each is
+approved or declined on its own.
+
+The file lands flattened into the last branch segment (`--<file>`) rather than
+nested under the skill (`/<file>`): a skill-level branch from before files were
+in the name is a ref FILE at `refs/heads/suggestions/<user>/<skill>`, and
+nesting would ask git to make that same path a directory — a D/F conflict that
+would fail every propose for as long as the old branch existed. Requests opened
+on those legacy branches are still recognised as the caller's own, and while
+their touched paths are still uncomputed they hold every file of the skill
+rather than offering an editor that would fork them.
+
+File names also reach git's ref rules for the first time, so the branch slug now
+collapses `..` and rewrites a trailing `.lock` — both are rejected outright by
+the backend's branch-name validator, and a skill shipping a `deps.lock` beside
+its SKILL.md would otherwise have been unproposable with only a bare 400 to
+explain it.
+
+The owner's change-request dock gets the two things that per-file requests made
+necessary: a `»` control that folds it to a slim tab on the viewport edge (it
+is fixed-position chrome and can sit on the column it is about), and a cap of
+three visible cards with the rest scrolling. The cap is measured from the third
+card's own edge rather than set as a fixed height, because these titles wrap
+anywhere from one line to four.

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import {
   WorkspaceContext,
@@ -34,9 +34,13 @@ vi.mock('../services/library.api', () => ({
   listMyChangeRequests: vi.fn(),
   // Real behaviour, not a stub: the page resolves the caller's own request by
   // this branch name, so a `vi.fn()` returning undefined would quietly disable
-  // the very lookup these tests are checking.
-  suggestionBranchFor: (email: string, skill: string) =>
-    `suggestions/${email.split('@')[0]}/${skill}`,
+  // the very lookup these tests are checking. Mirrors the real function: with
+  // a file the branch carries it (`--<slug>`), without one it is the legacy
+  // skill-level name.
+  suggestionBranchFor: (email: string, skill: string, file?: string) =>
+    `suggestions/${email.split('@')[0]}/${skill}${
+      file === undefined ? '' : `--${file.toLowerCase().replace(/[^a-z0-9._-]+/g, '-')}`
+    }`,
 }));
 vi.mock('../../pr/services/pr-merge.api', () => ({ mergePullRequest: apiMock.mergePullRequest }));
 vi.mock('../../pr/services/pr-cancel.api', () => ({
@@ -559,6 +563,28 @@ describe('SkillPage — deciding on a change', () => {
   });
 
   /**
+   * The dock is fixed-position chrome that can sit ON the column it is about,
+   * so `»` folds it to a slim tab on the edge. What survives the fold is the
+   * landmark (still reachable), the count (still a signal), and the way back.
+   */
+  it('collapses the dock to an edge tab and back', async () => {
+    renderPage(true, [foreignCr]);
+    await screen.findByRole('complementary', { name: 'Change requests for this skill' });
+    expect(screen.getByText('Changes from Olga — newsletter')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse the change requests' }));
+
+    expect(screen.queryByText('Changes from Olga — newsletter')).toBeNull();
+    const dock = screen.getByRole('complementary', { name: 'Change requests for this skill' });
+    const show = within(dock).getByRole('button', { name: 'Show the change requests' });
+    // The count is the one thing the tab still says.
+    expect(within(show).getByText('1')).toBeInTheDocument();
+
+    fireEvent.click(show);
+    expect(await screen.findByText('Changes from Olga — newsletter')).toBeInTheDocument();
+  });
+
+  /**
    * `author.login` is the shared service account, and arrives as an opaque
    * `user-<hash>`. When the app user can't be resolved the surface must say so
    * neutrally rather than print the id as if it were a person.
@@ -825,9 +851,39 @@ describe('SkillPage — deciding on a change', () => {
    * `touchedNodePaths` is "Empty if not yet computed". In that window every
    * path-derived check collapses together — so the page used to offer a second
    * editor, and submitting it opened a SECOND change request against a branch
-   * that already had one. Resolving by branch closes the window.
+   * that already had one. Resolving by branch closes the window per file: the
+   * branch names the file it is about, so only that file recognises it.
    */
-  it("recognises the caller's own request before its touched paths are computed", async () => {
+  it("recognises the caller's own per-file request before its touched paths are computed", async () => {
+    const uncomputed = {
+      ...foreignCr,
+      appAuthor: { name: 'Razvan' },
+      branch: 'suggestions/razvan/newsletter--skill.md',
+      touchedNodePaths: [],
+    } as unknown as PullRequestSummary;
+
+    renderPage(false, [uncomputed], [uncomputed.number]);
+    await screen.findByRole('heading', { name: 'newsletter' });
+
+    // The rest of the skill stays open to propose on — prove the editor CAN
+    // appear on another file first, so the absence below is the gate at work
+    // rather than data that never arrived.
+    fireEvent.click(screen.getByRole('tab', { name: 'sources.yaml' }));
+    expect(await screen.findByRole('button', { name: 'Propose changes' })).toBeInTheDocument();
+
+    // No second editor over the top of a request that already exists.
+    fireEvent.click(screen.getByRole('tab', { name: 'SKILL.md' }));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Propose changes' })).toBeNull(),
+    );
+  });
+
+  /**
+   * A request from before branches carried the file cannot say which file it
+   * is about while its paths are uncomputed — so every file treats it as its
+   * own rather than offering an editor that would fork it.
+   */
+  it("holds every file for a legacy skill-level request until its paths are computed", async () => {
     const uncomputed = {
       ...foreignCr,
       appAuthor: { name: 'Razvan' },
@@ -838,7 +894,10 @@ describe('SkillPage — deciding on a change', () => {
     renderPage(false, [uncomputed], [uncomputed.number]);
     await screen.findByRole('heading', { name: 'newsletter' });
 
-    // No second editor over the top of a request that already exists.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Propose changes' })).toBeNull(),
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'sources.yaml' }));
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: 'Propose changes' })).toBeNull(),
     );
@@ -853,5 +912,48 @@ describe('SkillPage — deciding on a change', () => {
 
     fireEvent.click(withdraw);
     await waitFor(() => expect(apiMock.cancelPullRequest).toHaveBeenCalledWith(7));
+  });
+
+  /**
+   * The gate is per FILE, not per skill. A pending proposal on SKILL.md used
+   * to hide "Propose changes" on every other file of the skill — the exact
+   * bug: once you proposed anywhere, the rest of the skill was closed to you.
+   */
+  it('keeps offering the editor on files your pending proposal does not touch', async () => {
+    renderPage(false, [foreignCr], [7]);
+
+    // My proposal on SKILL.md: no editor there…
+    await screen.findByRole('button', { name: 'Withdraw' });
+    expect(screen.queryByRole('button', { name: 'Propose changes' })).toBeNull();
+
+    // …but sources.yaml is still mine to propose on.
+    fireEvent.click(screen.getByRole('tab', { name: 'sources.yaml' }));
+    expect(await screen.findByRole('button', { name: 'Propose changes' })).toBeInTheDocument();
+  });
+
+  /**
+   * And proposing there opens a request of its OWN — `existingCr: null`, so
+   * `proposeChange` mints the file's branch and a fresh change request instead
+   * of growing the one already pending on SKILL.md.
+   */
+  it('opens a separate change request for a second file, not a rider on the first', async () => {
+    renderPage(false, [foreignCr], [7]);
+    await screen.findByRole('heading', { name: 'newsletter' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'sources.yaml' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Propose changes' }));
+
+    const box = await screen.findByRole('textbox', { name: /Propose changes to sources\.yaml/ });
+    await waitFor(() => expect((box as HTMLTextAreaElement).value.length).toBeGreaterThan(10));
+    fireEvent.change(box, { target: { value: 'watchlist:\n  - topic: robotics' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Propose changes' }));
+
+    await waitFor(() => expect(apiMock.proposeChange).toHaveBeenCalled());
+    expect(apiMock.proposeChange.mock.calls[0][0]).toMatchObject({
+      skillName: 'newsletter',
+      repoRelativePath: 'Skills/newsletter/sources.yaml',
+      file: 'sources.yaml',
+      existingCr: null,
+    });
   });
 });

--- a/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
+++ b/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
@@ -124,6 +124,46 @@ describe('suggestionBranchFor', () => {
   });
 
   /**
+   * Truncating the base loses its identity the same way flattening loses the
+   * file's, so it carries a digest on the same reasoning. Two skills alike for
+   * as far as the ref can hold them would otherwise share one branch — and a
+   * shared branch is a shared change request, which is the very thing per-file
+   * branches exist to prevent.
+   */
+  it('keeps two skills apart when only the truncated tail distinguishes them', () => {
+    const a = suggestionBranchFor('juan@bevel.software', `${'x'.repeat(400)}a`, 'SKILL.md');
+    const b = suggestionBranchFor('juan@bevel.software', `${'x'.repeat(400)}b`, 'SKILL.md');
+
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(255);
+    expect(b.length).toBeLessThanOrEqual(255);
+    assertGitAccepts(a);
+    assertGitAccepts(b);
+  });
+
+  /**
+   * The digest is over the RAW inputs rather than over the assembled base,
+   * which matters because `branchSegment` has already run by then: these two
+   * skill names are identical once every character git refuses has become '-',
+   * so a digest taken after that step could not tell them apart either.
+   */
+  it('keeps two skills apart when sanitising alone would merge them', () => {
+    const a = suggestionBranchFor('juan@bevel.software', `${'x'.repeat(400)} (v1)`, 'SKILL.md');
+    const b = suggestionBranchFor('juan@bevel.software', `${'x'.repeat(400)} [v1]`, 'SKILL.md');
+
+    expect(a).not.toBe(b);
+    assertGitAccepts(a);
+    assertGitAccepts(b);
+  });
+
+  /** The ordinary case must not pick up a base digest it does not need. */
+  it('leaves a base that fits untouched', () => {
+    const b = suggestionBranchFor('juan@bevel.software', 'newsletter', 'SKILL.md');
+
+    expect(b).toBe('suggestions/juan/newsletter--skill.md-8124a561');
+  });
+
+  /**
    * The dot rules. Both reject the WHOLE branch backend-side, and both only
    * became reachable when file names started feeding the branch — dots are
    * rare in skill names and universal in filenames.

--- a/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
+++ b/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
@@ -31,12 +31,19 @@ function assertGitAccepts(branch: string) {
 }
 
 describe('suggestionBranchFor', () => {
+  /**
+   * The exact strings are pinned, not just their shape. `SkillPage` decides
+   * which open request belongs to the file on screen by RECOMPUTING this name
+   * and comparing it to the request's branch, so the output is a stored
+   * contract: change how it is built and every request already open stops
+   * being recognised as its author's own.
+   */
   it('names the file, so one skill can hold several open proposals', () => {
     const a = suggestionBranchFor('juan@bevel.software', 'newsletter', 'SKILL.md');
     const b = suggestionBranchFor('juan@bevel.software', 'newsletter', 'sources.yaml');
 
-    expect(a).toBe('suggestions/juan/newsletter--skill.md');
-    expect(b).toBe('suggestions/juan/newsletter--sources.yaml');
+    expect(a).toBe('suggestions/juan/newsletter--skill.md-8124a561');
+    expect(b).toBe('suggestions/juan/newsletter--sources.yaml-346aab36');
     // Different files, different branches — this is the whole fix.
     expect(a).not.toBe(b);
   });
@@ -62,7 +69,57 @@ describe('suggestionBranchFor', () => {
   it('flattens a nested file path into the one segment', () => {
     const b = suggestionBranchFor('juan@bevel.software', 'deck', 'reference/DESIGN-SYSTEM.md');
 
-    expect(b).toBe('suggestions/juan/deck--reference-design-system.md');
+    expect(b).toBe('suggestions/juan/deck--reference-design-system.md-692a31cc');
+    assertGitAccepts(b);
+  });
+
+  /**
+   * Flattening is LOSSY: '/' and every other character git will not take both
+   * become '-', so a nested path and a hyphenated one at the skill root reduce
+   * to the same readable slug. That is only a naming curiosity until you
+   * remember `SkillPage` matches a request to a file by branch — one branch
+   * for two files means the first file's pending request is served to the
+   * second as its own, the editor stays shut, and a proposal on the second is
+   * written into the first's request rather than opening its own. The digest
+   * is taken from the path BEFORE flattening, which is what keeps them apart.
+   */
+  it('does not collide two files that flatten to the same slug', () => {
+    const nested = suggestionBranchFor('juan@bevel.software', 'deck', 'reference/DESIGN-SYSTEM.md');
+    const flat = suggestionBranchFor('juan@bevel.software', 'deck', 'reference-design-system.md');
+
+    expect(nested).not.toBe(flat);
+    // Same readable slug — only the digest separates them, which is the point.
+    expect(nested.startsWith('suggestions/juan/deck--reference-design-system.md-')).toBe(true);
+    expect(flat.startsWith('suggestions/juan/deck--reference-design-system.md-')).toBe(true);
+    assertGitAccepts(nested);
+    assertGitAccepts(flat);
+  });
+
+  /**
+   * 255 is git's hard ceiling on a ref, and nothing upstream bounds a file
+   * path, so the slug is truncated to the room the base leaves. The digest
+   * survives the truncation — it is appended after it — so two long paths
+   * sharing a truncated prefix still get their own branches.
+   */
+  it('bounds an overlong nested path to a ref git will accept', () => {
+    const deep = `${'deeply/nested/'.repeat(40)}notes.md`;
+    const b = suggestionBranchFor('juan@bevel.software', 'deck', deep);
+
+    expect(b.length).toBeLessThanOrEqual(255);
+    assertGitAccepts(b);
+
+    // Truncation must not merge two distinct paths that share a long prefix.
+    const sibling = suggestionBranchFor('juan@bevel.software', 'deck', `${deep}x`);
+    expect(sibling.length).toBeLessThanOrEqual(255);
+    expect(sibling).not.toBe(b);
+    assertGitAccepts(sibling);
+  });
+
+  /** A skill name long enough to crowd out the file still yields a legal ref. */
+  it('bounds the ref even when the base itself is pathological', () => {
+    const b = suggestionBranchFor('juan@bevel.software', 'x'.repeat(400), 'SKILL.md');
+
+    expect(b.length).toBeLessThanOrEqual(255);
     assertGitAccepts(b);
   });
 
@@ -80,7 +137,7 @@ describe('suggestionBranchFor', () => {
     // A segment may not end `.lock` — that is how git names its own lockfiles.
     const lock = suggestionBranchFor('juan@bevel.software', 'deck', 'deps.lock');
     expect(lock.endsWith('.lock')).toBe(false);
-    expect(lock).toBe('suggestions/juan/deck--deps-lock');
+    expect(lock).toBe('suggestions/juan/deck--deps-lock-5647bf0c');
     assertGitAccepts(lock);
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
+++ b/packages/core-frontend/src/modules/library/__tests__/suggestion-branch.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { suggestionBranchFor } from '../services/library.api';
+
+/**
+ * The branch name is the ONLY thing tying a proposal to the file it is about,
+ * and the backend refuses to create a branch whose name breaks git's ref rules
+ * (`assertValidBranchName` in core-backend's `git/branch-name.ts`). A name that
+ * trips one of those rules surfaces as a bare 400 on "Propose changes" with
+ * nothing on screen saying why — so the rules are asserted here rather than
+ * discovered in production.
+ *
+ * These mirror the backend's checks. They are duplicated rather than imported
+ * because core-frontend does not depend on core-backend; if that validator
+ * gains a rule, this file is the place that has to learn it too.
+ */
+const startsLegal = (b: string) => /^[A-Za-z0-9]/.test(b);
+const legalChars = (b: string) => /^[A-Za-z0-9][A-Za-z0-9/_\-.]*$/.test(b);
+
+function assertGitAccepts(branch: string) {
+  expect(startsLegal(branch)).toBe(true);
+  expect(legalChars(branch)).toBe(true);
+  expect(branch).not.toContain('..');
+  expect(branch).not.toContain('//');
+  expect(branch).not.toContain('@{');
+  expect(branch.endsWith('/') || branch.endsWith('.')).toBe(false);
+  expect(branch.length).toBeLessThanOrEqual(255);
+  for (const segment of branch.split('/')) {
+    expect(segment.startsWith('.')).toBe(false);
+    expect(segment.endsWith('.lock')).toBe(false);
+  }
+}
+
+describe('suggestionBranchFor', () => {
+  it('names the file, so one skill can hold several open proposals', () => {
+    const a = suggestionBranchFor('juan@bevel.software', 'newsletter', 'SKILL.md');
+    const b = suggestionBranchFor('juan@bevel.software', 'newsletter', 'sources.yaml');
+
+    expect(a).toBe('suggestions/juan/newsletter--skill.md');
+    expect(b).toBe('suggestions/juan/newsletter--sources.yaml');
+    // Different files, different branches — this is the whole fix.
+    expect(a).not.toBe(b);
+  });
+
+  /**
+   * FLATTENED with `--`, never nested with `/`. A leftover skill-level branch
+   * from before files were in the name is a ref FILE at
+   * `refs/heads/suggestions/juan/newsletter`; nesting would ask git to make
+   * that same path a directory, and it refuses (D/F conflict) — every propose
+   * on the skill would fail for as long as the old branch existed.
+   */
+  it('keeps the file a sibling of the legacy skill branch, not a child of it', () => {
+    const legacy = suggestionBranchFor('juan@bevel.software', 'newsletter');
+    const file = suggestionBranchFor('juan@bevel.software', 'newsletter', 'SKILL.md');
+
+    expect(legacy).toBe('suggestions/juan/newsletter');
+    expect(file.startsWith(`${legacy}/`)).toBe(false);
+    expect(file.startsWith(`${legacy}--`)).toBe(true);
+    // Same parent directory ⇒ both can exist at once.
+    expect(file.split('/').length).toBe(legacy.split('/').length);
+  });
+
+  it('flattens a nested file path into the one segment', () => {
+    const b = suggestionBranchFor('juan@bevel.software', 'deck', 'reference/DESIGN-SYSTEM.md');
+
+    expect(b).toBe('suggestions/juan/deck--reference-design-system.md');
+    assertGitAccepts(b);
+  });
+
+  /**
+   * The dot rules. Both reject the WHOLE branch backend-side, and both only
+   * became reachable when file names started feeding the branch — dots are
+   * rare in skill names and universal in filenames.
+   */
+  it('survives file names git would otherwise reject', () => {
+    // `..` is invalid anywhere in a ref.
+    const dots = suggestionBranchFor('juan@bevel.software', 'deck', 'notes..md');
+    expect(dots).not.toContain('..');
+    assertGitAccepts(dots);
+
+    // A segment may not end `.lock` — that is how git names its own lockfiles.
+    const lock = suggestionBranchFor('juan@bevel.software', 'deck', 'deps.lock');
+    expect(lock.endsWith('.lock')).toBe(false);
+    expect(lock).toBe('suggestions/juan/deck--deps-lock');
+    assertGitAccepts(lock);
+  });
+
+  it('produces a legal branch for the punctuation a real skill folder carries', () => {
+    for (const file of [
+      'SKILL.md',
+      'scripts/export-pdf.py',
+      'scripts/video-to-gif.sh',
+      'template/deck.html',
+      'reference/QA-STANDARDS.md',
+      '.gitignore',
+      'weird name (v2).md',
+      'ünïcode.md',
+    ]) {
+      assertGitAccepts(suggestionBranchFor('Juan.Viera@bevel.software', 'create-reading-deck', file));
+    }
+  });
+});

--- a/packages/core-frontend/src/modules/library/components/ChangeRequestDock.tsx
+++ b/packages/core-frontend/src/modules/library/components/ChangeRequestDock.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import type { PullRequestSummary } from '@bevel-software/platform-shared';
 import { Badge } from '../../../shared/components';
 import { changeAuthorName } from '../utils/cr-author';
@@ -6,6 +7,9 @@ interface ChangeRequestDockProps {
   crs: PullRequestSummary[];
   onSelect(cr: PullRequestSummary): void;
 }
+
+/** How many requests stand fully visible before the rest scroll. */
+const VISIBLE_CARDS = 3;
 
 /**
  * Owner-only panel: a minimal name-list of the open change requests touching
@@ -17,6 +21,21 @@ interface ChangeRequestDockProps {
  * detail became a page that put it on top of the group sidebar. A page has no
  * centred panel to hang off, so the edge is the only stable anchor.
  *
+ * Two consequences of being fixed-position chrome, both handled here:
+ *
+ *  - It can sit ON the column it is about. So the `»` in the header folds it
+ *    to a slim tab on the edge — count still showing, cards gone — and the
+ *    tab unfolds it. The state is per MOUNT, deliberately: a decision queue
+ *    that remembers being hidden across visits is one that quietly stops
+ *    being seen.
+ *  - It grows with its cards, and per-file change requests mean one person
+ *    can now fill it. The list stops growing after the third card and scrolls
+ *    the rest: three is enough to say "there is work here", which is the
+ *    dock's whole job. The cap is MEASURED rather than a fixed height because
+ *    titles wrap anywhere from one line to four (`… · scripts/export-pdf.py`),
+ *    so any fixed number either beheads the third card or leaves room for a
+ *    fourth.
+ *
  * Renders nothing when there is nothing to review: an empty box floating beside
  * a skill states, permanently and to the one person who could act, that there
  * is work here — when there isn't.
@@ -26,10 +45,68 @@ interface ChangeRequestDockProps {
  * label below was dead text and the panel was unreachable by landmark
  * navigation. The name is also what keeps it one: `<aside>` nested inside the
  * page's `<article>` degrades to `generic` UNLESS it is named, so the label and
- * the element depend on each other — do not drop either.
+ * the element depend on each other — do not drop either. The collapsed tab
+ * keeps both for the same reason.
  */
 export function ChangeRequestDock({ crs, onSelect }: ChangeRequestDockProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const list = useRef<HTMLDivElement>(null);
+  const [listMaxH, setListMaxH] = useState<number | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    if (collapsed) return; // no list on screen, nothing to measure
+    const el = list.current;
+    if (!el) return;
+
+    const measure = () => {
+      if (crs.length <= VISIBLE_CARDS) {
+        setListMaxH(undefined);
+        return;
+      }
+      const third = el.children[VISIBLE_CARDS - 1] as HTMLElement | undefined;
+      if (!third) return;
+      // The third card's bottom edge in the list's CONTENT coordinates —
+      // `scrollTop` folds a mid-scroll re-measure back in. Guarded to > 0
+      // because a layout-less environment (tests) answers 0, and a 0 cap
+      // would not be "three visible", it would be none.
+      const cap =
+        third.getBoundingClientRect().bottom - el.getBoundingClientRect().top + el.scrollTop;
+      setListMaxH(cap > 0 ? cap : undefined);
+    };
+
+    measure();
+    // Cards change height after the first paint — fonts arrive, titles
+    // re-wrap on zoom — and the cap has to follow the third card's edge.
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    for (const card of Array.from(el.children)) ro.observe(card);
+    return () => ro.disconnect();
+  }, [crs, collapsed]);
+
   if (crs.length === 0) return null;
+
+  if (collapsed) {
+    return (
+      <aside
+        className="lib-cr-dock fixed right-0 top-1/2 z-[55] -translate-y-1/2"
+        aria-label="Change requests for this skill"
+      >
+        <button
+          type="button"
+          aria-label="Show the change requests"
+          aria-expanded={false}
+          title="Show the change requests"
+          className="flex items-center gap-1.5 rounded-l-xl border border-r-0 border-line bg-surface py-2.5 pl-2 pr-1.5 text-detail text-ink-muted shadow-overlay transition-colors hover:text-ink"
+          onClick={() => setCollapsed(false)}
+        >
+          <span aria-hidden>«</span>
+          <Badge tone="wait" size="xs">
+            {crs.length}
+          </Badge>
+        </button>
+      </aside>
+    );
+  }
 
   return (
     <aside
@@ -41,8 +118,22 @@ export function ChangeRequestDock({ crs, onSelect }: ChangeRequestDockProps) {
         <Badge tone="wait" size="xs">
           {crs.length}
         </Badge>
+        <button
+          type="button"
+          aria-label="Collapse the change requests"
+          aria-expanded={true}
+          title="Collapse the change requests"
+          className="-mr-2 ml-auto rounded-sm px-1.5 py-0.5 text-detail text-ink-faint transition-colors hover:bg-hover hover:text-ink"
+          onClick={() => setCollapsed(true)}
+        >
+          <span aria-hidden>»</span>
+        </button>
       </div>
-      <div className="flex flex-col gap-2 overflow-y-auto px-2.5 pb-3">
+      <div
+        ref={list}
+        style={{ maxHeight: listMaxH }}
+        className="flex flex-col gap-2 overflow-y-auto px-2.5 pb-3"
+      >
         {crs.map((cr) => (
           <button
             key={cr.number}

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -117,31 +117,6 @@ export function SkillPage() {
     () => (skillPath ? data.crs.filter((c) => touchesSkill(c, skillPath)) : []),
     [data.crs, skillPath],
   );
-  /**
-   * The caller's own open change request for this skill, resolved by BRANCH.
-   *
-   * Not by touched paths: `touchedNodePaths` is documented "Empty if not yet
-   * computed", and while it is empty every path-derived check collapses at
-   * once — the request stops looking like it touches this skill, so `ownCr`
-   * goes null, the editor offers itself again, and `proposeChange` takes its
-   * no-existing-request path and opens a SECOND change request against the
-   * branch that already has one.
-   *
-   * The branch is deterministic (`suggestionBranchFor`) and exists from the
-   * moment the request does, so it answers "is this mine?" in the window where
-   * paths cannot. The path-based lookup stays as a fallback — it can only add
-   * matches, never remove them — so a request opened on some other branch (by
-   * an agent, say) is still recognised as the caller's.
-   */
-  const myBranch = user ? suggestionBranchFor(user.email, name) : null;
-  const ownCr = useMemo(
-    () =>
-      data.crs.find((c) => data.myCrNumbers.has(c.number) && c.branch === myBranch) ??
-      skillCrs.find((c) => data.myCrNumbers.has(c.number)) ??
-      null,
-    [data.crs, data.myCrNumbers, myBranch, skillCrs],
-  );
-
   /** Which tabs get a dot: the files an open change request actually touches. */
   const pendingFiles = useMemo(() => {
     const set = new Set<string>();
@@ -214,17 +189,52 @@ export function SkillPage() {
   );
 
   /**
-   * Whether to offer the editor. Keyed off `ownCr` — which knows the caller's
-   * request by branch — rather than off `boxes`, which cannot see a request
-   * whose touched paths have not been computed yet and would hand out a second
-   * editor over the top of one.
+   * The caller's own open change request for the file ON SCREEN, resolved by
+   * BRANCH first.
    *
-   * Consequence worth knowing: one open proposal per person per SKILL, not per
-   * file. Adding a second file to a request you already have open now means
-   * withdrawing it (or asking your agent), which is the cost of never being
-   * able to fork your own pending change in two.
+   * Not by touched paths alone: `touchedNodePaths` is documented "Empty if not
+   * yet computed", and while it is empty every path-derived check collapses at
+   * once — the request stops looking like it touches this file, the editor
+   * offers itself again, and `proposeChange` takes its no-existing-request
+   * path and opens a SECOND change request against the branch that already has
+   * one. The branch is deterministic (`suggestionBranchFor`) and exists from
+   * the moment the request does, so it answers "is this mine, about this
+   * file?" in the window where paths cannot.
+   *
+   * Three clauses, in order of how much they know:
+   *  - my request on this file's own branch — closes the uncomputed window for
+   *    requests opened since branches started carrying the file;
+   *  - my request whose computed paths include this file — catches requests
+   *    opened on branches this page cannot predict (by an agent, say);
+   *  - my request on the LEGACY skill-level branch while its paths are still
+   *    uncomputed — it may be about any file here, so every file treats it as
+   *    its own rather than offering an editor that would fork it.
    */
-  const iAlreadyProposedHere = ownCr !== null;
+  const myFileBranch = user ? suggestionBranchFor(user.email, name, active) : null;
+  const mySkillBranch = user ? suggestionBranchFor(user.email, name) : null;
+  const ownCrForFile = useMemo(
+    () =>
+      data.crs.find((c) => data.myCrNumbers.has(c.number) && c.branch === myFileBranch) ??
+      boxes.find((c) => data.myCrNumbers.has(c.number)) ??
+      data.crs.find(
+        (c) =>
+          data.myCrNumbers.has(c.number) &&
+          c.branch === mySkillBranch &&
+          c.touchedNodePaths.length === 0,
+      ) ??
+      null,
+    [data.crs, data.myCrNumbers, myFileBranch, mySkillBranch, boxes],
+  );
+
+  /**
+   * Whether to offer the editor: only when the caller has no open proposal on
+   * THIS file. Per FILE, not per skill — a pending proposal on SKILL.md must
+   * not lock `sources.yaml`; each file's proposal is its own branch and its
+   * own change request, decided on its own. What stays closed is re-proposing
+   * on a file with a proposal already pending, which would fork one pending
+   * change into two decisions the owner has to reconcile.
+   */
+  const iAlreadyProposedHere = ownCrForFile !== null;
 
   const openInEditor = useCallback(
     (wsRelative: string) => navigate(kbFileUrl(DEFAULT_BRANCH, wsRelative)),
@@ -236,10 +246,11 @@ export function SkillPage() {
     await proposeChange({
       skillName: name,
       repoRelativePath: fileRepoPath,
+      file: active,
       content,
       userEmail: user.email,
       userName: user.name,
-      existingCr: ownCr,
+      existingCr: ownCrForFile,
     });
     setEditing(false);
     setRevision((r) => r + 1);

--- a/packages/core-frontend/src/modules/library/services/library.api.ts
+++ b/packages/core-frontend/src/modules/library/services/library.api.ts
@@ -91,50 +91,83 @@ export async function readFileOnBranch(branch: string, repoRelativePath: string)
   return readFile(workspace.id, `${workspace.kbDirName}/${repoRelativePath}`);
 }
 
-/** Keep only characters git branch segments accept; collapse the rest to '-'. */
+/**
+ * Keep only characters git branch segments accept; collapse the rest to '-'.
+ *
+ * The two dot rules are not cosmetic — `assertValidBranchName` REJECTS the
+ * whole branch over either, and the rejection surfaces as a 400 on "Propose
+ * changes" with nothing on screen explaining why. They matter now that FILE
+ * names reach this function (`suggestionBranchFor`), because file names are
+ * where dots actually live: `..` anywhere in a ref is invalid, and a segment
+ * ending `.lock` is how git names its own lockfiles, so a skill shipping a
+ * `deps.lock` beside its SKILL.md would otherwise be unproposable.
+ */
 function branchSegment(raw: string): string {
   const cleaned = raw
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/\.{2,}/g, '.')
     .replace(/^[-.]+/, '')
-    .replace(/[.]+$/, '');
+    .replace(/[.]+$/, '')
+    .replace(/\.lock$/, '-lock');
   return cleaned || 'user';
 }
 
-/** The one suggestion branch per user per skill (see mocks/README.md — suggestions are git). */
-export function suggestionBranchFor(userEmail: string, skillName: string): string {
-  return `suggestions/${branchSegment(userEmail.split('@')[0])}/${branchSegment(skillName)}`;
+/**
+ * The one suggestion branch per user per skill FILE (see mocks/README.md —
+ * suggestions are git). The file lands FLATTENED into the last segment
+ * (`--<slug>`) rather than nested under the skill (`/<slug>`): skill-level
+ * branches from before files were part of the name (`suggestions/u/skill`)
+ * linger after a merge or cancel, and git refuses to create
+ * `suggestions/u/skill/anything` while one exists — the ref would have to be
+ * a file and a directory at once.
+ *
+ * Without `file` this returns that legacy skill-level name, which callers
+ * still need in order to RECOGNISE requests opened before branches carried
+ * the file — not to open new ones.
+ */
+export function suggestionBranchFor(userEmail: string, skillName: string, file?: string): string {
+  const base = `suggestions/${branchSegment(userEmail.split('@')[0])}/${branchSegment(skillName)}`;
+  return file === undefined ? base : `${base}--${branchSegment(file)}`;
 }
 
 export interface ProposeChangeInput {
   skillName: string;
   /** Repo-root-relative path of the file being proposed on. */
   repoRelativePath: string;
+  /** The same file relative to the skill folder (e.g. `SKILL.md`) — names the branch. */
+  file: string;
   /** The file's full new text — what the author typed in the editor. */
   content: string;
   /** Optional "why" — lands in the change-request description / a comment. */
   note?: string;
   userEmail: string;
   userName: string;
-  /** The caller's open change request for this skill, if any. */
+  /** The caller's open change request for this file, if any. */
   existingCr?: PullRequestSummary | null;
 }
 
 /**
- * Propose a change: commit the new text to the author's suggestion branch
- * (`suggestions/<user>/<skill>`, forked from the default branch) and make sure
- * an open change request against the default branch exists for it.
+ * Propose a change: commit the new text to the author's suggestion branch for
+ * this file (`suggestions/<user>/<skill>--<file>`, forked from the default
+ * branch) and make sure an open change request against the default branch
+ * exists for it.
  *
  * Save = share: `writeFile` on the branch workspace auto-commits and pushes, so
  * the proposal is durable the moment this resolves — there is no local-only
  * state that could be lost between here and the owner reading it.
  *
- * One branch and one change request PER PERSON PER SKILL, not per file: a
- * proposal that rewrites a step and its example touches two files and is one
- * decision, so it has to arrive as one thing to approve.
+ * One branch and one change request PER PERSON PER FILE: proposing on a second
+ * file of the same skill opens a second request rather than growing the first,
+ * so a pending proposal never locks the rest of the skill, and each file's
+ * change is approved or declined on its own. The title names the file for the
+ * same reason — the owner's dock can now hold several requests from the same
+ * person on the same skill.
  */
 export async function proposeChange(input: ProposeChangeInput): Promise<{ branch: string }> {
-  const branch = input.existingCr?.branch ?? suggestionBranchFor(input.userEmail, input.skillName);
+  const branch =
+    input.existingCr?.branch ??
+    suggestionBranchFor(input.userEmail, input.skillName, input.file);
 
   if (!input.existingCr) {
     try {
@@ -160,7 +193,7 @@ export async function proposeChange(input: ProposeChangeInput): Promise<{ branch
     await openChangeRequest({
       sourceBranch: branch,
       targetBranch: DEFAULT_BRANCH,
-      title: `Changes from ${input.userName} — ${input.skillName}`,
+      title: `Changes from ${input.userName} — ${input.skillName} · ${input.file}`,
       description: input.note || undefined,
     });
   }

--- a/packages/core-frontend/src/modules/library/services/library.api.ts
+++ b/packages/core-frontend/src/modules/library/services/library.api.ts
@@ -113,6 +113,39 @@ function branchSegment(raw: string): string {
   return cleaned || 'user';
 }
 
+/** Git's own ceiling on a ref name; a longer one is refused outright. */
+const MAX_BRANCH_LENGTH = 255;
+
+/**
+ * A 32-bit FNV-1a digest of the file path, as fixed-width hex.
+ *
+ * What matters is WHAT it hashes: the raw path, before `branchSegment` has
+ * touched it. `branchSegment` is lossy by design — every character git will
+ * not take becomes '-', so `reference/DESIGN-SYSTEM.md` and
+ * `reference-design-system.md` come out of it as the same slug. Two files
+ * sharing one branch is not a cosmetic clash: `SkillPage` decides which
+ * request belongs to the open file BY BRANCH, so the first file's pending
+ * request is handed to the second as its own, the editor stays closed, and a
+ * proposal on the second file is written into the first file's request
+ * instead of opening its own.
+ *
+ * Not a cryptographic hash and does not need to be — it separates the files
+ * within one skill folder, and 32 bits is orders of magnitude more than the
+ * dozens of paths that live there.
+ */
+function pathDigest(raw: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < raw.length; i += 1) {
+    hash ^= raw.charCodeAt(i);
+    // ×16777619 (the FNV prime) written as shifts, so it stays in 32 bits.
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+/** Drop separators a truncation may have left dangling on the end. */
+const trimEnd = (s: string): string => s.replace(/[-./]+$/, '');
+
 /**
  * The one suggestion branch per user per skill FILE (see mocks/README.md —
  * suggestions are git). The file lands FLATTENED into the last segment
@@ -122,13 +155,35 @@ function branchSegment(raw: string): string {
  * `suggestions/u/skill/anything` while one exists — the ref would have to be
  * a file and a directory at once.
  *
- * Without `file` this returns that legacy skill-level name, which callers
- * still need in order to RECOGNISE requests opened before branches carried
- * the file — not to open new ones.
+ * The file segment is a readable slug plus a digest of the path it came from.
+ * The slug alone cannot identify the file — it is lossy (see `pathDigest`) —
+ * and it is unbounded, while the ref it lands in is capped at 255. So the
+ * digest carries the identity and the slug is free to be truncated to
+ * whatever room the base leaves, staying human-readable without being load
+ * bearing.
+ *
+ * Without `file` this returns the legacy skill-level name, byte for byte as
+ * before — callers still need it in order to RECOGNISE requests opened before
+ * branches carried the file, and those branches already exist under that
+ * exact name.
  */
 export function suggestionBranchFor(userEmail: string, skillName: string, file?: string): string {
   const base = `suggestions/${branchSegment(userEmail.split('@')[0])}/${branchSegment(skillName)}`;
-  return file === undefined ? base : `${base}--${branchSegment(file)}`;
+  if (file === undefined) return base;
+
+  const digest = pathDigest(file);
+  // The `--` joiner and the `-<digest>` are the parts that cannot be dropped;
+  // whatever the cap leaves after them is the slug's to use.
+  const fixedCost = 2 + digest.length + 1;
+  // A base long enough to crowd out the digest is pathological (a ~240-char
+  // skill name), but truncating it beats emitting a ref git will reject.
+  const head =
+    base.length + fixedCost <= MAX_BRANCH_LENGTH
+      ? base
+      : trimEnd(base.slice(0, MAX_BRANCH_LENGTH - fixedCost));
+  const slug = trimEnd(branchSegment(file).slice(0, MAX_BRANCH_LENGTH - head.length - fixedCost));
+
+  return slug ? `${head}--${slug}-${digest}` : `${head}--${digest}`;
 }
 
 export interface ProposeChangeInput {

--- a/packages/core-frontend/src/modules/library/services/library.api.ts
+++ b/packages/core-frontend/src/modules/library/services/library.api.ts
@@ -171,19 +171,32 @@ export function suggestionBranchFor(userEmail: string, skillName: string, file?:
   const base = `suggestions/${branchSegment(userEmail.split('@')[0])}/${branchSegment(skillName)}`;
   if (file === undefined) return base;
 
-  const digest = pathDigest(file);
+  const fileDigest = pathDigest(file);
   // The `--` joiner and the `-<digest>` are the parts that cannot be dropped;
   // whatever the cap leaves after them is the slug's to use.
-  const fixedCost = 2 + digest.length + 1;
+  const fileCost = 2 + fileDigest.length + 1;
+
   // A base long enough to crowd out the digest is pathological (a ~240-char
-  // skill name), but truncating it beats emitting a ref git will reject.
-  const head =
-    base.length + fixedCost <= MAX_BRANCH_LENGTH
-      ? base
-      : trimEnd(base.slice(0, MAX_BRANCH_LENGTH - fixedCost));
+  // skill name), but truncating it beats emitting a ref git will reject — and
+  // truncation loses the base's identity exactly as flattening loses the
+  // file's, so it earns a digest on the same reasoning: two skills alike for
+  // their first 235 characters would otherwise share one branch, and a shared
+  // branch is a shared change request. The digest is over the RAW inputs, not
+  // over `base`, so it survives BOTH lossy steps — `branchSegment` has already
+  // mapped every character git refuses onto '-' by the time `base` exists, so
+  // skills differing only in punctuation are indistinguishable there too.
+  const baseTruncated = base.length + fileCost > MAX_BRANCH_LENGTH;
+  const baseSuffix = baseTruncated ? `-${pathDigest(`${userEmail} ${skillName}`)}` : '';
+  const fixedCost = fileCost + baseSuffix.length;
+
+  const head = baseTruncated
+    ? trimEnd(base.slice(0, MAX_BRANCH_LENGTH - fixedCost))
+    : base;
   const slug = trimEnd(branchSegment(file).slice(0, MAX_BRANCH_LENGTH - head.length - fixedCost));
 
-  return slug ? `${head}--${slug}-${digest}` : `${head}--${digest}`;
+  return slug
+    ? `${head}--${slug}-${fileDigest}${baseSuffix}`
+    : `${head}--${fileDigest}${baseSuffix}`;
 }
 
 export interface ProposeChangeInput {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent change proposals for each file, with file-specific branches and titles.
  * Preserved support for existing skill-wide change requests.
  * Added a collapsible change-request panel with a request-count tab.
  * Limited expanded request lists to three visible cards, with scrolling for additional items.

* **Bug Fixes**
  * Improved branch naming for nested, dotted, Unicode, lockfile, and lengthy filenames.
  * Prevented duplicate proposals and correctly handled requests with unavailable file paths.
  * Improved handling of legacy requests and proposals across separate files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->