### PR TITLE
A deployment that has not been set up yet can reach its setup screen

### DIFF
--- a/packages/core-frontend/src/core/__tests__/bootstrap.test.ts
+++ b/packages/core-frontend/src/core/__tests__/bootstrap.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { configureBranchModel, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import { loadServerConfig } from '../bootstrap';
+
+/**
+ * The bootstrap runs before React does, and it is the ONLY thing between a
+ * fresh deployment and its setup screen. What it must not do is treat "not
+ * configured yet" as "broken" — that puts the screen which fixes the problem
+ * on the far side of the error reporting it.
+ */
+const CONFIGURED = {
+  defaultBranch: 'target-company-state',
+  protectedBranches: ['current-company-state', 'target-company-state'],
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // The model is module-global; restore what the shared test setup applied so
+  // a later suite is not left with whatever a case here configured.
+  configureBranchModel(CONFIGURED);
+});
+
+const respond = (branchModel: unknown) =>
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({ branchModel }) });
+
+describe('loadServerConfig', () => {
+  it('applies a configured model', async () => {
+    // Start from a different model so the assertion cannot pass by accident.
+    configureBranchModel({ defaultBranch: 'main', protectedBranches: ['main'] });
+    respond(CONFIGURED);
+    await loadServerConfig();
+    expect(DEFAULT_BRANCH).toBe('target-company-state');
+  });
+
+  /**
+   * The case that made a fresh install unusable: the server answers with an
+   * empty model because nobody has set one, and the bootstrap must let the app
+   * mount so `SetupGate` can render the screen that collects it.
+   */
+  it('does not fail on a deployment that has not been set up yet', async () => {
+    respond({ defaultBranch: '', protectedBranches: [] });
+    await expect(loadServerConfig()).resolves.toBeUndefined();
+  });
+
+  /** A half-set model is no more usable than an empty one, and no more fatal. */
+  it('tolerates a model that is present but incoherent', async () => {
+    respond({ defaultBranch: 'main', protectedBranches: ['release'] });
+    await expect(loadServerConfig()).resolves.toBeUndefined();
+  });
+
+  /** A server that cannot be reached IS a failure — the caller reports it. */
+  it('still fails when the request itself does', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 502 });
+    await expect(loadServerConfig()).rejects.toThrow(/Could not load configuration/);
+  });
+});

--- a/packages/core-frontend/src/core/bootstrap.ts
+++ b/packages/core-frontend/src/core/bootstrap.ts
@@ -1,4 +1,4 @@
-import { configureBranchModel, isBranchModelConfigured } from '@bevel-software/platform-shared';
+import { configureBranchModel, validateBranchModel } from '@bevel-software/platform-shared';
 
 /** What `GET /api/config` serves. Unauthenticated — see the route's comment. */
 interface ServerConfig {
@@ -20,13 +20,27 @@ interface ServerConfig {
  * near side of having a session.
  */
 export async function loadServerConfig(): Promise<void> {
-  // Idempotent, so a hot reload or a double-invoked entry point does not throw
-  // on re-applying the same model.
-  if (isBranchModelConfigured()) return;
+  // No "already configured?" short-circuit: applying the same model twice is a
+  // no-op, `configureBranchModel` only rejects an INVALID one, and the guard
+  // made this function unobservable once anything had configured the module —
+  // including its own tests.
   const res = await fetch('/api/config');
   if (!res.ok) throw new Error(`Could not load configuration (${res.status})`);
   const config = (await res.json()) as ServerConfig;
-  configureBranchModel(config.branchModel);
+  /**
+   * An UNCONFIGURED deployment is not a failure — it is the state the setup
+   * screen exists for. A fresh install has no branch model yet, and
+   * `configureBranchModel` throws on an empty one, so applying it blindly
+   * turned first-run into "this deployment is not responding" and put the
+   * screen that fixes it on the far side of the error.
+   *
+   * Leaving the model unset is safe because nothing that reads it renders
+   * until `SetupGate` opens: the login screen does not use it, and everything
+   * that does is behind the gate, which stays shut until the branch model is
+   * among the settings that make setup complete.
+   */
+  const problem = validateBranchModel(config.branchModel);
+  if (!problem) configureBranchModel(config.branchModel);
 }
 
 /**


### PR DESCRIPTION
A fresh deployment could not reach its own setup screen.

The browser bootstrap applied whatever branch model `GET /api/config` returned, and `configureBranchModel` throws on an empty one. A deployment that has not been set up yet has no branch model — that is precisely the state the setup screen exists for — so first-run rendered **"This deployment is not responding"**, putting the screen that fixes the problem on the far side of the error reporting it.

The backend already handled this correctly: it configures only a valid model and leaves the rest to `isComplete`. The browser did not, which undid it.

```js
configureBranchModel({ defaultBranch: '', protectedBranches: [] })
// → Error: A default branch is required — the branch users land on.
```

## The fix

An unconfigured model is left unset. That is safe for the same reason it is safe on the server: nothing that reads it renders until `SetupGate` opens. The login screen does not use it, and everything that does is behind the gate, which stays shut until the branch model is among the settings that make setup complete.

Also dropped the `isBranchModelConfigured()` short-circuit. Re-applying the same model is a no-op and `configureBranchModel` only rejects an *invalid* one, so the guard bought nothing — while making the function unobservable once anything had configured the module, including its own tests.

## Tests

Four, in a file that did not exist: a configured model is applied, an empty one and an incoherent one both resolve rather than throw, and a request that genuinely fails still does.

## Verification

`CoreConfig` was constructed from a staging environment carrying no KB or branch variables — it boots, with `kbRepoUrl` empty and awaiting the screen. (A full container boot was not possible here; the Docker daemon was not running.)

core-frontend 902/902 · core-backend 1266 passing (the 4 known Windows-env failures) · typecheck clean · web build ok · ratchet 155 vs baseline 273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading when branch models are empty, invalid, or inconsistent.
  * Setup now continues gracefully instead of failing for invalid branch model settings.
  * Valid branch models are applied only after successful validation.
* **Tests**
  * Added coverage for configured models, unconfigured deployments, inconsistent models, and configuration request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->