### PR TITLE
Deployment page: drop the lede, warn before repointing a live repository

### DIFF
--- a/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
+++ b/packages/core-frontend/src/modules/settings/components/DeploymentPage.tsx
@@ -61,12 +61,6 @@ export function DeploymentPage() {
 
   return (
     <PageShell title="Deployment" width="4xl">
-      <p className="max-w-[62ch] text-detail text-ink-muted">
-        Where your knowledge, skills and tools live, the branch model, and single sign-on: the
-        same form as first-run setup, editable whenever something changes. Values set in the
-        environment stay locked here; change them where they are set.
-      </p>
-
       {!loaded && <div className="mt-6 text-sm text-ink-muted">Loading…</div>}
 
       {/* A failed fetch never clears `status`, so a refresh that breaks

--- a/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
+++ b/packages/core-frontend/src/modules/settings/components/__tests__/DeploymentPage.test.tsx
@@ -56,6 +56,11 @@ describe('DeploymentPage', () => {
     expect(await screen.findByText('Provider address')).toBeInTheDocument();
     // And the same redirect-URI helper the setup screen shows.
     expect(screen.getByText(/api\/auth\/oidc\/callback/)).toBeInTheDocument();
+    // Post-setup only: the caution against repointing a LIVE deployment at a
+    // different repository (first-run has nothing to lose yet).
+    expect(
+      screen.getByText(/Only change this if the same repository was moved or renamed/),
+    ).toBeInTheDocument();
   });
 
   it('tells a non-admin this is not theirs, and never fetches the settings', () => {

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -353,6 +353,18 @@ export function SetupScreen({ settings, onSaved, variant = 'setup' }: Props) {
           </datalist>
         )}
         <p className="mt-1 text-meta text-ink-faint">{copy.help}</p>
+        {/* Only AFTER setup: on first run there is nothing yet to lose, so
+            the caution would be noise. Once a deployment is live, this field
+            is the one whose careless edit strands everything. */}
+        {variant === 'settings' && setting.key === 'kbRepoUrl' && (
+          <p className="mt-1.5 text-meta text-ink-muted">
+            <b className="font-semibold">
+              Only change this if the same repository was moved or renamed.
+            </b>{' '}
+            Pointing it at a different repository does not carry anything over: the knowledge,
+            skills and tools stay in the old one, and open change requests will stop working.
+          </p>
+        )}
         {problems[setting.key] && (
           <p id={`${setting.key}-problem`} role="alert" className="mt-1 text-meta text-danger">
             {problems[setting.key]}


### PR DESCRIPTION
One commit that landed on the branch just after #38 merged:

- Removes the Deployment page's introductory paragraph; the form says everything it said.
- The repository-address field gains an admin-view-only caution: only change it if the same repository was moved or renamed — pointing it at a different repository carries nothing over, and open change requests stop working. First-run setup stays uncluttered.

Validation: typecheck clean, frontend 974/974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)