### PR TITLE
Remove "Undo this save" from the file history view

### DIFF
--- a/.changeset/undo-save-retires.md
+++ b/.changeset/undo-save-retires.md
@@ -1,0 +1,11 @@
+---
+'@bevel-software/platform-shared': patch
+'@bevel-software/platform-core-backend': patch
+'@bevel-software/platform-core-frontend': patch
+---
+
+Remove "Undo this save" from the file history view, and the revert
+machinery behind it: the `POST /workflow/changes/:sha/revert` endpoint,
+`IWorkflowService.revertChange`, and `GitService.revertCommit`. The
+history panel is now purely a reading surface — a timeline with each
+save's changes rendered beside it.

--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.service.facade.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.service.facade.test.ts
@@ -139,7 +139,6 @@ function makeGit(): GitService {
     diffStat: vi.fn(),
     pendingChanges: vi.fn(),
     resolveForkBase: vi.fn(),
-    revertCommit: vi.fn(),
     logForFile: vi.fn(),
     diffFileAtCommit: vi.fn(),
     diffFileBetweenBranches: vi.fn(),

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.accessGating.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.accessGating.test.ts
@@ -232,55 +232,6 @@ describe('GitService — commit gate uses HEAD (not working tree)', () => {
   });
 });
 
-describe('GitService — revert gate uses HEAD', () => {
-  let root: string;
-  const workspaceId = 'ws-revert-gate';
-
-  beforeEach(async () => {
-    root = await mkTmpRoot();
-  });
-  afterEach(async () => {
-    await fs.rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
-  });
-
-  it('passes ref=HEAD when gating a revert', async () => {
-    const { ac, calls } = recordingAccessControl();
-    const { svc, repo } = await makeSvc(root, workspaceId, ac);
-    await commitFile(repo, 'Knowledge/Foo.md', 'a\n', 'seed');
-    await commitFile(repo, 'Knowledge/Foo.md', 'b\n', 'second');
-    const { stdout: sha } = await execFileAsync('git', ['-C', repo, 'rev-parse', 'HEAD'], {
-      encoding: 'utf-8',
-    });
-
-    // We only care that the gate is invoked with `HEAD`; downstream
-    // behaviour of `git revert` (which may or may not succeed for unrelated
-    // environmental reasons — author parsing, signing config, etc.) is out
-    // of scope for this test.
-    await svc.revertCommit(workspaceId, USER, sha.trim()).catch(() => undefined);
-
-    const gateCalls = calls.filter((c) => c.method === 'canWriteBatchAtRef');
-    expect(gateCalls).toHaveLength(1);
-    expect(gateCalls[0].ref).toBe('HEAD');
-    expect(gateCalls[0].paths).toContain('Knowledge/Foo.md');
-  });
-
-  it('refuses with AccessDeniedError when the gate denies', async () => {
-    const { ac } = recordingAccessControl({
-      canWriteBatchAtRef: (_ref, _email, paths) => new Map(paths.map((p) => [p, false])),
-    });
-    const { svc, repo } = await makeSvc(root, workspaceId, ac);
-    await commitFile(repo, 'Knowledge/Foo.md', 'a\n', 'seed');
-    await commitFile(repo, 'Knowledge/Foo.md', 'b\n', 'second');
-    const { stdout: sha } = await execFileAsync('git', ['-C', repo, 'rev-parse', 'HEAD'], {
-      encoding: 'utf-8',
-    });
-
-    await expect(svc.revertCommit(workspaceId, USER, sha.trim())).rejects.toBeInstanceOf(
-      AccessDeniedError,
-    );
-  });
-});
-
 describe('GitService — push gate uses origin/<branch> (not HEAD or working tree)', () => {
   let root: string;
   const workspaceId = 'ws-push-gate';

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -1620,60 +1620,6 @@ export class GitService implements IGitService {
     });
   }
 
