### PR TITLE
Deployment settings page: the setup screen, reachable after setup

### DIFF
--- a/.changeset/setup-gets-an-address.md
+++ b/.changeset/setup-gets-an-address.md
@@ -1,0 +1,11 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Deployment settings get a permanent address. The first-run setup form —
+knowledge-base connection, branch model, single sign-on — is now also an
+admin settings page at `/deployment`, so adding SSO (or rotating its
+client secret, or renaming a branch) after setup no longer means finding
+the right environment variable. Same form, same env-lock rule, same
+connection test; the backend accepted these writes all along — only the
+door was missing.

--- a/.changeset/setup-gets-an-address.md
+++ b/.changeset/setup-gets-an-address.md
@@ -2,10 +2,11 @@
 '@bevel-software/platform-core-frontend': patch
 ---
 
-Deployment settings get a permanent address. The first-run setup form —
-knowledge-base connection, branch model, single sign-on — is now also an
-admin settings page at `/deployment`, so adding SSO (or rotating its
-client secret, or renaming a branch) after setup no longer means finding
-the right environment variable. Same form, same env-lock rule, same
-connection test; the backend accepted these writes all along — only the
-door was missing.
+Deployment settings get a permanent address. The first-run setup form
+(repository connection, branch model, single sign-on) is now also an
+admin settings page at `/deployment`, so SAVED settings can be added or
+changed after setup — adding SSO later, rotating its client secret,
+renaming a branch. Values managed by the environment stay read-only
+there, named and locked, and still change where they are set. Same form,
+same rules, same connection test; the backend accepted these writes all
+along — only the door was missing.

--- a/packages/core-frontend/src/core/CoreAppShell.tsx
+++ b/packages/core-frontend/src/core/CoreAppShell.tsx
@@ -40,6 +40,7 @@ import { ReviewProvider } from '../modules/review/state/ReviewProvider';
 import { ReviewPanelSurface } from '../modules/review/components/ReviewPanelSurface';
 import { ConnectToolsPage } from '../modules/secrets-vault/components/ConnectToolsPage';
 import { SettingsLayout } from '../modules/settings/components/SettingsLayout';
+import { DeploymentPage } from '../modules/settings/components/DeploymentPage';
 import { SecretsPage } from '../modules/secrets-vault/components/SecretsPage';
 import { AccountPage } from '../modules/auth/components/AccountPage';
 import { ExternalAgentAccessPage } from '../modules/toolbar/components/ExternalAgentAccessPage';
