### PR TITLE
Blank defaults for the variables the setup screen now collects

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       # Bitbucket, Azure DevOps, self-hosted): GIT_TOKEN is the Basic-auth
       # password and GIT_USERNAME the Basic username (host-specific — see
       # .env.example).
-      - GIT_TOKEN=${GIT_TOKEN}
+      - GIT_TOKEN=${GIT_TOKEN:-}
       - GIT_USERNAME=${GIT_USERNAME:-}
       - JWT_SECRET=${JWT_SECRET}
       # The deployment owner. REQUIRED: always an admin whatever the sign-in
@@ -82,13 +82,13 @@ services:
       # SSO allow-list (part of the OIDC config above). SSO auto-provisions, so
       # against a multi-tenant issuer this is the only signup boundary.
       - ALLOWED_EMAIL_DOMAINS=${ALLOWED_EMAIL_DOMAINS:-}
-      - KB_REPO_URL=${KB_REPO_URL}
-      - KB_DIR_NAME=${KB_DIR_NAME}
+      - KB_REPO_URL=${KB_REPO_URL:-}
+      - KB_DIR_NAME=${KB_DIR_NAME:-}
       # Branch model. Runtime only now — the frontend is served these over
       # /api/config instead of having them compiled in, so one image runs
       # anywhere and renaming a branch no longer needs a rebuild.
-      - DEFAULT_BRANCH=${DEFAULT_BRANCH}
-      - PROTECTED_BRANCHES=${PROTECTED_BRANCHES}
+      - DEFAULT_BRANCH=${DEFAULT_BRANCH:-}
+      - PROTECTED_BRANCHES=${PROTECTED_BRANCHES:-}
       # 32-byte key (base64 or hex) encrypting secrets-vault values + MCP
       # OAuth client secrets/tokens.
       - SECRETS_ENC_KEY=${SECRETS_ENC_KEY}


### PR DESCRIPTION
Five variables were still referenced without a default, from when they were required. Leaving them unset is now the ordinary path — they are collected on the setup screen — so every deploy logged five `variable is not set, defaulting to a blank string` warnings for a configuration that is entirely correct. Warnings that fire when nothing is wrong are how real ones get missed.

`JWT_SECRET` and `SECRETS_ENC_KEY` keep no default deliberately: those are genuinely required, and the warning is the only hint compose gives before the app refuses to boot over them.

No behavioural change — `${X}` and `${X:-}` both resolve to empty. Verified: with only the four required variables set, `docker compose config` now emits nothing on stderr.

**Worth recording, since it is what makes leaving them blank safe:** compose passes every optional variable through as an empty string, and the settings layer trims before deciding, so an empty value reads as `unset` rather than `set by the environment`. All twelve settable fields stay editable on the setup screen under a deployment that supplies none of them — checked against the real service, not the types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling by allowing Git and knowledge-base repository settings to remain empty when environment variables are not provided.
  * Preserved existing service behavior for all other configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->