-  async revertCommit(
-    workspaceId: string,
-    user: AuthUser,
-    sha: string,
-  ): Promise<CommitAttribution> {
-    if (!/^[a-f0-9]{7,40}$/i.test(sha)) {
-      throw new WorkflowValidationError('invalid commit sha');
-    }
-    assertValidAuthor(user);
-    return this.mutex.run(workspaceId, async () => {
-      const cwd = await this.repoDir(workspaceId);
-      const branch = await this.currentBranch(cwd);
-
-      // Revert creates a new commit reversing `sha`. Same model as commit:
-      // gate only on protected branches; reverts on feature/draft branches
-      // are free (they produce a commit that would still need to merge via
-      // PR to affect canonical state).
-      if (isProtectedBranch(branch)) {
-        const { stdout: diffOut } = await this.git(cwd, [
-          'diff-tree', '--no-commit-id', '--name-only', '-r', sha,
-        ]);
-        const touched = diffOut.split('\n').map((s) => s.trim()).filter(Boolean);
-        await this.assertCanWriteAtRef(workspaceId, 'HEAD', user.email, touched);
-      }
-
-      await this.git(cwd, [
-        'revert',
-        '--no-edit',
-        `--author=${user.name} <${user.email}>`,
-        sha,
-      ]);
-
-      const { stdout } = await this.git(cwd, [
-        'log',
-        '-1',
-        '--pretty=format:%H%x00%an%x00%ae%x00%s%x00%aI',
-      ]);
-      const [headSha, authorName, authorEmail, subj, committedAt] = stdout.split('\x00');
-
-      // A revert may have touched roles.yaml or access.md — drop cached
-      // access state so the next gate read reflects the rolled-back tree.
-      // Mirrors the commit / pull paths.
-      this.accessControl?.invalidate(workspaceId);
-
-      return {
-        sha: headSha?.trim() ?? '',
-        authorName: authorName ?? '',
-        authorEmail: authorEmail ?? '',
-        subject: subj ?? '',
-        committedAt: committedAt?.trim() ?? new Date().toISOString(),
-      };
-    });
-  }
-
   async logForFile(
     workspaceId: string,
     relativePath: string,

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -266,17 +266,6 @@ export function createWorkflowRoutes(
     }
   });
 