@@ -362,6 +363,7 @@ export function ShellRoutes({ apps }: { apps: AppDef[] }) {
         <Route path="/account" element={<AccountPage />} />
         <Route path="/external-agent-access" element={<ExternalAgentAccessPage />} />
         <Route path="/roles-and-members" element={<AdminRolesPage />} />
+        <Route path="/deployment" element={<DeploymentPage />} />
         <Route path="/user-accounts" element={<UserAccountsPage />} />
         <Route path="/tools" element={<ToolsExplorerPage />} />
       </Route>

--- a/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
+++ b/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
@@ -33,6 +33,10 @@ export function DeploymentPage() {
   const [loaded, setLoaded] = useState(false);
 
   const refresh = useCallback(() => {
+    // Non-admins never fetch: the endpoint would answer them safely (status
+    // without settings), but this page has already told them it is not
+    // theirs — a request whose answer nothing renders is noise.
+    if (!isAdmin) return;
     fetchSetupStatus()
       .then((s) => {
         setStatus(s);
@@ -40,7 +44,7 @@ export function DeploymentPage() {
       })
       .catch(() => setFailed(true))
       .finally(() => setLoaded(true));
-  }, []);
+  }, [isAdmin]);
 
   useEffect(refresh, [refresh]);
 

--- a/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
+++ b/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PageShell } from '../../../shared/components/PageShell';
+import { Banner, Button } from '../../../shared/components';
+import { useAdmin } from '../../admin/state/admin.context';
+import { fetchSetupStatus, type SetupStatus } from '../../setup/services/setup.api';
+import { SetupScreen } from '../../setup/components/SetupScreen';
+
+/**
+ * Deployment settings, routed at `/deployment` — the first-run setup screen
+ * given a permanent address.
+ *
+ * Setup used to be reachable exactly once: the gate showed it while the
+ * deployment was unconfigured and never again, so adding single sign-on (or
+ * rotating its client secret, or renaming a branch) later meant knowing which
+ * environment variable to set and restarting — the very thing the setup
+ * screen exists to spare people. The FORM was never the limitation — the
+ * backend accepts these writes from any admin at any time — only the door
+ * was. This page is that door.
+ *
+ * It reuses `SetupScreen` whole rather than extracting the SSO half: the
+ * knowledge-base connection and branch model are exactly as legitimate to
+ * revisit, and one form means the env-lock rule, the connection test and the
+ * restart notices cannot drift between first run and later.
+ *
+ * Admin-gated as presentation only — the backend enforces the same gate on
+ * every settings endpoint, and non-admin status responses carry no settings
+ * at all.
+ */
+export function DeploymentPage() {
+  const { isAdmin } = useAdmin();
+  const [status, setStatus] = useState<SetupStatus | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const refresh = useCallback(() => {
+    fetchSetupStatus()
+      .then((s) => {
+        setStatus(s);
+        setFailed(false);
+      })
+      .catch(() => setFailed(true))
+      .finally(() => setLoaded(true));
+  }, []);
+
+  useEffect(refresh, [refresh]);
+
+  if (!isAdmin) {
+    return (
+      <PageShell title="Deployment" width="4xl">
+        <div className="text-sm text-ink-muted">
+          Admins only. Ask an admin if the sign-in method or the knowledge-base connection needs
+          changing.
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell title="Deployment" width="4xl">
+      <p className="max-w-[62ch] text-detail text-ink-muted">
+        The knowledge-base connection, the branch model, and single sign-on — the same form as
+        first-run setup, editable whenever something changes. Values set in the environment stay
+        locked here; change them where they are set.
+      </p>
+
+      {!loaded && <div className="mt-6 text-sm text-ink-muted">Loading…</div>}
+
+      {loaded && (failed || !status?.settings) && (
+        <Banner tone="danger" role="alert" className="mt-6">
+          Couldn&apos;t load the deployment settings.
+          <Button variant="outline" size="sm" className="ml-3" onClick={refresh}>
+            Try again
+          </Button>
+        </Banner>
+      )}
+
+      {loaded && status?.settings && (
+        <div className="mt-6">
+          <SetupScreen settings={status.settings} onSaved={refresh} variant="settings" />
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
+++ b/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
@@ -69,9 +69,17 @@ export function DeploymentPage() {
 
       {!loaded && <div className="mt-6 text-sm text-ink-muted">Loading…</div>}
 
+      {/* A failed fetch never clears `status`, so a refresh that breaks
+          AFTER a save leaves the form (and any restart notice inside it)
+          mounted below this banner — the failure costs a retry button, never
+          the confirmation of what was just saved. The copy tells the two
+          apart: nothing on screen yet is a load problem, a form still on
+          screen is a refresh problem. */}
       {loaded && (failed || !status?.settings) && (
         <Banner tone="danger" role="alert" className="mt-6">
-          Couldn&apos;t load the deployment settings.
+          {status?.settings
+            ? "Couldn't refresh the deployment settings."
+            : "Couldn't load the deployment settings."}
           <Button variant="outline" size="sm" className="ml-3" onClick={refresh}>
             Try again
           </Button>

--- a/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
+++ b/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
@@ -48,7 +48,7 @@ export function DeploymentPage() {
     return (
       <PageShell title="Deployment" width="4xl">
         <div className="text-sm text-ink-muted">
-          Admins only. Ask an admin if the sign-in method or the knowledge-base connection needs
+          Admins only. Ask an admin if the sign-in method or the repository connection needs
           changing.
         </div>
       </PageShell>
@@ -58,9 +58,9 @@ export function DeploymentPage() {
   return (
     <PageShell title="Deployment" width="4xl">
       <p className="max-w-[62ch] text-detail text-ink-muted">
-        The knowledge-base connection, the branch model, and single sign-on — the same form as
-        first-run setup, editable whenever something changes. Values set in the environment stay
-        locked here; change them where they are set.
+        Where your knowledge, skills and tools live, the branch model, and single sign-on: the
+        same form as first-run setup, editable whenever something changes. Values set in the
+        environment stay locked here; change them where they are set.
       </p>
 
       {!loaded && <div className="mt-6 text-sm text-ink-muted">Loading…</div>}

--- a/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
+++ b/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
@@ -10,10 +10,11 @@ import { AdminContext, type AdminContextValue } from '../../../admin/state/admin
  * The form's own behaviour is covered by the setup suite — same component.
  */
 
-const apiMock = vi.hoisted(() => ({ fetchSetupStatus: vi.fn() }));
+const apiMock = vi.hoisted(() => ({ fetchSetupStatus: vi.fn(), saveSettings: vi.fn() }));
 vi.mock('../../../setup/services/setup.api', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   fetchSetupStatus: apiMock.fetchSetupStatus,
+  saveSettings: apiMock.saveSettings,
 }));
 
 import { DeploymentPage } from '../DeploymentPage';
@@ -64,6 +65,30 @@ describe('DeploymentPage', () => {
     // Never fetched, not merely never rendered: the page already told them
     // this is not theirs, so a request nothing renders is pure noise.
     expect(apiMock.fetchSetupStatus).not.toHaveBeenCalled();
+  });
+
+  it('a failed refresh after an awaiting-restart save keeps the form AND the notice', async () => {
+    // The save landed; only the follow-up status fetch died. The page must
+    // not trade the confirmation of what was saved for a load error — the
+    // form stays mounted with its restart notice, and the banner above it
+    // says "refresh", not "load", with a retry.
+    apiMock.saveSettings.mockResolvedValue({
+      restartRequired: true,
+      complete: false,
+      awaitingRestart: true,
+      settings: COMPLETE_STATUS.settings,
+    });
+    renderPage(admin(true));
+    await screen.findByText('Provider address');
+    apiMock.fetchSetupStatus.mockRejectedValueOnce(new Error('down'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
+
+    expect(await screen.findByText(/needs a restart/)).toBeInTheDocument();
+    expect(await screen.findByText(/Couldn't refresh the deployment settings/)).toBeInTheDocument();
+    // Still the form, not a blank page: the last good settings render on.
+    expect(screen.getByText('Provider address')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
   });
 
   it('offers a retry when the status cannot be loaded, and the retry fetches again', async () => {

--- a/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
+++ b/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdminContext, type AdminContextValue } from '../../../admin/state/admin.context';
+
+/**
+ * The deployment settings page — first-run setup with a permanent address.
+ * What is worth testing is the door itself: an admin gets the real form (with
+ * the same fields the setup gate shows), a non-admin gets told this is not
+ * theirs, and a failed status load offers a retry instead of a blank page.
+ * The form's own behaviour is covered by the setup suite — same component.
+ */
+
+const apiMock = vi.hoisted(() => ({ fetchSetupStatus: vi.fn() }));
+vi.mock('../../../setup/services/setup.api', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  fetchSetupStatus: apiMock.fetchSetupStatus,
+}));
+
+import { DeploymentPage } from '../DeploymentPage';
+
+function admin(isAdmin: boolean): AdminContextValue {
+  return { isAdmin } as AdminContextValue;
+}
+
+/** A settled status: setup is COMPLETE — this page exists for exactly then. */
+const COMPLETE_STATUS = {
+  complete: true,
+  awaitingRestart: false,
+  isAdmin: true,
+  settings: [
+    { key: 'kbRepoUrl', section: 'knowledge-base', source: 'saved', value: 'https://git.example.com/kb.git' },
+    { key: 'oidcIssuerUrl', section: 'sign-in', source: 'saved', value: '' },
+    { key: 'oidcClientId', section: 'sign-in', source: 'saved', value: '' },
+    { key: 'oidcClientSecret', section: 'sign-in', source: 'saved', value: '' },
+  ],
+};
+
+function renderPage(value: AdminContextValue) {
+  return render(
+    <AdminContext.Provider value={value}>
+      <DeploymentPage />
+    </AdminContext.Provider>,
+  );
+}
+
+describe('DeploymentPage', () => {
+  beforeEach(() => {
+    apiMock.fetchSetupStatus.mockReset();
+    apiMock.fetchSetupStatus.mockResolvedValue(COMPLETE_STATUS);
+  });
+
+  it('shows the setup form to an admin — AFTER setup is complete', async () => {
+    renderPage(admin(true));
+    // The single-sign-on fields are reachable again: the whole point of the page.
+    expect(await screen.findByText('Provider address')).toBeInTheDocument();
+    // And the same redirect-URI helper the setup screen shows.
+    expect(screen.getByText(/api\/auth\/oidc\/callback/)).toBeInTheDocument();
+  });
+
+  it('tells a non-admin this is not theirs, and never fetches the settings', () => {
+    renderPage(admin(false));
+    expect(screen.getByText(/Admins only/)).toBeInTheDocument();
+    expect(screen.queryByText('Provider address')).toBeNull();
+  });
+
+  it('offers a retry when the status cannot be loaded', async () => {
+    apiMock.fetchSetupStatus.mockRejectedValueOnce(new Error('down'));
+    renderPage(admin(true));
+    expect(await screen.findByText(/Couldn't load the deployment settings/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+});

--- a/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
+++ b/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AdminContext, type AdminContextValue } from '../../../admin/state/admin.context';
 
 /**
@@ -61,12 +61,20 @@ describe('DeploymentPage', () => {
     renderPage(admin(false));
     expect(screen.getByText(/Admins only/)).toBeInTheDocument();
     expect(screen.queryByText('Provider address')).toBeNull();
+    // Never fetched, not merely never rendered: the page already told them
+    // this is not theirs, so a request nothing renders is pure noise.
+    expect(apiMock.fetchSetupStatus).not.toHaveBeenCalled();
   });
 
-  it('offers a retry when the status cannot be loaded', async () => {
+  it('offers a retry when the status cannot be loaded, and the retry fetches again', async () => {
     apiMock.fetchSetupStatus.mockRejectedValueOnce(new Error('down'));
     renderPage(admin(true));
     expect(await screen.findByText(/Couldn't load the deployment settings/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+    expect(apiMock.fetchSetupStatus).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    await waitFor(() => expect(apiMock.fetchSetupStatus).toHaveBeenCalledTimes(2));
+    // The second answer (the beforeEach default) is the real settings.
+    expect(await screen.findByText('Provider address')).toBeInTheDocument();
   });
 });

--- a/packages/core-frontend/src/modules/settings/settings-nav-items.tsx
+++ b/packages/core-frontend/src/modules/settings/settings-nav-items.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Boxes, CircleUserRound, KeyRound, Lock, Users } from 'lucide-react';
+import { Boxes, CircleUserRound, KeyRound, Lock, SlidersHorizontal, Users } from 'lucide-react';
 import { useAppRegistry, type AdminMenuItem } from '../../core/registry';
 
 /**
@@ -62,6 +62,14 @@ export const CORE_MENU_ITEMS: AdminMenuItem[] = [
     icon: <CircleUserRound size={15} />,
     label: 'Account',
     path: '/account',
+  },
+  {
+    id: 'deployment',
+    section: 'admin',
+    order: 5,
+    icon: <SlidersHorizontal size={15} />,
+    label: 'Deployment',
+    path: '/deployment',
   },
   {
     id: 'roles-members',

--- a/packages/core-frontend/src/modules/setup/__tests__/setup.test.tsx
+++ b/packages/core-frontend/src/modules/setup/__tests__/setup.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../services/setup.api', async () => {
 });
 
 import { SetupGate } from '../components/SetupGate';
+import { SetupScreen } from '../components/SetupScreen';
 import { SettingsProblems, type SettingStatus } from '../services/setup.api';
 
 const KB = 'knowledge-base' as const;
@@ -437,6 +438,44 @@ describe('SetupScreen', () => {
     expect(api.saveSettings).toHaveBeenCalledWith(
       expect.objectContaining({ defaultBranch: 'main', protectedBranches: 'main' }),
     );
+  });
+
+  it('settings mode: a COMPLETE save refreshes in place, never reloads the document', async () => {
+    // In setup mode a complete save reloads the page (the gate's browser
+    // holds no branch model yet). On the Deployment page the app around the
+    // form is already running — a save must refetch status, not yank the
+    // document out from under the admin. `onSaved` being called at all is
+    // the distinguishing observable: the setup path reloads INSTEAD of
+    // calling it.
+    const onSaved = vi.fn();
+    render(<SetupScreen settings={SETTINGS} onSaved={onSaved} variant="settings" />);
+    api.saveSettings.mockResolvedValue({
+      restartRequired: false,
+      complete: true,
+      settings: SETTINGS,
+    });
+
+    await userEvent.type(screen.getByLabelText('Repository address'), 'https://x/y.git');
+    await userEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+  });
+
+  it('settings mode: an awaiting-restart save refreshes AND keeps the restart notice', async () => {
+    const onSaved = vi.fn();
+    render(<SetupScreen settings={SETTINGS} onSaved={onSaved} variant="settings" />);
+    api.saveSettings.mockResolvedValue({
+      restartRequired: true,
+      complete: false,
+      awaitingRestart: true,
+      settings: SETTINGS,
+    });
+
+    await userEvent.type(screen.getByLabelText('Repository address'), 'https://x/y.git');
+    await userEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(await screen.findByText(/needs a restart/)).toBeInTheDocument();
   });
 
   it('derives the standard branch name on save when the repository is empty', async () => {

--- a/packages/core-frontend/src/modules/setup/__tests__/setup.test.tsx
+++ b/packages/core-frontend/src/modules/setup/__tests__/setup.test.tsx
@@ -171,7 +171,7 @@ describe('SetupScreen', () => {
     ]);
     const token = screen.getByLabelText('Access token');
     expect(token).toHaveValue('');
-    expect(token).toHaveAttribute('placeholder', 'Saved — type to replace');
+    expect(token).toHaveAttribute('placeholder', 'Saved. Type to replace');
   });
 
   /**
@@ -249,7 +249,7 @@ describe('SetupScreen', () => {
       ),
     );
     expect(screen.queryByRole('heading', { name: 'Single sign-on' })).toBeNull();
-    expect(screen.getByRole('heading', { name: 'Knowledge base' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Knowledge, skills & tools' })).toBeInTheDocument();
   });
 
   /**
@@ -405,7 +405,7 @@ describe('SetupScreen', () => {
    */
   it('keeps the connection test inside the knowledge-base card', async () => {
     await renderScreen();
-    const card = screen.getByRole('heading', { name: 'Knowledge base' }).closest('section');
+    const card = screen.getByRole('heading', { name: 'Knowledge, skills & tools' }).closest('section');
     expect(card).not.toBeNull();
     expect(card).toContainElement(screen.getByRole('button', { name: 'Test connection' }));
     // Above Advanced, because testing is what fills Advanced in.
@@ -439,22 +439,28 @@ describe('SetupScreen', () => {
     );
   });
 
-  it('still saves when the repository cannot name a branch either', async () => {
+  it('derives the standard branch name on save when the repository is empty', async () => {
     await renderScreen();
     api.testConnection.mockResolvedValue({ ok: true, empty: true, branches: [], defaultBranch: null });
     api.saveSettings.mockResolvedValue({
       restartRequired: false,
-      complete: false,
+      complete: true,
       settings: SETTINGS,
     });
-    api.fetchSetupStatus.mockResolvedValue({ complete: false, isAdmin: true, settings: SETTINGS });
+    api.fetchSetupStatus.mockResolvedValue({ complete: true, isAdmin: true, settings: SETTINGS });
 
     await userEvent.type(screen.getByLabelText('Repository address'), 'https://x/y.git');
     await userEvent.click(screen.getByRole('button', { name: 'Save and continue' }));
 
-    // Saved what it had, then said what remained — not a refusal up front.
-    await waitFor(() => expect(api.saveSettings).toHaveBeenCalled());
-    expect(await screen.findByRole('status')).toHaveTextContent('Main branch');
+    // An EMPTY repository has no branch to report, but it will be seeded with
+    // whatever is configured — so the conventional name is derived and the
+    // save FINISHES setup, instead of succeeding into a "still needs Main
+    // branch" notice about a value the app could have supplied itself.
+    await waitFor(() =>
+      expect(api.saveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ defaultBranch: 'main', protectedBranches: 'main' }),
+      ),
+    );
   });
 
   /**

--- a/packages/core-frontend/src/modules/setup/components/SetupGate.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupGate.tsx
@@ -55,8 +55,8 @@ export function SetupGate({ children }: { children: ReactNode }) {
         <div className="max-w-[46ch] text-center">
           <h1 className="text-title font-semibold text-ink">Still being set up</h1>
           <p className="mt-2 text-body text-ink-muted">
-            An admin is connecting this deployment to its knowledge base. It will be ready shortly —
-            try again in a few minutes.
+            An admin is connecting this deployment to the place its knowledge, skills and tools
+            will live. It will be ready shortly; try again in a few minutes.
           </p>
         </div>
       </div>

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -112,6 +112,15 @@ interface Props {
   settings: SettingStatus[];
   /** Re-read the status after a save, so the gate can let the app through. */
   onSaved(): void;
+  /**
+   * Where the screen is standing. `setup` (the default) is the first-run
+   * gate: full-page chrome, its own heading. `settings` is the SAME form
+   * embedded in the admin Deployment page — the host owns the chrome and the
+   * words around it, so the wrapper and heading stay out of the way. One
+   * component on purpose: the fields, the env-lock rule, the connection test
+   * and the restart banners must never drift between first run and later.
+   */
+  variant?: 'setup' | 'settings';
 }
 
 /**
@@ -130,7 +139,7 @@ interface Props {
  * silently outranking the infrastructure config someone is reviewing in a
  * repo, which is the same rule the server enforces.
  */
-export function SetupScreen({ settings, onSaved }: Props) {
+export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
   const [draft, setDraft] = useState<Record<string, string>>({});
   const [problems, setProblems] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
@@ -344,14 +353,18 @@ export function SetupScreen({ settings, onSaved }: Props) {
   // it would scroll within. Being exactly the height of the root is what makes
   // the overflow this element's own to handle.
   return (
-    <div className="h-full overflow-y-auto bg-sunken px-6 py-12">
-      <div className="mx-auto w-full max-w-2xl">
-        <h1 className="text-display font-semibold text-ink">Set up this deployment</h1>
-        <p className="mt-2 max-w-[62ch] text-lede text-ink-muted">
-          One thing is needed before anyone can use it: somewhere to keep the knowledge base.
-          Connect a repository below, test it, and the rest fills itself in. Single sign-on is
-          optional and can wait.
-        </p>
+    <div className={variant === 'setup' ? 'h-full overflow-y-auto bg-sunken px-6 py-12' : ''}>
+      <div className={variant === 'setup' ? 'mx-auto w-full max-w-2xl' : 'w-full max-w-2xl'}>
+        {variant === 'setup' && (
+          <>
+            <h1 className="text-display font-semibold text-ink">Set up this deployment</h1>
+            <p className="mt-2 max-w-[62ch] text-lede text-ink-muted">
+              One thing is needed before anyone can use it: somewhere to keep the knowledge base.
+              Connect a repository below, test it, and the rest fills itself in. Single sign-on is
+              optional and can wait.
+            </p>
+          </>
+        )}
 
         <div ref={noticeRef}>
           {error && (

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -16,7 +16,7 @@ const FIELDS: Record<
 > = {
   kbRepoUrl: {
     label: 'Repository address',
-    help: 'Where your knowledge base is stored. Copy the address from your repository page — GitHub, GitLab, Bitbucket and Azure DevOps all work. A brand-new empty repository is fine.',
+    help: 'Where your knowledge, skills and tools are stored. Copy the address from your repository page: GitHub, GitLab, Bitbucket and Azure DevOps all work. A brand-new empty repository is fine.',
     placeholder: 'https://github.com/acme/knowledge-base.git',
   },
   gitToken: {
@@ -30,13 +30,13 @@ const FIELDS: Record<
     // expects beside a token, so it is filled in automatically and only
     // surfaces under Advanced for hosts we cannot recognise.
     label: 'Token username',
-    help: 'A fixed value the git host expects next to the token — not your account name. Filled in automatically for known hosts; only change it for a self-hosted server.',
+    help: 'A fixed value the git host expects next to the token, not your account name. Filled in automatically for known hosts; only change it for a self-hosted server.',
     placeholder: 'x-access-token',
     advanced: true,
   },
   kbDirName: {
     label: 'Folder name',
-    help: 'What the knowledge base folder is called. Cosmetic — leave it as it is.',
+    help: 'What the repository folder is called inside each workspace. Cosmetic; leave it as it is.',
     placeholder: 'knowledge-base',
     advanced: true,
   },
@@ -48,13 +48,13 @@ const FIELDS: Record<
   },
   protectedBranches: {
     label: 'Branches that need approval',
-    help: 'Nobody can change these directly — edits arrive as a request someone approves. Separate several with commas. The main branch has to be one of them.',
+    help: 'Nobody can change these directly; edits arrive as a request someone approves. Separate several with commas. The main branch has to be one of them.',
     placeholder: 'main',
     advanced: true,
   },
   oidcIssuerUrl: {
     label: 'Provider address',
-    help: 'From your identity provider — Entra, Okta, Google Workspace, Auth0 and others all publish one.',
+    help: 'From your identity provider. Entra, Okta, Google Workspace, Auth0 and others all publish one.',
     placeholder: 'https://login.microsoftonline.com/<tenant>/v2.0',
   },
   oidcClientId: {
@@ -79,7 +79,7 @@ const FIELDS: Record<
   },
   allowedEmailDomains: {
     label: 'Allowed email domains',
-    help: 'Only people with an address at these domains can sign in this way. Separate several with commas. Leave blank to allow any address — safe with a provider that only serves your organisation, risky with one that does not.',
+    help: 'Only people with an address at these domains can sign in this way. Separate several with commas. Leave blank to allow any address: safe with a provider that only serves your organisation, risky with one that does not.',
     placeholder: 'example.com',
   },
 };
@@ -96,9 +96,9 @@ const REQUIRED_KEYS = ['kbRepoUrl', 'gitToken', 'defaultBranch', 'protectedBranc
 const SECTIONS: { id: SettingStatus['section']; title: string; blurb: string }[] = [
   {
     id: 'knowledge-base',
-    title: 'Knowledge base',
+    title: 'Knowledge, skills & tools',
     blurb:
-      'Where everything is stored. Connect a git repository — an empty one is fine, it will be set up for you — and test it; the rest fills itself in.',
+      'Where everything lives, together in one git repository: knowledge, skills and tools. Connect one (an empty repository is fine, it will be set up for you) and test it; the rest fills itself in.',
   },
   {
     id: 'sign-in',
@@ -203,7 +203,11 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
         result.defaultBranch ||
         ['main', 'master', 'trunk'].find((name) => result.branches?.includes(name)) ||
         result.branches?.[0] ||
-        null;
+        // An EMPTY repository has no branch to report, but it will be seeded
+        // with whatever is configured here, so the conventional name is the
+        // right suggestion. Suggesting nothing was the one way "Connected"
+        // could still end, silently, in a save that did not finish setup.
+        (result.empty ? 'main' : null);
       if (result.ok && suggested) {
         setDraft((d) => ({
           ...d,
@@ -232,7 +236,9 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
       const suggested =
         result.defaultBranch ||
         ['main', 'master', 'trunk'].find((name) => result.branches?.includes(name)) ||
-        result.branches?.[0];
+        result.branches?.[0] ||
+        // Same empty-repository rule as the visible test button above.
+        (result.empty ? 'main' : undefined);
       if (!suggested) return null;
       setTest(result);
       const derived: Record<string, string> = {};
@@ -321,7 +327,7 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
             placeholder={
               // A configured secret has no value to show, so the field says
               // what leaving it blank means instead.
-              setting.secret && setting.configured ? 'Saved — type to replace' : copy.placeholder
+              setting.secret && setting.configured ? 'Saved. Type to replace' : copy.placeholder
             }
             value={draft[setting.key] ?? (setting.secret ? '' : (setting.value ?? ''))}
             onChange={(e) => set(setting.key, e.target.value)}
@@ -359,9 +365,9 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
           <>
             <h1 className="text-display font-semibold text-ink">Set up this deployment</h1>
             <p className="mt-2 max-w-[62ch] text-lede text-ink-muted">
-              One thing is needed before anyone can use it: somewhere to keep the knowledge base.
-              Connect a repository below, test it, and the rest fills itself in. Single sign-on is
-              optional and can wait.
+              One thing is needed before anyone can use it: somewhere to keep your knowledge,
+              skills and tools. Connect a repository below, test it, and the rest fills itself in.
+              Single sign-on is optional and can wait.
             </p>
           </>
         )}
@@ -378,14 +384,14 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
               that silently failed. */}
           {needsRestart && (
             <Banner tone="wait" role="status" className="mt-6">
-              Saved. This deployment needs a restart to pick the branch settings up — everything
+              Saved. This deployment needs a restart to pick the branch settings up; everything
               else is in place.
             </Banner>
           )}
 
           {stillMissing.length > 0 && (
             <Banner tone="wait" role="status" className="mt-6">
-              Saved what you filled in — but this deployment still needs{' '}
+              Saved what you filled in, but this deployment still needs{' '}
               <b className="font-semibold">{stillMissing.join(', ')}</b> before anyone can use it.
               Test the connection and the version fields fill themselves in.
             </Banner>
@@ -470,7 +476,7 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
                       >
                         {test.ok
                           ? test.empty
-                            ? 'Connected. The repository is empty — it will be set up for you on first use.'
+                            ? 'Connected. The repository is empty; it will be set up for you on first use, and the version fields below are filled in with the standard name.'
                             : `Connected. Found ${test.branches?.length ?? 0} branch${
                                 test.branches?.length === 1 ? '' : 'es'
                               }.`
@@ -502,7 +508,7 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
                     <summary className="cursor-pointer list-none text-detail font-medium text-ink-muted marker:hidden hover:text-ink">
                       Advanced
                       <span className="ml-1.5 text-meta text-ink-faint">
-                        — sensible defaults; open only if you need to change one
+                        (sensible defaults; open only if you need to change one)
                       </span>
                     </summary>
                     <div className="mt-4 space-y-6">

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -279,14 +279,23 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
       setStillMissing(result.complete || result.awaitingRestart ? [] : missing);
       if (result.awaitingRestart) {
         setNeedsRestart(true);
+        // The settings page still wants fresh status — the notice above says
+        // what the restart is for; the form should show what was saved.
+        if (variant === 'settings') onSaved();
         return;
       }
-      if (result.complete) {
+      if (result.complete && variant === 'setup') {
         // A FULL RELOAD, not just re-rendering the gate. The branch model the
         // browser holds was fetched before any of this existed, and every
         // module that reads it took its value then — so the app behind the
         // gate would build URLs for a branch called nothing. Reloading is the
         // one thing guaranteed to re-fetch it everywhere.
+        //
+        // SETUP MODE ONLY: on the settings page the app around the form is
+        // already running against a fetched branch model, and yanking the
+        // whole document out from under an admin who just pressed Save is
+        // not a refresh, it is a punishment. Rare branch-model edits there
+        // arrive with `restartRequired`, which the notice explains.
         window.location.reload();
         return;
       }


### PR DESCRIPTION
Gives the first-run setup form a permanent address at `/deployment` (settings nav, admin section), so single sign-on, the knowledge-base connection, and the branch model can be configured after setup — not only while the gate is open. The backend accepted these writes from any admin all along; only the door was missing.

- `SetupScreen` gains a `variant`: `'setup'` keeps first-run chrome, `'settings'` embeds the identical form (fields, env-lock rule, connection test, restart notices) in a host page.
- New `DeploymentPage` with admin gating (presentation only — the backend enforces the real gate), loading and retry states.
- The settings-nav allow-list derives from the row list, so the new row self-registers.

Validation: 3 new page tests, frontend 971/971, typecheck clean, web build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deployment settings page at `/deployment` for administrators.
  * Deployment settings support knowledge, skills, and tools connections, branch configuration, and SSO settings.
  * Added Deployment to settings navigation.
  * Empty repositories now default branch settings to `main`.

* **Bug Fixes**
  * Added loading, retry, and save status handling.
  * Non-administrators receive an access message without triggering settings requests.
  * Save errors preserve entered settings and display restart guidance.
  * Clarified setup guidance and automatic version-field population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->