### PR TITLE
fix: hide empty skill creation from non-admins

### DIFF
--- a/.changeset/admins-start-empty-skills.md
+++ b/.changeset/admins-start-empty-skills.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Hide the empty SKILL.md creation panel from non-admins in group and personal add dialogs. Non-admins retain the agent-assisted creation prompt, while admins keep both paths.

--- a/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/AddToGroupDialog.test.tsx
@@ -5,6 +5,7 @@ import {
   WorkspaceContext,
   type WorkspaceContextValue,
 } from '../../workspace/state/workspace.context';
+import { AdminContext, type AdminContextValue } from '../../admin/state/admin.context';
 import { LibraryToastProvider } from '../state/toast';
 import { withAuth } from './auth-harness';
 
@@ -32,6 +33,19 @@ function workspace(kbDirName: string | null) {
   return { workspaceId: 'target-company-state', kbDirName } as unknown as WorkspaceContextValue;
 }
 
+function admin(isAdmin: boolean): AdminContextValue {
+  return {
+    isAdmin,
+    unreadCount: 0,
+    lastSeen: null,
+    markSeen: vi.fn(),
+    refresh: vi.fn(),
+    rolesConfigCorrupted: false,
+    rolesConfigErrors: [],
+    runRolesRecovery: vi.fn(),
+  };
+}
+
 function LocationProbe() {
   const location = useLocation();
   return (
@@ -46,33 +60,36 @@ function renderDialog(
   kbDirName: string | null = 'knowledge-base',
   canWrite = true,
   existingSkills: string[] = [],
+  isAdmin = true,
 ) {
   const onClose = vi.fn();
   render(
     <MemoryRouter initialEntries={['/skills-and-tools/groups/GTM']}>
-      <WorkspaceContext.Provider value={workspace(kbDirName)}>
-        <LibraryToastProvider>
-          {withAuth(
-            <>
-              <Routes>
-                <Route
-                  path="*"
-                  element={
-                    <AddToGroupDialog
-                      name="GTM"
-                      primaryPath="Groups/GTM"
-                      canWrite={canWrite}
-                      existingSkills={existingSkills}
-                      onClose={onClose}
-                    />
-                  }
-                />
-              </Routes>
-              <LocationProbe />
-            </>,
-          )}
-        </LibraryToastProvider>
-      </WorkspaceContext.Provider>
+      <AdminContext.Provider value={admin(isAdmin)}>
+        <WorkspaceContext.Provider value={workspace(kbDirName)}>
+          <LibraryToastProvider>
+            {withAuth(
+              <>
+                <Routes>
+                  <Route
+                    path="*"
+                    element={
+                      <AddToGroupDialog
+                        name="GTM"
+                        primaryPath="Groups/GTM"
+                        canWrite={canWrite}
+                        existingSkills={existingSkills}
+                        onClose={onClose}
+                      />
+                    }
+                  />
+                </Routes>
+                <LocationProbe />
+              </>,
+            )}
+          </LibraryToastProvider>
+        </WorkspaceContext.Provider>
+      </AdminContext.Provider>
     </MemoryRouter>,
   );
   return {
@@ -228,7 +245,7 @@ describe('AddToGroupDialog: starting an empty SKILL.md', () => {
 // The group page used to fork on `canWrite` into two different flows. It does
 // not any more: everybody gets THIS dialog, and the only thing role changes is
 // what the prompt says happens next — and, now, where the new file lands.
-describe('AddToGroupDialog for a non-writer', () => {
+describe('AddToGroupDialog for an admin non-writer', () => {
   it('offers the same dialog, and tells the truth about review', () => {
     renderDialog('knowledge-base', false);
     expect(
@@ -238,7 +255,7 @@ describe('AddToGroupDialog for a non-writer', () => {
     expect(screen.queryByText(/no review step/)).not.toBeInTheDocument();
   });
 
-  it('still offers both doors', () => {
+  it('still offers an admin both doors', () => {
     renderDialog('knowledge-base', false);
     expect(screen.getByRole('textbox', { name: 'Skill name' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy prompt' })).toBeInTheDocument();
@@ -264,5 +281,31 @@ describe('AddToGroupDialog for a non-writer', () => {
     // page stays put, and the new skill appears on it as an "In review" card.
     expect(await screen.findByText(/sent to the group's owners for review/)).toBeInTheDocument();
     expect(href()).toBe('/skills-and-tools/groups/GTM');
+  });
+});
+
+describe('AddToGroupDialog for a non-admin', () => {
+  beforeEach(() => {
+    apiMock.createEmptySkill.mockClear();
+  });
+
+  it('removes empty skill creation even when the person can write the group', () => {
+    renderDialog('knowledge-base', true, [], false);
+
+    expect(screen.queryByText('Start an empty SKILL.md')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Skill name' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy prompt' })).toBeInTheDocument();
+    expect(screen.getByText(/add it to GTM for everyone in the group/)).toBeInTheDocument();
+    expect(screen.queryByText(/Two ways in/)).not.toBeInTheDocument();
+  });
+
+  it('keeps only the reviewed agent path when the person cannot write the group', () => {
+    renderDialog('knowledge-base', false, [], false);
+
+    expect(screen.queryByText('Start an empty SKILL.md')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Skill name' })).not.toBeInTheDocument();
+    expect(screen.getByText(/change request for an owner to review/)).toBeInTheDocument();
+    expect(screen.getByText(/send it to the group as a change request/)).toBeInTheDocument();
+    expect(apiMock.createEmptySkill).not.toHaveBeenCalled();
   });
 });

--- a/packages/core-frontend/src/modules/library/__tests__/GroupPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/GroupPage.test.tsx
@@ -6,6 +6,7 @@ import {
   WorkspaceContext,
   type WorkspaceContextValue,
 } from '../../workspace/state/workspace.context';
+import { AdminContext, type AdminContextValue } from '../../admin/state/admin.context';
 import type { LibraryData } from '../hooks/useLibraryData';
 import type { ToolSecrets } from '../../secrets-vault/services/tool-secrets.api';
 import type { GroupSummary } from '../services/groups.api';
@@ -65,6 +66,17 @@ const workspace = {
   workspaceId: 'target-company-state',
   kbDirName: 'knowledge-base',
 } as unknown as WorkspaceContextValue;
+
+const nonAdmin: AdminContextValue = {
+  isAdmin: false,
+  unreadCount: 0,
+  lastSeen: null,
+  markSeen: vi.fn(),
+  refresh: vi.fn(),
+  rolesConfigCorrupted: false,
+  rolesConfigErrors: [],
+  runRolesRecovery: vi.fn(),
+};
 
 const connectedTool = (over: Partial<ToolSecrets> = {}): ToolSecrets => ({
   slug: 'heyreach',
@@ -139,25 +151,24 @@ function LocationProbe() {
 function renderGroup(name: string, children?: ReactNode) {
   return render(
     <MemoryRouter initialEntries={[`/skills-and-tools/groups/${encodeURIComponent(name)}`]}>
-      <WorkspaceContext.Provider value={workspace}>
-        <LibraryToastProvider>
-          <LibraryProvider>
-            {/* The add dialog's create half signs the new skill's change
-                request with the caller, so it reads `useAuth` — which throws
-                rather than returning null when nothing provides it. */}
-            {withAuth(
-              <>
-                <Routes>
-                  <Route path="/skills-and-tools/groups/:group" element={<GroupPage />} />
-                  <Route path="*" element={<div />} />
-                </Routes>
-                <LocationProbe />
-                {children}
-              </>,
-            )}
-          </LibraryProvider>
-        </LibraryToastProvider>
-      </WorkspaceContext.Provider>
+      <AdminContext.Provider value={nonAdmin}>
+        <WorkspaceContext.Provider value={workspace}>
+          <LibraryToastProvider>
+            <LibraryProvider>
+              {withAuth(
+                <>
+                  <Routes>
+                    <Route path="/skills-and-tools/groups/:group" element={<GroupPage />} />
+                    <Route path="*" element={<div />} />
+                  </Routes>
+                  <LocationProbe />
+                  {children}
+                </>,
+              )}
+            </LibraryProvider>
+          </LibraryToastProvider>
+        </WorkspaceContext.Provider>
+      </AdminContext.Provider>
     </MemoryRouter>,
   );
 }
@@ -206,6 +217,7 @@ describe('GroupPage', () => {
       await screen.findByRole('heading', { name: 'Add a skill or tool to GTM' }),
     ).toBeInTheDocument();
     expect(screen.getByText(/No review step/)).toBeInTheDocument();
+    expect(screen.queryByText('Start an empty SKILL.md')).not.toBeInTheDocument();
   });
 
   it('opens the same add dialog for everyone else, and says review is coming', async () => {
@@ -214,7 +226,8 @@ describe('GroupPage', () => {
     expect(
       await screen.findByRole('heading', { name: 'Add a skill or tool to GTM' }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/an owner reviews it before it joins/)).toBeInTheDocument();
+    expect(screen.getByText(/change request for an owner to review/)).toBeInTheDocument();
+    expect(screen.queryByText('Start an empty SKILL.md')).not.toBeInTheDocument();
   });
 
   it('offers no separate propose door to anybody', async () => {

--- a/packages/core-frontend/src/modules/library/__tests__/PersonalAddDialog.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PersonalAddDialog.test.tsx
@@ -5,6 +5,7 @@ import {
   WorkspaceContext,
   type WorkspaceContextValue,
 } from '../../workspace/state/workspace.context';
+import { AdminContext, type AdminContextValue } from '../../admin/state/admin.context';
 import { LibraryToastProvider } from '../state/toast';
 import { withAuth, TEST_PERSONAL_GROUP } from './auth-harness';
 
@@ -35,36 +36,51 @@ const workspace = {
   kbDirName: 'knowledge-base',
 } as unknown as WorkspaceContextValue;
 
+function admin(isAdmin: boolean): AdminContextValue {
+  return {
+    isAdmin,
+    unreadCount: 0,
+    lastSeen: null,
+    markSeen: vi.fn(),
+    refresh: vi.fn(),
+    rolesConfigCorrupted: false,
+    rolesConfigErrors: [],
+    runRolesRecovery: vi.fn(),
+  };
+}
+
 function LocationProbe() {
   const location = useLocation();
   return <div aria-label="href">{location.pathname}</div>;
 }
 
-function renderDialog(existingSkills: string[] = []) {
+function renderDialog(existingSkills: string[] = [], isAdmin = true) {
   const onClose = vi.fn();
   render(
     <MemoryRouter initialEntries={['/skills-and-tools/yours']}>
-      <WorkspaceContext.Provider value={workspace}>
-        <LibraryToastProvider>
-          {withAuth(
-            <>
-              <Routes>
-                <Route
-                  path="*"
-                  element={
-                    <PersonalAddDialog
-                      name={TEST_PERSONAL_GROUP}
-                      existingSkills={existingSkills}
-                      onClose={onClose}
-                    />
-                  }
-                />
-              </Routes>
-              <LocationProbe />
-            </>,
-          )}
-        </LibraryToastProvider>
-      </WorkspaceContext.Provider>
+      <AdminContext.Provider value={admin(isAdmin)}>
+        <WorkspaceContext.Provider value={workspace}>
+          <LibraryToastProvider>
+            {withAuth(
+              <>
+                <Routes>
+                  <Route
+                    path="*"
+                    element={
+                      <PersonalAddDialog
+                        name={TEST_PERSONAL_GROUP}
+                        existingSkills={existingSkills}
+                        onClose={onClose}
+                      />
+                    }
+                  />
+                </Routes>
+                <LocationProbe />
+              </>,
+            )}
+          </LibraryToastProvider>
+        </WorkspaceContext.Provider>
+      </AdminContext.Provider>
     </MemoryRouter>,
   );
   return {
@@ -94,7 +110,7 @@ describe('PersonalAddDialog', () => {
     Reflect.deleteProperty(navigator, 'clipboard');
   });
 
-  it('offers both doors, not just the prompt', () => {
+  it('offers an admin both doors, not just the prompt', () => {
     const { field } = renderDialog();
     expect(field()).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Copy prompt' })).toBeInTheDocument();
@@ -142,5 +158,16 @@ describe('PersonalAddDialog', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('already exists');
     expect(create()).toBeDisabled();
     await waitFor(() => expect(apiMock.createEmptySkill).not.toHaveBeenCalled());
+  });
+
+  it('gives a non-admin only the agent-assisted path', () => {
+    renderDialog([], false);
+
+    expect(screen.queryByText('Start an empty SKILL.md')).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Skill name' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy prompt' })).toBeInTheDocument();
+    expect(screen.getByText(/Tell your agent what you need/)).toBeInTheDocument();
+    expect(screen.getByText(/Yours alone until you add it to a group/)).toBeInTheDocument();
+    expect(apiMock.createEmptySkill).not.toHaveBeenCalled();
   });
 });

--- a/packages/core-frontend/src/modules/library/components/AddToGroupDialog.tsx
+++ b/packages/core-frontend/src/modules/library/components/AddToGroupDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, Surface } from '../../../shared/components';
+import { useAdmin } from '../../admin/state/admin.context';
 import { NewSkillPanel } from './NewSkillPanel';
 import { useLibraryToast } from '../state/toast.context';
 import { COPIED_TOAST, COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
@@ -9,13 +10,13 @@ export interface AddToGroupDialogProps {
   /** Repo-relative primary folder, e.g. `Groups/GTM`. */
   primaryPath: string;
   /**
-   * Whether the caller can write the folder. It changes ONE clause of the
-   * prompt and nothing else — see the note below on why the door is the same
-   * for everyone. `null` (verdict not in yet) is treated as "not a writer":
+   * Whether the caller can write the folder. It changes the prompt's landing
+   * clause and, for an admin, whether an empty skill lands directly or goes
+   * through review. `null` (verdict not in yet) is treated as "not a writer":
    * the cautious sentence is true either way, the confident one is not.
    */
   canWrite: boolean | null;
-  /** Every skill name already in the catalog — the create half rejects collisions. */
+  /** Every skill name already in the catalog. The admin create half rejects collisions. */
   existingSkills: string[];
   onClose(): void;
 }
@@ -23,26 +24,19 @@ export interface AddToGroupDialogProps {
 /**
  * "Add a skill or tool to {group}" — the writer's half of the group page.
  *
- * Two ways in, and NEITHER of them is an upload form. A skill is a folder
- * (`SKILL.md` plus whatever it needs), so the honest doors are one that makes
- * that folder for you and one that hands the job to the agent. The prototype's
- * dropzone is deliberately not ported: there is no upload endpoint behind it,
- * and a dropzone that silently does nothing is worse than a button that does
- * something.
+ * The agent prompt is the path everyone gets. Admins also get the direct
+ * starter that creates an empty `SKILL.md`; non-admins do not. A placeholder
+ * is useful to an admin who can finish it directly, while a non-admin should
+ * send complete drafted content through the ordinary review flow.
  *
  * The prompt is the actual product here. It is copy-pasteable into the agent
  * verbatim and it already knows the group, so nobody has to explain where the
  * skill goes.
  *
- * ONE door, for every role. This dialog used to be the writer's half of a
- * fork — everyone else got a separate "Propose a skill or tool" page — which
- * meant the same button in the same spot opened a different flow with
- * different words depending on who pressed it. Who reviews what is a property
- * of the GROUP, not of the door, so the door is the same and the prompt's last
- * clause tells the truth about what happens next: a writer's skill goes in
- * directly, everyone else's arrives as a change request. Nothing here writes
- * to the KB, so there is no permission to gate on — the dialog hands you a
- * prompt and a link.
+ * The add button itself stays consistent for every role. What changes is the
+ * safe action inside it: non-admins can copy the prompt, and the prompt's last
+ * clause tells the truth about whether the resulting skill lands directly or
+ * arrives as a change request.
  */
 export function AddToGroupDialog({
   name,
@@ -51,6 +45,7 @@ export function AddToGroupDialog({
   existingSkills,
   onClose,
 }: AddToGroupDialogProps) {
+  const { isAdmin } = useAdmin();
   const toast = useLibraryToast();
 
   // The only sentence in this dialog that varies by role.
@@ -81,26 +76,36 @@ export function AddToGroupDialog({
       }
     >
       <p className="text-ui text-ink-muted">
-        {canWrite
-          ? `Two ways in. Either way it joins ${name}. Everyone in the group gets it the next time their agent connects.`
-          : `Two ways in. Either way it goes to ${name} as a change request, and an owner reviews it before it joins.`}
+        {isAdmin
+          ? canWrite
+            ? `Two ways in. Either way it joins ${name}. Everyone in the group gets it the next time their agent connects.`
+            : `Two ways in. Either way it goes to ${name} as a change request, and an owner reviews it before it joins.`
+          : canWrite
+            ? `Use the prompt below to have your agent draft the skill and add it to ${name} for everyone in the group.`
+            : `Use the prompt below to have your agent draft the skill and send it to ${name} as a change request for an owner to review.`}
       </p>
 
-      <NewSkillPanel
-        destination={{ parentPath: primaryPath, canWrite }}
-        existingSkills={existingSkills}
-        onCreated={onClose}
-      />
+      {isAdmin && (
+        <>
+          <NewSkillPanel
+            destination={{ parentPath: primaryPath, canWrite }}
+            existingSkills={existingSkills}
+            onCreated={onClose}
+          />
 
-      <div className="my-3.5 flex items-center gap-3">
-        <span aria-hidden="true" className="h-px flex-1 bg-line" />
-        <span className="text-meta text-ink-faint">or</span>
-        <span aria-hidden="true" className="h-px flex-1 bg-line" />
-      </div>
+          <div className="my-3.5 flex items-center gap-3">
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+            <span className="text-meta text-ink-faint">or</span>
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+          </div>
+        </>
+      )}
 
-      <p className="text-ui text-ink-muted">
-        {`Tell your agent what you need. It drafts the skill and adds it to ${name}.`}
-      </p>
+      {isAdmin && (
+        <p className="text-ui text-ink-muted">
+          {`Tell your agent what you need. It drafts the skill and adds it to ${name}.`}
+        </p>
+      )}
 
       <Surface tone="sunken" radius="md" elevation="none" padded className="mt-2.5">
         <p className="font-mono text-detail text-ink">{prompt}</p>

--- a/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
+++ b/packages/core-frontend/src/modules/library/components/NewSkillPanel.tsx
@@ -31,7 +31,7 @@ export interface NewSkillPanelProps {
 }
 
 /**
- * "Start an empty SKILL.md" — the first of the two doors in both add-dialogs.
+ * "Start an empty SKILL.md", the admin-only first path in both add dialogs.
  *
  * This used to be a link that opened the destination folder in the workspace
  * and left you there. Opening a folder is not creating a skill: you still had

--- a/packages/core-frontend/src/modules/library/components/PersonalAddDialog.tsx
+++ b/packages/core-frontend/src/modules/library/components/PersonalAddDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, Surface } from '../../../shared/components';
+import { useAdmin } from '../../admin/state/admin.context';
 import { NewSkillPanel } from './NewSkillPanel';
 import { useLibraryToast } from '../state/toast.context';
 import { COPIED_TOAST, COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
@@ -6,7 +7,7 @@ import { COPIED_TOAST, COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipb
 export interface PersonalAddDialogProps {
   /** The list's own name, e.g. `Juan's List` — the copy says it out loud. */
   name: string;
-  /** Every skill name already in the catalog — the create half rejects collisions. */
+  /** Every skill name already in the catalog. The admin create half rejects collisions. */
   existingSkills: string[];
   onClose(): void;
 }
@@ -15,10 +16,9 @@ export interface PersonalAddDialogProps {
  * "Add a skill or tool" for a person's own list — the prototype's
  * `personalAddModal` (proto:3366-3369).
  *
- * The same two doors as a group's, because the prototype's whole point about
- * the add flow is that there is only one. What differs is where the thing
- * LANDS, and the dialog says so in its first line: a skill you build stays
- * yours until a group takes it in.
+ * The same role split as a group's add flow. Everyone can copy a prompt for
+ * their agent. Admins can also start an empty skill directly; non-admins do
+ * not get a placeholder they would have to finish in a separate follow-up.
  *
  * This page used to have no first door at all. The reason was real but narrow:
  * the group dialog's first half was a LINK into the destination folder, and
@@ -31,6 +31,7 @@ export interface PersonalAddDialogProps {
  * permission special-case anywhere in this flow.
  */
 export function PersonalAddDialog({ name, existingSkills, onClose }: PersonalAddDialogProps) {
+  const { isAdmin } = useAdmin();
   const toast = useLibraryToast();
   const prompt = `Help me build a new skill or tool at Bevel. Keep it to myself for now. It goes in my own list, not a group.`;
 
@@ -59,13 +60,21 @@ export function PersonalAddDialog({ name, existingSkills, onClose }: PersonalAdd
         {`It lands in ${name}. Yours alone until you add it to a group.`}
       </p>
 
-      <NewSkillPanel destination={{ personal: true }} existingSkills={existingSkills} onCreated={onClose} />
+      {isAdmin && (
+        <>
+          <NewSkillPanel
+            destination={{ personal: true }}
+            existingSkills={existingSkills}
+            onCreated={onClose}
+          />
 
-      <div className="my-3.5 flex items-center gap-3">
-        <span aria-hidden="true" className="h-px flex-1 bg-line" />
-        <span className="text-meta text-ink-faint">or</span>
-        <span aria-hidden="true" className="h-px flex-1 bg-line" />
-      </div>
+          <div className="my-3.5 flex items-center gap-3">
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+            <span className="text-meta text-ink-faint">or</span>
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+          </div>
+        </>
+      )}
 
       <p className="text-ui text-ink-muted">
         Tell your agent what you need. It drafts the skill and puts it here.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted empty skill creation to administrators in personal and group add dialogs.
  * Non-admins now see only the agent-assisted prompt flow.
  * Administrators retain both direct creation and agent-assisted options.
  * Updated messaging to clarify available options based on permissions.

* **Bug Fixes**
  * Prevented non-admin users from accessing or triggering empty skill creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->