-  router.post('/workspace/:id/workflow/changes/:sha/revert', async (req, res) => {
-    const user = await requireUser(req, res);
-    if (!user) return;
-    try {
-      res.json(await workflow.revertChange(req.params.id, user, req.params.sha));
-    } catch (err) {
-      const { status, body } = toHttpError(err);
-      res.status(status).json(body);
-    }
-  });
-
   router.get('/workspace/:id/workflow/compare-file', async (req, res) => {
     if (!(await requireUser(req, res))) return;
     const pathParam = typeof req.query.path === 'string' ? req.query.path : '';

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -480,10 +480,6 @@ export class WorkflowService implements IWorkflowService {
     return this.git.logForFile(workspaceId, path, limit);
   }
 
-  revertChange(workspaceId: string, user: AuthUser, sha: string): Promise<Change> {
-    return this.git.revertCommit(workspaceId, user, sha);
-  }
-
   compareFile(
     workspaceId: string,
     path: string,

--- a/packages/core-frontend/src/modules/git/__tests__/BranchSwitcher.test.tsx
+++ b/packages/core-frontend/src/modules/git/__tests__/BranchSwitcher.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type {
   BranchInfo,
-  CommitAttribution,
   WorkingTreeStatus,
 } from '@bevel-software/platform-shared';
 
@@ -30,16 +29,6 @@ import {
   type WorkspaceContextValue,
 } from '../../workspace/state/workspace.context';
 
-function makeAttr(): CommitAttribution {
-  return {
-    sha: 'abcdef1234567890',
-    authorName: 'Alice',
-    authorEmail: 'alice@example.com',
-    subject: 's',
-    committedAt: '2026-04-29T00:00:00Z',
-  };
-}
-
 function makeStatus(overrides: Partial<WorkingTreeStatus> = {}): WorkingTreeStatus {
   return {
     branch: 'alice/draft',
@@ -62,7 +51,6 @@ function makeGit(overrides: Partial<GitContextValue> = {}): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => makeAttr(),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/git/__tests__/FileHistoryPanel.test.tsx
+++ b/packages/core-frontend/src/modules/git/__tests__/FileHistoryPanel.test.tsx
@@ -2,19 +2,6 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { BranchInfo, CommitAttribution, WorkingTreeStatus } from '@bevel-software/platform-shared';
 
-// Mock the access API before importing the component tree — useFileAccess
-// fires a fetch in an effect on mount, and we don't want real network in tests.
-const accessMock = vi.hoisted(() => ({
-  result: { canWrite: true, eligible: { roles: ['Admin'], users: [] } } as {
-    canWrite: boolean;
-    eligible: { roles: string[]; users: { name: string; email: string }[] };
-  },
-}));
-vi.mock('../../access/api', () => ({
-  fetchFileAccess: vi.fn(async () => accessMock.result),
-  fetchFileAccessBatch: vi.fn(async () => ({ results: {} })),
-}));
-
 import { FileHistoryPanel } from '../components/FileHistoryPanel';
 import { GitContext, type GitContextValue } from '../state/git.context';
 import {
@@ -51,7 +38,6 @@ function makeGit(overrides: Partial<GitContextValue> = {}): GitContextValue {
     pull: async () => {},
     deleteBranch: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => makeAttr({ sha: 'revertsha1234567' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),
@@ -65,15 +51,11 @@ const workspace = {
   kbDirName: 'knowledge-base',
 } as unknown as WorkspaceContextValue;
 
-function renderWith(
-  git: GitContextValue,
-  onRevert: () => Promise<void> = async () => {},
-  filePath = 'knowledge-base/Knowledge/Foo.md',
-) {
+function renderWith(git: GitContextValue, filePath = 'knowledge-base/Knowledge/Foo.md') {
   return render(
     <WorkspaceContext.Provider value={workspace}>
       <GitContext.Provider value={git}>
-        <FileHistoryPanel filePath={filePath} onRevertCompleted={onRevert} />
+        <FileHistoryPanel filePath={filePath} />
       </GitContext.Provider>
     </WorkspaceContext.Provider>,
   );
@@ -131,7 +113,6 @@ describe('FileHistoryPanel', () => {
         fetchFileHistory: async () => history,
         fetchFileDiff,
       }),
-      async () => {},
       'knowledge-base/Knowledge/data.csv',
     );
     const row = await screen.findByText('edit');
@@ -152,7 +133,6 @@ describe('FileHistoryPanel', () => {
         fetchFileHistory: async () => history,
         fetchFileDiff: async () => '',
       }),
-      async () => {},
       'knowledge-base/Knowledge/data.csv',
     );
     fireEvent.click(await screen.findByText('edit'));
@@ -171,75 +151,4 @@ describe('FileHistoryPanel', () => {
     expect(await screen.findByText(/No file changes in this save/i)).toBeInTheDocument();
   });
 
-  it('calls revert and fires onRevertCompleted on success', async () => {
-    const onRevert = vi.fn();
-    const revert = vi.fn(async () => makeAttr({ sha: 'reverteddeadbeef' }));
-    const history = [makeAttr({ sha: 'aaaaaaa0000000000', subject: 'edit' })];
-    renderWith(
-      makeGit({
-        fetchFileHistory: async () => history,
-        revert,
-      }),
-      onRevert,
-    );
-    fireEvent.click(await screen.findByText('edit'));
-    const undoButton = await screen.findByRole('button', { name: /Undo this save/i });
-    fireEvent.click(undoButton);
-    await waitFor(() => expect(revert).toHaveBeenCalledWith('aaaaaaa0000000000'));
-    await waitFor(() => expect(onRevert).toHaveBeenCalled());
-  });
-
-  it.each(['current-company-state', 'target-company-state'] as const)(
-    'enables the undo button on protected branch %s when the user has write access',
-    async (branch) => {
-      // The historical gate was "protected branch → disabled." Revert is now
-      // gated by per-path write access (canWrite) instead — admins on a
-      // canonical branch can undo directly.
-      const history = [makeAttr({ sha: 'aaaaaaa0000000000', subject: 'edit' })];
-      renderWith(
-        makeGit({
-          status: {
-            branch,
-            hasUpstream: true,
-            unmergedFromUpstream: false,
-          },
-          fetchFileHistory: async () => history,
-        }),
-      );
-      fireEvent.click(await screen.findByText('edit'));
-      const undoButton = await screen.findByRole('button', { name: /Undo this save/i });
-      await waitFor(() => expect(undoButton).not.toBeDisabled());
-    },
-  );
-
-  it('disables the undo button when the user lacks write access on a protected branch', async () => {
-    // The revert gate is only consulted on protected branches — drafts are
-    // free-for-all (the backend's revertCommit skips the access check on
-    // non-protected branches, so the editor mirrors that by leaving the
-    // button enabled). Reproducing the disabled state requires a protected
-    // branch where the gate actually runs.
-    accessMock.result = {
-      canWrite: false,
-      eligible: { roles: ['Admin'], users: [] },
-    };
-    try {
-      const history = [makeAttr({ sha: 'aaaaaaa0000000000', subject: 'edit' })];
-      renderWith(
-        makeGit({
-          status: {
-            branch: 'current-company-state',
-            hasUpstream: true,
-            unmergedFromUpstream: false,
-          },
-          fetchFileHistory: async () => history,
-        }),
-      );
-      fireEvent.click(await screen.findByText('edit'));
-      const undoButton = await screen.findByRole('button', { name: /Undo this save/i });
-      await waitFor(() => expect(undoButton).toBeDisabled());
-      expect(undoButton.getAttribute('title')).toMatch(/don't have permission/i);
-    } finally {
-      accessMock.result = { canWrite: true, eligible: { roles: ['Admin'], users: [] } };
-    }
-  });
 });

--- a/packages/core-frontend/src/modules/git/__tests__/PullNeededBanner.test.tsx
+++ b/packages/core-frontend/src/modules/git/__tests__/PullNeededBanner.test.tsx
@@ -58,7 +58,6 @@ function makeGit(
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({ authorName: '', authorEmail: '', sha: '', subject: '', committedAt: '' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/git/__tests__/PullRequestsForMe.test.tsx
+++ b/packages/core-frontend/src/modules/git/__tests__/PullRequestsForMe.test.tsx
@@ -44,9 +44,6 @@ function makeGit(availability: GitContextValue['availability'] = 'ready'): GitCo
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({
-      sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-01-01T00:00:00Z',
-    }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/git/__tests__/useAutoPullUpdates.test.tsx
+++ b/packages/core-frontend/src/modules/git/__tests__/useAutoPullUpdates.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import type { BranchInfo, CommitAttribution, FileTreeEntry, WorkingTreeStatus } from '@bevel-software/platform-shared';
+import type { BranchInfo, FileTreeEntry, WorkingTreeStatus } from '@bevel-software/platform-shared';
 import { useAutoPullUpdates } from '../hooks/useAutoPullUpdates';
 import type { GitContextValue } from '../state/git.context';
 import type { WorkspaceContextValue } from '../../workspace/state/workspace.context';
@@ -45,13 +45,6 @@ function makeGit(
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async (): Promise<CommitAttribution> => ({
-      authorName: '',
-      authorEmail: '',
-      sha: '',
-      subject: '',
-      committedAt: '',
-    }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/git/components/FileHistoryPanel.tsx
+++ b/packages/core-frontend/src/modules/git/components/FileHistoryPanel.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { History, Undo2, AlertTriangle, Loader2 } from 'lucide-react';
+import { History, AlertTriangle, Loader2 } from 'lucide-react';
 import type { CommitAttribution, FileDiffPayload } from '@bevel-software/platform-shared';
 import { useGit } from '../state/git.context';
 import { formatRelativeTime } from '../../../lib/utils';
 import { UnifiedDiffView } from './UnifiedDiffView';
 import { MarkdownDiffViewer } from '../../review/components/MarkdownDiffViewer';
 import { friendlyGitError } from '../services/error-messages';
-import { useFileAccess } from '../../access/hooks/useFileAccess';
 import { useEventBus, canonicalizeWorkspaceId } from '../../workflow/state/event-bus.context';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 
@@ -27,16 +26,9 @@ function formatAbsoluteTime(iso: string): string {
 
 interface Props {
   filePath: string;
-  /**
-   * Called after a successful undo so the parent can reconcile (reopen the file, refresh
-   * the tree, refetch status). Returning a Promise lets the panel await reconciliation
-   * before clearing its `reverting` flag so buttons don't re-enable while reload is in
-   * progress.
-   */
-  onRevertCompleted(): Promise<void>;
 }
 
-export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
+export function FileHistoryPanel({ filePath }: Props) {
   const git = useGit();
   const [commits, setCommits] = useState<CommitAttribution[] | null>(null);
   const [selected, setSelected] = useState<CommitAttribution | null>(null);
@@ -47,34 +39,18 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
   const [mdPayload, setMdPayload] = useState<FileDiffPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [diffLoading, setDiffLoading] = useState(false);
-  const [reverting, setReverting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
   const latestDiffRequestRef = useRef<string | null>(null);
-
-  // Revert (the backend's `git revert` flow) is gated by per-path write
-  // access on protected branches only — draft branches are free-for-all,
-  // mirroring the backend's revertCommit gate. The hook returns
-  // canWrite=true on drafts without a network call, so the button stays
-  // enabled. On protected branches, default-allow on loading / API failure
-  // so a transient hiccup doesn't grey out the button for users who
-  // actually have access — the backend will refuse with AccessDenied at
-  // click time if not. (Edge case: a commit may have touched other files
-  // the caller can't write. The backend checks all of them; the user sees
-  // a click-then-error for that, which is acceptable.)
-  const access = useFileAccess(filePath, git.status?.branch ?? null);
-  const cannotRevert = access.canWrite === false;
 
   // Pull the stable callbacks out so the effect's deps don't include the whole
   // `git` object — that object is a useMemo result that changes on every status
   // poll, which would otherwise wipe local state (selection, loading) every 30s.
-  const { fetchFileHistory, fetchFileDiff, fetchFileAtChange, revert } = git;
+  const { fetchFileHistory, fetchFileDiff, fetchFileAtChange } = git;
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    setNotice(null);
     setSelected(null);
     setDiff(null);
     setMdPayload(null);
@@ -136,7 +112,7 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
   const selectCommit = useCallback(
     (commit: CommitAttribution) => {
       setSelected(commit);
-      // Clear any banner left over from a previous failed diff/revert so the UI
+      // Clear any banner left over from a previous failed diff so the UI
       // reflects only the currently-selected save's state.
       setError(null);
       setDiff(null);
@@ -181,22 +157,6 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
     [filePath, fetchFileDiff, fetchFileAtChange],
   );
 
-  const handleRevert = useCallback(async () => {
-    if (!selected || reverting) return;
-    setError(null);
-    setNotice(null);
-    setReverting(true);
-    try {
-      const attr = await revert(selected.sha);
-      setNotice(`Undone. Created a new save (${shortSha(attr.sha)}) that reverses ${shortSha(selected.sha)}.`);
-      await onRevertCompleted();
-    } catch (err) {
-      setError(friendlyGitError(err));
-    } finally {
-      setReverting(false);
-    }
-  }, [revert, selected, reverting, onRevertCompleted]);
-
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-white">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-line shrink-0">
@@ -210,12 +170,6 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
           <span className="flex-1">{error}</span>
         </div>
       )}
-      {notice && !error && (
-        <div className="px-3 py-2 bg-emerald-50 border-b border-emerald-200/60 text-xs text-emerald-700 shrink-0">
-          {notice}
-        </div>
-      )}
-
       <div className="flex-1 flex min-h-0">
         {/* Left: commit list */}
         <div className="w-72 shrink-0 overflow-y-auto border-r border-line">
@@ -271,7 +225,7 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
           )}
         </div>
 
-        {/* Right: diff + revert */}
+        {/* Right: the selected save's changes */}
         <div className="flex-1 flex flex-col min-w-0">
           {!selected && (
             <div className="flex-1 flex items-center justify-center px-6 text-xs text-ink-muted">
@@ -290,24 +244,6 @@ export function FileHistoryPanel({ filePath, onRevertCompleted }: Props) {
                 >
                   {shortSha(selected.sha)}
                 </span>
-                <button
-                  type="button"
-                  onClick={handleRevert}
-                  disabled={reverting || cannotRevert || git.availability !== 'ready'}
-                  title={
-                    cannotRevert
-                      ? "You don't have permission to edit this file"
-                      : 'Creates a new save that reverses this one'
-                  }
-                  className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium bg-sunken hover:bg-hover text-ink border border-line-strong transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {reverting ? (
-                    <Loader2 size={12} className="animate-spin" />
-                  ) : (
-                    <Undo2 size={12} />
-                  )}
-                  Undo this save
-                </button>
               </div>
               <div className="flex-1 overflow-auto">
                 {diffLoading && (

--- a/packages/core-frontend/src/modules/git/hooks/__tests__/useGitState.deleteBranch.test.tsx
+++ b/packages/core-frontend/src/modules/git/hooks/__tests__/useGitState.deleteBranch.test.tsx
@@ -23,7 +23,6 @@ vi.mock('../../services/git.api', () => ({
   deleteBranch: vi.fn(),
   pull: vi.fn(),
   fetchForkBase: vi.fn(),
-  revert: vi.fn(),
   fetchFileHistory: vi.fn(),
   fetchFileDiff: vi.fn(),
   fetchFileAtChange: vi.fn(),

--- a/packages/core-frontend/src/modules/git/hooks/useGitState.ts
+++ b/packages/core-frontend/src/modules/git/hooks/useGitState.ts
@@ -16,7 +16,6 @@ import {
   fetchForkBase,
   fetchStatus,
   pull as apiPull,
-  revert as apiRevert,
 } from '../services/git.api';
 
 const STATUS_POLL_MS = 30_000;
@@ -254,17 +253,6 @@ export function useGitState(workspaceId: string | null): GitContextValue {
     return fetchForkBase(wid, branch);
   }, []);
 
-  const revert = useCallback(
-    async (sha: string): Promise<CommitAttribution> => {
-      const wid = workspaceIdRef.current;
-      if (!wid) throw new Error('No workspace loaded');
-      const attribution = await apiRevert(wid, sha);
-      await refreshStatus();
-      return attribution;
-    },
-    [refreshStatus],
-  );
-
   const fetchFileHistoryCb = useCallback(
     async (path: string, limit?: number): Promise<CommitAttribution[]> => {
       const wid = workspaceIdRef.current;
@@ -323,7 +311,6 @@ export function useGitState(workspaceId: string | null): GitContextValue {
       deleteBranch: deleteBranchCb,
       pull,
       fetchForkBase: fetchForkBaseCb,
-      revert,
       fetchFileHistory: fetchFileHistoryCb,
       fetchFileDiff: fetchFileDiffCb,
       fetchFileAtChange: fetchFileAtChangeCb,
@@ -340,7 +327,6 @@ export function useGitState(workspaceId: string | null): GitContextValue {
       deleteBranchCb,
       pull,
       fetchForkBaseCb,
-      revert,
       fetchFileHistoryCb,
       fetchFileDiffCb,
       fetchFileAtChangeCb,

--- a/packages/core-frontend/src/modules/git/services/git.api.ts
+++ b/packages/core-frontend/src/modules/git/services/git.api.ts
@@ -110,17 +110,6 @@ export async function fetchForkBase(
   return data.base;
 }
 
-export async function revert(
-  workspaceId: string,
-  sha: string,
-): Promise<CommitAttribution> {
-  return handleApiResponse(
-    await authFetch(`/api/workspace/${workspaceId}/workflow/changes/${encodeURIComponent(sha)}/revert`, {
-      method: 'POST',
-    }),
-  );
-}
-
 export async function fetchFileHistory(
   workspaceId: string,
   path: string,

--- a/packages/core-frontend/src/modules/git/state/git.context.ts
+++ b/packages/core-frontend/src/modules/git/state/git.context.ts
@@ -53,7 +53,6 @@ export interface GitContextValue {
    * `branch` is itself protected / can't be resolved.
    */
   fetchForkBase(branch: string): Promise<string | null>;
-  revert(sha: string): Promise<CommitAttribution>;
   fetchFileHistory(path: string, limit?: number): Promise<CommitAttribution[]>;
   fetchFileDiff(path: string, sha: string): Promise<string>;
   /**

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -113,9 +113,6 @@ const git = {
   deleteBranch: async () => {},
   pull: async () => {},
   fetchForkBase: async () => null,
-  revert: async () => ({
-    sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-01-01T00:00:00Z',
-  }),
   fetchFileHistory: async () => [],
   fetchFileDiff: async () => '',
   fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/toolbar/components/__tests__/Toolbar.test.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/__tests__/Toolbar.test.tsx
@@ -70,13 +70,6 @@ function renderToolbar(overrides?: {
   const toggleExplorer = vi.fn();
   const toggleChat = vi.fn();
   const logout = vi.fn();
-  const makeCommit = () => ({
-    sha: 'abc',
-    authorName: 'n',
-    authorEmail: 'e',
-    subject: 's',
-    committedAt: '2026-04-20T00:00:00.000Z',
-  });
 
   const auth: AuthContextValue = {
     user: {
@@ -103,7 +96,6 @@ function renderToolbar(overrides?: {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => makeCommit(),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/workspace/components/FileViewer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileViewer.tsx
@@ -65,8 +65,6 @@ export function FileViewer() {
     acceptPendingContent,
     rejectPendingContent,
     addTab,
-    refreshFileTree,
-    bumpFsRevision,
     reloadTabFromDisk,
   } = useWorkspace();
   // Chat decoupling: the suggested-prompt seed is an optional registry port
@@ -304,22 +302,6 @@ export function FileViewer() {
       setIsManualDirty(false);
     }
   }, [onProtectedBranch, isReviewingPending, proposeMode]);
-
-  const handleRevertCompleted = useCallback(async () => {
-    await refreshFileTree();
-    // A revert writes to the working tree, so the active tab's cached content
-    // is stale. Bump fs revision — the hook's invalidation effect refetches
-    // the active tab, and if the file no longer exists (e.g. revert of its
-    // creation), drops it from the tab list. The state→URL effect in
-    // FileRoute then updates the URL to the new active tab.
-    bumpFsRevision();
-    await git.refreshStatus();
-    // A revert writes to the working tree, so pending-review state may no
-    // longer match what's on disk. Refresh the session before switching tabs
-    // so the review panel reflects the reconciled paths.
-    await review.refresh();
-    setActiveTab('content');
-  }, [refreshFileTree, bumpFsRevision, git, review]);
 
   const handleAccept = useCallback(async () => {
     if (isSubmitting) return;
@@ -1062,10 +1044,7 @@ export function FileViewer() {
       {activeTab === 'history' && historyAvailable ? (
         <>
           <BackToDocument onBack={() => setActiveTab('content')} label="Version history" />
-          <FileHistoryPanel
-            filePath={openFilePath}
-            onRevertCompleted={handleRevertCompleted}
-          />
+          <FileHistoryPanel filePath={openFilePath} />
         </>
       ) : activeTab === 'compare' && historyAvailable ? (
         <>

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
@@ -57,7 +57,6 @@ function makeGit(): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({ sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-04-29T00:00:00Z' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
@@ -28,7 +28,6 @@ function makeGit(overrides: Partial<GitContextValue> = {}): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({ sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-04-20T00:00:00.000Z' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileViewer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileViewer.test.tsx
@@ -161,13 +161,6 @@ function makeGit(status: WorkingTreeStatus): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({
-      sha: 'abc',
-      authorName: 'n',
-      authorEmail: 'e',
-      subject: 's',
-      committedAt: '2026-04-20T00:00:00.000Z',
-    }),
     fetchFileHistory: fetchFileHistoryMock,
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/MarkdownRenderer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/MarkdownRenderer.test.tsx
@@ -29,7 +29,6 @@ function makeGit(): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({ sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-04-20T00:00:00.000Z' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/core-frontend/src/modules/workspace/routing/__tests__/kb-routes.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/routing/__tests__/kb-routes.test.tsx
@@ -23,7 +23,6 @@ function gitOnBranch(branch: string): GitContextValue {
     deleteBranch: async () => {},
     pull: async () => {},
     fetchForkBase: async () => null,
-    revert: async () => ({ sha: 'a', authorName: 'n', authorEmail: 'e', subject: 's', committedAt: '2026-04-20T00:00:00.000Z' }),
     fetchFileHistory: async () => [],
     fetchFileDiff: async () => '',
     fetchFileAtChange: async () => ({ baseline: null, current: null }),

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -130,11 +130,6 @@ export interface IGitService {
    * count. Returns null if no protected branch can be reached.
    */
   resolveForkBase(workspaceId: string, branch: string): Promise<string | null>;
-  revertCommit(
-    workspaceId: string,
-    user: AuthUser,
-    sha: string,
-  ): Promise<CommitAttribution>;
   logForFile(
     workspaceId: string,
     relativePath: string,

--- a/packages/shared/src/workflow/interface.ts
+++ b/packages/shared/src/workflow/interface.ts
@@ -152,12 +152,6 @@ export interface IWorkflowService {
   /** Per-file history. Newest first; clamps to ≤ 100 entries. */
   listChangesForFile(workspaceId: string, path: string, limit?: number): Promise<Change[]>;
   /**
-   * Revert a single change by creating a new change that undoes it.
-   * Refused on protected branches; refused without write permission on the
-   * touched paths.
-   */
-  revertChange(workspaceId: string, user: AuthUser, sha: string): Promise<Change>;
-  /**
    * Diff of one file between two branches. Both names must resolve to a
    * known branch on this workspace (local head or remote-tracking). Returns
    * the raw unified diff body — empty when identical, includes the


### PR DESCRIPTION
Removes the Undo-this-save button from the version-history panel, per product decision, and deletes the whole revert chain behind it rather than leaving it dead: the frontend plumbing (git.api / git context / useGitState), the `POST /workflow/changes/:sha/revert` route, `WorkflowService.revertChange`, `GitService.revertCommit`, and both shared interface entries. The history panel is now purely a reading surface.

Validation: backend 1315 passed (2 env-skipped), frontend 945 passed, typecheck clean on all three packages, web build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the “Undo this save” option from file history.
  - File history is now a read-only timeline showing saved changes.
  - Removed the associated revert action and endpoint.
  - File comparison and history viewing remain available.
- **Bug Fixes**
  - Simplified history error messaging to focus on diff-loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->