### PR TITLE
Skills are edited where they are read

### DIFF
--- a/.changeset/edit-where-you-read.md
+++ b/.changeset/edit-where-you-read.md
@@ -1,0 +1,10 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Skills are edited where they are read. The skill page's Edit button now
+opens the same in-place editor the propose flow uses — over the rendered
+file, without leaving for the Knowledge app — and a writer's Save lands
+straight on the default branch. Creating a skill lands on the new skill's
+own library page with the editor open (a proposal stays put instead: the
+skill appears as an "In review" card where it was created).

--- a/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
@@ -34,7 +34,12 @@ function workspace(kbDirName: string | null) {
 
 function LocationProbe() {
   const location = useLocation();
-  return <div aria-label="href">{location.pathname}</div>;
+  return (
+    <>
+      <div aria-label="href">{location.pathname}</div>
+      <div aria-label="router-state">{JSON.stringify(location.state)}</div>
+    </>
+  );
 }
 
 function renderDialog(
@@ -177,9 +182,14 @@ describe('AddToGroupDialog: starting an empty SKILL.md', () => {
       ),
     );
     // Lands on the new skill's own LIBRARY page — never bounced to the
-    // Knowledge app — with the editor handed the open signal.
+    // Knowledge app — with the editor handed the open signal IN ROUTER
+    // STATE. Asserted by field, so a renamed or dropped flag fails here
+    // rather than silently landing on a read-only page.
     await waitFor(() =>
       expect(href()).toBe('/skills-and-tools/skills/weekly-report'),
+    );
+    expect(screen.getByLabelText('router-state')).toHaveTextContent(
+      JSON.stringify({ startEditing: true }),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
@@ -176,11 +176,10 @@ describe('AddToGroupDialog: starting an empty SKILL.md', () => {
         }),
       ),
     );
-    // Lands ON the new file, not on the folder that holds it.
+    // Lands on the new skill's own LIBRARY page — never bounced to the
+    // Knowledge app — with the editor handed the open signal.
     await waitFor(() =>
-      expect(href()).toBe(
-        '/workspace/target-company-state/knowledge-base/Groups/GTM/weekly-report/SKILL.md',
-      ),
+      expect(href()).toBe('/skills-and-tools/skills/weekly-report'),
     );
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -251,12 +250,9 @@ describe('AddToGroupDialog for a non-writer', () => {
         expect.objectContaining({ canWrite: false }),
       ),
     );
-    // Their own branch, because that is where the file actually is.
-    await waitFor(() =>
-      expect(href()).toBe(
-        '/workspace/suggestions%2Fjuan%2Fweekly-report/knowledge-base/Groups/GTM/weekly-report/SKILL.md',
-      ),
-    );
-    expect(await screen.findByText(/sent for review/)).toBeInTheDocument();
+    // A proposal has no page yet, so the dialog does NOT navigate — the group
+    // page stays put, and the new skill appears on it as an "In review" card.
+    expect(await screen.findByText(/sent to the group's owners for review/)).toBeInTheDocument();
+    expect(href()).toBe('/skills-and-tools/groups/GTM');
   });
 });

--- a/packages/core-frontend/src/modules/library/__tests__/PersonalAddDialog.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PersonalAddDialog.test.tsx
@@ -114,9 +114,8 @@ describe('PersonalAddDialog', () => {
         expect.objectContaining({ personal: true, name: 'scratch' }),
       ),
     );
