### PR TITLE
An explicit DATABASE_URL stops being silently discarded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,18 @@
 # ── Database ────────────────────────────────────────────────────────────────
+# TWO WAYS, depending on where Postgres lives.
+#
+# Running the app yourself (`pnpm dev`), or pointing docker-compose at a
+# database you already have: set DATABASE_URL. It wins over the knobs below.
 DATABASE_URL=postgresql://bevel:bevel@localhost:5432/bevel
+#
+# Using the Postgres that docker-compose brings with it: leave DATABASE_URL
+# unset and set these instead — compose builds the URL from them and hands it
+# to both containers, so they cannot disagree. Postgres applies them only when
+# it FIRST initialises its volume; changing them later does not rename an
+# existing user or database.
+# POSTGRES_USER=bevel
+# POSTGRES_PASSWORD=bevel
+# POSTGRES_DB=bevel
 
 # ── Server ──────────────────────────────────────────────────────────────────
 PORT=3001

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pnpm install
 pnpm build
 
 # 3. Configure
-cp .env.example .env   # then fill in: DATABASE_URL, JWT_SECRET,
+cp .env.example .env   # then fill in: DATABASE_URL (or the POSTGRES_* knobs
+                       # if you use the Postgres docker-compose ships), JWT_SECRET,
                        # SECRETS_ENC_KEY, ADMIN_EMAIL — plus ADMIN_PASSWORD
                        # unless you set LOGIN_PASSWORD=false. The knowledge-base
                        # repo and its token are asked for on the setup screen at
@@ -54,7 +55,8 @@ outgoing one still holds it.
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `DATABASE_URL` | yes | Postgres connection string |
+| `DATABASE_URL` | yes* | Postgres connection string. Wins over the `POSTGRES_*` knobs — set it to use a database you already have |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | compose only | Credentials for the Postgres docker-compose brings with it; compose builds `DATABASE_URL` from them when you do not supply one. Applied only when the volume is first initialised |
 | `JWT_SECRET` | yes | Signs login sessions + OAuth state |
 | `ADMIN_EMAIL` | yes | The deployment owner: always an admin (whatever the sign-in method), and the initial Admin of a freshly seeded KB |
 | `ADMIN_PASSWORD` | with password login | Password half of the bootstrap credential — checked against the env, never stored. Not needed when `LOGIN_PASSWORD=false` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,8 +96,18 @@ services:
       # serves the SPA itself, so both default to this container's origin.
       - PUBLIC_BACKEND_URL=${PUBLIC_BACKEND_URL:-http://localhost:3001}
       - PUBLIC_FRONTEND_URL=${PUBLIC_FRONTEND_URL:-http://localhost:3001}
-      # Mirrors the db service's POSTGRES_* knobs (in-network hostname `db`).
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-bevel}:${POSTGRES_PASSWORD:-bevel}@db:5432/${POSTGRES_DB:-bevel}
+      # An explicit DATABASE_URL WINS — that is how you point this at a managed
+      # Postgres instead of the bundled `db` service. It used to be composed
+      # unconditionally from the POSTGRES_* knobs below, which silently
+      # overrode anything an operator set: `.env` documents DATABASE_URL, so
+      # following it and deploying with compose connected you to the throwaway
+      # container while your real database sat untouched.
+      #
+      # Falling back to the POSTGRES_* knobs keeps the batteries-included path
+      # working unchanged (in-network hostname `db`). When you do supply a URL,
+      # the `db` service still starts and is simply unused — stop it with
+      # `docker compose up --scale db=0` if that bothers you.
+      - DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-bevel}:${POSTGRES_PASSWORD:-bevel}@db:5432/${POSTGRES_DB:-bevel}}
     # node:22-slim ships neither curl nor wget; Node 22's global fetch probes.
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3001/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]


### PR DESCRIPTION
`docker-compose.yml` built `DATABASE_URL` from the `POSTGRES_*` knobs **unconditionally** and put it in the app service's `environment:`, which outranks `--env-file`. So a `DATABASE_URL` set in `.env` was ignored — while `.env.example` and the README document `DATABASE_URL` and never mention `POSTGRES_*`.

An operator following the documentation, pointing it at a managed Postgres and deploying with compose therefore connected to the **throwaway container in the same stack**, while their real database sat untouched, with nothing saying so.

Confirmed rather than reasoned about:

```
DATABASE_URL=postgresql://me:pw@managed.example.com:5432/prod   # in .env
$ docker compose --env-file .env config | grep DATABASE_URL
      DATABASE_URL: postgresql://bevel:bevel@db:5432/bevel      # silently replaced
```

## The fix

An explicit URL wins, falling back to the composed value so the batteries-included path is unchanged:

```yaml
- DATABASE_URL=${DATABASE_URL:-postgresql://${POSTGRES_USER:-bevel}:${POSTGRES_PASSWORD:-bevel}@db:5432/${POSTGRES_DB:-bevel}}
```

Verified both ways:

| `.env` | resolves to |
| --- | --- |
| `DATABASE_URL=…@managed.example.com/prod` | `postgresql://me:pw@managed.example.com:5432/prod` |
| `POSTGRES_USER=alice`, `POSTGRES_PASSWORD=s3cret`, `POSTGRES_DB=kb` | `postgresql://alice:s3cret@db:5432/kb` |

## Docs

Both files now admit the other path exists: `DATABASE_URL` for a database you already have, `POSTGRES_*` for the one compose ships. Also recorded two things that stay true — with a URL supplied the bundled `db` still starts and is simply unused (`--scale db=0` to stop it), and Postgres applies `POSTGRES_*` only when it first initialises its volume, so changing them later renames nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance for using either an existing PostgreSQL database or the bundled Docker Compose database.
  * Documented database configuration precedence and first-time credential initialization.
* **Configuration**
  * Added example PostgreSQL user, password, and database settings.
  * Explicit database connection URLs now take precedence, while bundled database defaults remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->