-    await waitFor(() =>
-      expect(href()).toBe('/workspace/target-company-state/knowledge-base/Groups/scratch/SKILL.md'),
-    );
+    // The skill's own library page, editor invited open — not the Knowledge app.
+    await waitFor(() => expect(href()).toBe('/skills-and-tools/skills/scratch'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -23,6 +23,8 @@ const apiMock = vi.hoisted(() => ({
   cancelPullRequest: vi.fn(),
   fetchPrDetail: vi.fn(),
   approvePrFile: vi.fn(),
+  getOrCreateWorkspace: vi.fn(),
+  writeFile: vi.fn(),
 }));
 vi.mock('../services/library.api', () => ({
   defaultWorkspaceId: () => 'target-company-state',
@@ -35,6 +37,12 @@ vi.mock('../services/library.api', () => ({
   // the very lookup these tests are checking.
   suggestionBranchFor: (email: string, skill: string) =>
     `suggestions/${email.split('@')[0]}/${skill}`,
+}));
+// The workspace write path — what a writer's in-place Save goes through.
+vi.mock('../../workspace/services/workspace.api', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getOrCreateWorkspace: apiMock.getOrCreateWorkspace,
+  writeFile: apiMock.writeFile,
 }));
 // The change-request module's reads — the branch-file read feeds the editor
 // base and the per-request diffs.
@@ -481,6 +489,38 @@ describe('SkillPage', () => {
       'target-company-state',
       'Skills/newsletter/SKILL.md',
     );
+  });
+
+  it('Edit opens the editor IN PLACE, and Save writes straight to the default branch', async () => {
+    // The page must never bounce a writer to the Knowledge app: the same
+    // inline editor the propose flow uses opens over the rendered file, and
+    // submitting is a plain default-branch write — no change request.
+    accessMock.result = {
+      canWrite: true,
+      eligible: { roles: [], users: [] },
+      owners: { roles: [], users: [] },
+    };
+    apiMock.getOrCreateWorkspace.mockResolvedValue({
+      workspace: { id: 'target-company-state', kbDirName: 'knowledge-base' },
+    });
+    apiMock.writeFile.mockResolvedValue(undefined);
+    renderPage(true);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    const box = await screen.findByRole('textbox', { name: 'Edit SKILL.md' });
+    fireEvent.change(box, { target: { value: 'rewritten body' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(apiMock.writeFile).toHaveBeenCalledWith(
+        'target-company-state',
+        'knowledge-base/Skills/newsletter/SKILL.md',
+        'rewritten body',
+      ),
+    );
+    expect(await screen.findByText(/Saved — the skill now reads with your change/)).toBeInTheDocument();
+    // Direct means DIRECT: nothing rode the proposal path.
+    expect(apiMock.proposeChange).not.toHaveBeenCalled();
   });
 
   /**

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../workspace/state/workspace.context';
 import { AuthContext, type AuthContextValue } from '../../auth/state/auth.context';
 import { GitContext, type GitContextValue } from '../../git/state/git.context';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import type { PullRequestSummary, WorkflowEvent } from '@bevel-software/platform-shared';
 import { EventBusContext, type EventBusContextValue } from '../../workflow/state/event-bus.context';
 import type { ToolSecrets } from '../../secrets-vault/services/tool-secrets.api';
@@ -234,10 +235,15 @@ function renderPage(
   crs: PullRequestSummary[] = [],
   mine: number[] = [],
   bus: EventBusContextValue = makeFakeBus(),
+  routerState?: Record<string, unknown>,
 ) {
   libraryMock.value = libraryValue(owned, crs, mine);
   return render(
-    <MemoryRouter initialEntries={['/skills-and-tools/skills/newsletter']}>
+    <MemoryRouter
+      initialEntries={[
+        { pathname: '/skills-and-tools/skills/newsletter', state: routerState ?? null },
+      ]}
+    >
       <AuthContext.Provider value={auth}>
         <WorkspaceContext.Provider value={workspace}>
           <GitContext.Provider value={git}>
@@ -511,6 +517,11 @@ describe('SkillPage', () => {
     fireEvent.change(box, { target: { value: 'rewritten body' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
+    // The write targets the DEFAULT branch's workspace by name — the branch
+    // is the contract, the workspace id merely derives from it.
+    await waitFor(() =>
+      expect(apiMock.getOrCreateWorkspace).toHaveBeenCalledWith(DEFAULT_BRANCH),
+    );
     await waitFor(() =>
       expect(apiMock.writeFile).toHaveBeenCalledWith(
         'target-company-state',
@@ -521,6 +532,34 @@ describe('SkillPage', () => {
     expect(await screen.findByText(/Saved — the skill now reads with your change/)).toBeInTheDocument();
     // Direct means DIRECT: nothing rode the proposal path.
     expect(apiMock.proposeChange).not.toHaveBeenCalled();
+  });
+
+  it('arriving with startEditing in router state opens the editor without a click', async () => {
+    // The creation hand-off: NewSkillPanel navigates here with the flag, so
+    // the person who just made an empty skill lands with the cursor in it.
+    accessMock.result = {
+      canWrite: true,
+      eligible: { roles: [], users: [] },
+      owners: { roles: [], users: [] },
+    };
+    renderPage(true, [], [], makeFakeBus(), { startEditing: true });
+    expect(await screen.findByRole('textbox', { name: 'Edit SKILL.md' })).toBeInTheDocument();
+  });
+
+  it('shows NO action while the write verdict is still unresolved', async () => {
+    // A lookup that never answers models "in flight": an Edit shown on a
+    // guess could open the wrong editor mode — a writer's text must never
+    // ride the proposal path. The bar simply carries nothing until the ACL
+    // answers.
+    accessMock.fetchFileAccess.mockImplementation(() => new Promise(() => {}));
+    try {
+      renderPage(true);
+      await screen.findByRole('heading', { name: 'newsletter' });
+      expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Propose changes' })).toBeNull();
+    } finally {
+      accessMock.fetchFileAccess.mockImplementation(async () => accessMock.result);
+    }
   });
 
   /**

--- a/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
+++ b/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Surface, TextField } from '../../../shared/components';
 import { useAuth } from '../../auth/state/auth.context';
-import { kbFileUrl } from '../../workspace/routing/kb-routes';
+import { pathForSkill } from '../routes/library-paths';
 import { createEmptySkill } from '../services/library.api';
+import { useLibraryReload } from '../state/library-data';
 import { useLibraryToast } from '../state/toast.context';
 
 /**
@@ -49,6 +50,7 @@ export function NewSkillPanel({
   onCreated,
 }: NewSkillPanelProps) {
   const { user } = useAuth();
+  const reloadLibrary = useLibraryReload();
   const navigate = useNavigate();
   const toast = useLibraryToast();
   const [name, setName] = useState('');
@@ -87,16 +89,21 @@ export function NewSkillPanel({
         userEmail: user.email,
         userName: user.name,
       });
-      // Say which of the two things happened rather than let the person infer
-      // it from the branch in the URL bar.
-      toast(
-        created.direct
-          ? `Created ${trimmed} — opening it.`
-          : `Created ${trimmed} — sent for review, and opened on your branch.`,
-        'ok',
-      );
+      // The library is where the result lives, whichever way it went — nobody
+      // is bounced to the Knowledge app to meet the thing they just made.
+      reloadLibrary();
       onCreated();
-      navigate(kbFileUrl(created.branch, created.workspacePath));
+      if (created.direct) {
+        // Straight into the new skill's page, editor open: an empty SKILL.md
+        // is an invitation to write, not a page to admire.
+        toast(`Created ${trimmed} — opening it.`, 'ok');
+        navigate(pathForSkill(trimmed), { state: { startEditing: true } });
+      } else {
+        // A proposal has no page yet — the skill exists only on the author's
+        // branch. It appears right here as an "In review" card (the pending
+        // shelf), which is also where its review happens.
+        toast(`Created ${trimmed} — sent to the group's owners for review.`, 'ok');
+      }
     } catch (err) {
       // The workspace API forwards the backend's own refusal (e.g. "You don't
       // have permission to write to …"), which is worth more than a generic

--- a/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
+++ b/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
@@ -4,7 +4,7 @@ import { Button, Surface, TextField } from '../../../shared/components';
 import { useAuth } from '../../auth/state/auth.context';
 import { pathForSkill } from '../routes/library-paths';
 import { createEmptySkill } from '../services/library.api';
-import { useLibraryReload } from '../state/library-data';
+import { useLibraryReload } from '../state/library-context';
 import { useLibraryToast } from '../state/toast.context';
 
 /**

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillFileEditor.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillFileEditor.tsx
@@ -3,12 +3,23 @@ import { Banner, Button, Surface } from '../../../../shared/components';
 
 interface SkillFileEditorProps {
   file: string;
-  /** The text as it stands now — what the proposal will be diffed against. */
+  /** The text as it stands now — what the submitted text will be diffed against. */
   base: string;
-  /** Who has to say yes, for the line under the editor. */
+  /**
+   * What submitting DOES — the same editor serves both verdicts of the
+   * per-file ACL:
+   *   - `propose`: the text lands on the caller's suggestion branch as a
+   *     change request; nothing moves until the owner approves.
+   *   - `edit`: the text saves straight to the default branch — the caller
+   *     may write the file, so there is nobody to wait on.
+   * The mode only changes the words (button, reassurance line): what gets
+   * submitted and how the diff is computed are identical.
+   */
+  mode: 'edit' | 'propose';
+  /** Who has to say yes — read only in `propose` mode, for the line under the editor. */
   owner: string;
   onCancel(): void;
-  /** Resolves when the proposal has landed on the author's branch. */
+  /** Resolves when the text has landed (on the branch, or on the default branch). */
   onSubmit(next: string): Promise<void>;
 }
 
@@ -28,6 +39,7 @@ interface SkillFileEditorProps {
 export function SkillFileEditor({
   file,
   base,
+  mode,
   owner,
   onCancel,
   onSubmit,
@@ -69,7 +81,13 @@ export function SkillFileEditor({
     try {
       await onSubmit(toFileEndings(text));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Couldn't send your change.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : mode === 'edit'
+            ? "Couldn't save your change."
+            : "Couldn't send your change.",
+      );
       setBusy(false);
     }
   }
@@ -84,7 +102,7 @@ export function SkillFileEditor({
           what a textarea falls back to, so a class that fails to apply leaves a
           two-line box to edit a whole file in. */}
       <textarea
-        aria-label={`Propose changes to ${file}`}
+        aria-label={mode === 'edit' ? `Edit ${file}` : `Propose changes to ${file}`}
         spellCheck={false}
         rows={22}
         className="block max-h-[60vh] min-h-64 w-full resize-y bg-sunken px-6 py-4 font-mono text-detail leading-relaxed text-ink outline-none"
@@ -100,13 +118,15 @@ export function SkillFileEditor({
 
       <div className="flex flex-wrap items-center gap-2 border-t border-line px-3 py-2.5">
         <span className="mr-auto text-meta text-ink-faint">
-          Nothing changes until {owner} approves it.
+          {mode === 'edit'
+            ? 'Saves for everyone — agents pick it up the next time they connect.'
+            : `Nothing changes until ${owner} approves it.`}
         </span>
         <Button variant="quiet" size="sm" onClick={onCancel} disabled={busy}>
           Cancel
         </Button>
         <Button variant="primary" size="sm" onClick={() => void submit()} disabled={busy}>
-          {busy ? 'Sending…' : 'Propose changes'}
+          {mode === 'edit' ? (busy ? 'Saving…' : 'Save') : busy ? 'Sending…' : 'Propose changes'}
         </Button>
       </div>
     </Surface>

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   DEFAULT_BRANCH,
   groupOfPath,
@@ -13,6 +13,7 @@ import { kbFileUrl, resolveRelativePath, useNodeIdNav } from '../../../workspace
 import { cancelPullRequest } from '../../../pr/services/pr-cancel.api';
 import { useFileAccess } from '../../../access/hooks/useFileAccess';
 import { proposeChange, suggestionBranchFor } from '../../services/library.api';
+import { getOrCreateWorkspace, writeFile } from '../../../workspace/services/workspace.api';
 import { useSkillDetail } from '../../hooks/useSkillDetail';
 import { useApplyChangeRequest } from '../../../change-requests/hooks/useApplyChangeRequest';
 import { useCrFileDiffs } from '../../../change-requests/hooks/useCrFileDiffs';
@@ -176,7 +177,15 @@ export function SkillPage() {
 
   /** Bumped after every write so the branch reads re-run against fresh content. */
   const [revision, setRevision] = useState(0);
-  const [editing, setEditing] = useState(false);
+  /**
+   * Creation hands off straight into the editor: `NewSkillPanel` navigates
+   * here with `startEditing` in the router state, so the person who just made
+   * an empty skill lands with the cursor in it instead of on an empty page.
+   */
+  const location = useLocation();
+  const [editing, setEditing] = useState(
+    Boolean((location.state as { startEditing?: boolean } | null)?.startEditing),
+  );
   const [busyCr, setBusyCr] = useState<number | null>(null);
   /**
    * Change requests a merge attempt has REFUSED as unmergeable. Git is the only
@@ -257,12 +266,15 @@ export function SkillPage() {
    * the page failed to recognise would open a second one against the same
    * branch.
    */
+  const canEditDirectly = fileAccess.canWrite === true;
   const ownBranchBase = useFileOnBranch(
-    editing && ownCr ? ownCr.branch : null,
+    editing && !canEditDirectly && ownCr ? ownCr.branch : null,
     skillPath ? fileRepoPath : null,
     revision,
   );
-  const editorBase = ownCr ? ownBranchBase : rawOnMain;
+  // A direct edit always bases on the default branch — the file as everyone
+  // reads it. Only the propose flow stacks on the caller's own branch copy.
+  const editorBase = !canEditDirectly && ownCr ? ownBranchBase : rawOnMain;
 
   const openInEditor = useCallback(
     (wsRelative: string) => navigate(kbFileUrl(DEFAULT_BRANCH, wsRelative)),
@@ -283,6 +295,21 @@ export function SkillPage() {
         : `${window.location.origin}${window.location.pathname}#${slug}`,
     [kbDirName, skillPath, active],
   );
+
+  /**
+   * The writer's submit: straight onto the default branch. One `writeFile` is
+   * a complete save — the route acquires the file lock (where the ACL gate
+   * runs), writes, and releases into the commit queue — so this is the same
+   * save the Knowledge editor performs, minus the app switch.
+   */
+  async function saveDirect(content: string) {
+    const { workspace } = await getOrCreateWorkspace(DEFAULT_BRANCH);
+    await writeFile(workspace.id, `${workspace.kbDirName}/${fileRepoPath}`, content);
+    setEditing(false);
+    setRevision((r) => r + 1);
+    toast('Saved — the skill now reads with your change.');
+    data.reload();
+  }
 
   async function submitProposal(content: string) {
     if (!user) throw new Error('Sign in to propose a change.');
@@ -428,9 +455,10 @@ export function SkillPage() {
         <SkillFileEditor
           file={active}
           base={editorBase}
+          mode={canEditDirectly ? 'edit' : 'propose'}
           owner={ownerName}
           onCancel={() => setEditing(false)}
-          onSubmit={submitProposal}
+          onSubmit={canEditDirectly ? saveDirect : submitProposal}
         />
       ) : (
         <SkillFilePane
@@ -449,10 +477,14 @@ export function SkillPage() {
            * where, for anyone without a write grant, it ended in AccessDenied
            * after they had navigated away and typed the change. The trap was
            * never the button; it was offering it to people it would refuse.
-           * So now the file bar asks the per-file access resolver and shows
-           * exactly one of the two: `Edit` (to the Knowledge editor, which
-           * this pane now visually matches) when the caller may write the
-           * file, `Propose changes` when they may not.
+           * So the file bar asks the per-file access resolver and shows
+           * exactly one of the two — and BOTH now open the same editor in
+           * place, right over the rendered file. What differs is what
+           * submitting does: a writer's Save lands on the default branch, a
+           * proposal lands on the author's suggestion branch as a change
+           * request. Edit used to leave for the Knowledge app; being bounced
+           * to a different surface to change the file you are reading was
+           * the last piece of that old trap.
            *
            * One open proposal per person per SKILL, still — but proposing
            * again while yours is open is not refused anymore: it opens the
@@ -462,12 +494,12 @@ export function SkillPage() {
            */
           actions={
             fileAccess.canWrite !== false
-              ? kbDirName && (
+              ? rawOnMain !== null && (
                   <Button
                     variant="outline"
                     size="tiny"
-                    onClick={() => openInEditor(`${kbDirName}/${fileRepoPath}`)}
-                    title="Open this file in the Knowledge editor"
+                    onClick={() => setEditing(true)}
+                    title="Edit this file in place"
                   >
                     Edit
                   </Button>

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -451,7 +451,7 @@ export function SkillPage() {
         id={skillPanelId(tabsId)}
         aria-labelledby={skillTabId(tabsId, active)}
       >
-      {editing && editorBase !== null ? (
+      {editing && editorBase !== null && fileAccess.canWrite !== null ? (
         <SkillFileEditor
           file={active}
           base={editorBase}
@@ -493,7 +493,11 @@ export function SkillPage() {
            * fork, never a silent restart from the published text.
            */
           actions={
-            fileAccess.canWrite !== false
+            // Only a RESOLVED verdict earns a button: `null` (lookup in
+            // flight) briefly shows no action rather than an Edit that might
+            // open the wrong mode — a writer's text must never ride the
+            // proposal path just because they clicked before the ACL answered.
+            fileAccess.canWrite === true
               ? rawOnMain !== null && (
                   <Button
                     variant="outline"
@@ -504,7 +508,7 @@ export function SkillPage() {
                     Edit
                   </Button>
                 )
-              : rawOnMain !== null && (
+              : fileAccess.canWrite === false && rawOnMain !== null && (
                   <Button
                     variant="outline"
                     size="tiny"

--- a/packages/core-frontend/src/modules/library/state/library-context.ts
+++ b/packages/core-frontend/src/modules/library/state/library-context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react';
+import type { LibraryContextValue } from './library-data';
+
+/**
+ * The library's context object and its provider-optional hooks, in a file of
+ * their own: `library-data.tsx` renders the provider COMPONENT, and fast
+ * refresh only preserves state for files that export components alone — every
+ * hook this module grows would otherwise cost the provider its hot reload.
+ * (`useLibrary`, which predates the split, still lives beside the provider.)
+ */
+export const LibraryContext = createContext<LibraryContextValue | null>(null);
+
+/**
+ * The catalog's reload signal, tolerating an absent provider. For leaf
+ * components (dialog panels) that only need to ANNOUNCE "the catalog
+ * changed" — outside a provider (component tests, future embeddings) the
+ * announcement has no audience, and that is fine.
+ */
+export function useLibraryReload(): () => void {
+  const value = useContext(LibraryContext);
+  return value?.reload ?? (() => {});
+}

--- a/packages/core-frontend/src/modules/library/state/library-data.tsx
+++ b/packages/core-frontend/src/modules/library/state/library-data.tsx
@@ -1,12 +1,5 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState, type ReactNode,  } from 'react';
+import { LibraryContext } from './library-context';
 import { groupOfPath, isPersonalGroupFolder } from '@bevel-software/platform-shared';
 
 /**
@@ -90,7 +83,6 @@ export interface LibraryContextValue extends LibraryData {
   reloadGroups(): void;
 }
 
-const LibraryContext = createContext<LibraryContextValue | null>(null);
 
 export function LibraryProvider({ children }: { children: ReactNode }) {
   const data = useLibraryData();
@@ -212,17 +204,6 @@ export function useLibrary(): LibraryContextValue {
   const value = useContext(LibraryContext);
   if (!value) throw new Error('useLibrary must be used inside a LibraryProvider');
   return value;
-}
-
-/**
- * The catalog's reload signal, tolerating an absent provider. For leaf
- * components (dialog panels) that only need to ANNOUNCE "the catalog
- * changed" — outside a provider (component tests, future embeddings) the
- * announcement has no audience, and that is fine.
- */
-export function useLibraryReload(): () => void {
-  const value = useContext(LibraryContext);
-  return value?.reload ?? (() => {});
 }
 
 /**

--- a/packages/core-frontend/src/modules/library/state/library-data.tsx
+++ b/packages/core-frontend/src/modules/library/state/library-data.tsx
@@ -215,6 +215,17 @@ export function useLibrary(): LibraryContextValue {
 }
 
 /**
+ * The catalog's reload signal, tolerating an absent provider. For leaf
+ * components (dialog panels) that only need to ANNOUNCE "the catalog
+ * changed" — outside a provider (component tests, future embeddings) the
+ * announcement has no audience, and that is fine.
+ */
+export function useLibraryReload(): () => void {
+  const value = useContext(LibraryContext);
+  return value?.reload ?? (() => {});
+}
+
+/**
  * How many of a group's integrations need setup — the amber count on the
  * sidebar row and the group page's banner, computed from one place so the two
  * can never disagree.


### PR DESCRIPTION
Fixes the skill view's Edit button bouncing writers into the Knowledge app. Both ACL verdicts now open the same in-place editor over the rendered file — a writer's Save lands directly on the default branch, a non-writer's submit stays the change-request propose flow. Skill creation also stops navigating to the Knowledge app: a direct creation lands on the new skill's library page with the editor already open; a proposal stays put and appears as its "In review" card.

Validation: frontend 966/966, typecheck clean, web build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-place editing for skills directly from the library.
  * Authorized editors can save changes directly to the default branch.
  * Users without direct editing access can submit changes for review.
  * Skill creation now refreshes the library and opens directly to the new skill when appropriate.
  * Added clearer editing and proposal confirmations, labels, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->