### PR TITLE
fix: keep new skill page visible while loading

### DIFF
--- a/.changeset/new-skills-load-in-place.md
+++ b/.changeset/new-skills-load-in-place.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Render a new skill's name, initial file tab, and file frame immediately while its detail is loading instead of showing a mostly blank page.

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -563,15 +563,41 @@ describe('SkillPage', () => {
   });
 
   /**
-   * `getSkill` can take a while, and a page with no way out of it is a dead
-   * end — the error and loaded states both carry the link, so this one does too.
+   * Creation navigates before the first detail read settles. The route already
+   * carries enough identity to paint the skill page, so that interval must not
+   * be a blank column with a loading word floating in it.
    */
-  it('keeps the way back on screen while the skill is loading', async () => {
-    apiMock.getSkill.mockReturnValueOnce(new Promise(() => {}));
-    renderPage(false);
+  it('renders the new skill shell immediately while its first load is pending', async () => {
+    let resolveSkill!: (skill: typeof skillDetail) => void;
+    const pendingSkill = new Promise<typeof skillDetail>((resolve) => {
+      resolveSkill = resolve;
+    });
+    apiMock.getSkill.mockReturnValueOnce(pendingSkill);
+    accessMock.result = {
+      canWrite: true,
+      eligible: { roles: [], users: [] },
+      owners: { roles: [], users: [] },
+    };
+    renderPage(true, [], [], makeFakeBus(), { startEditing: true });
 
-    expect(await screen.findByText('Loading…')).toBeInTheDocument();
+    const heading = await screen.findByRole('heading', { name: 'newsletter' });
+    const skillTab = screen.getByRole('tab', { name: 'SKILL.md' });
+    const panel = screen.getByRole('tabpanel');
+    expect(skillTab).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('file-pane-card')).toBeInTheDocument();
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(panel).toHaveAttribute('aria-busy', 'true');
     expect(screen.getByRole('button', { name: /All skills & tools/ })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSkill(skillDetail);
+      await pendingSkill;
+    });
+    expect(await screen.findByRole('textbox', { name: 'Edit SKILL.md' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'newsletter' })).toBe(heading);
+    expect(screen.getByRole('tab', { name: 'SKILL.md' })).toBe(skillTab);
+    expect(screen.getByRole('tabpanel')).toBe(panel);
+    expect(panel).not.toHaveAttribute('aria-busy');
   });
 
   it('says so plainly when the skill cannot be loaded', async () => {

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -359,19 +359,7 @@ export function SkillPage() {
     </Button>
   );
 
-  // Same frame as the other two branches: the way out is on screen while the
-  // skill loads, not only once it has, and the column does not jump when the
-  // content arrives under it.
-  if (detail.loading) {
-    return (
-      <Article>
-        {backLink}
-        <p className="py-16 text-center text-ui text-ink-muted">Loading…</p>
-      </Article>
-    );
-  }
-
-  if (detail.error || !skill) {
+  if (!detail.loading && (detail.error || !skill)) {
     return (
       <Article>
         {backLink}
@@ -389,7 +377,7 @@ export function SkillPage() {
   // underneath it. It is the SHARED dialog, scoped to this skill: its folder
   // frames the file list, and the skill's own files always show so an owner
   // can read the untouched parts too.
-  if (compareCr) {
+  if (compareCr && skill) {
     return (
       <ChangeRequestDialog
         cr={compareCr}
@@ -404,14 +392,18 @@ export function SkillPage() {
     );
   }
 
+  // Loading deliberately falls through to this real page tree. The route
+  // already knows the skill name, `files` already contains SKILL.md, and
+  // keeping these exact nodes mounted prevents a blank handoff followed by a
+  // second layout when the detail request settles.
   return (
     <Article>
       {backLink}
 
       <header className="mt-4">
         <div className="flex items-center gap-3">
-          <h1 className="text-display font-semibold text-ink">{skill.name}</h1>
-          {owned && (
+          <h1 className="text-display font-semibold text-ink">{skill?.name ?? name}</h1>
+          {skill && owned && (
             <Badge tone="outline" size="xs" className="shrink-0 uppercase">
               Owner
             </Badge>
@@ -446,8 +438,16 @@ export function SkillPage() {
         role="tabpanel"
         id={skillPanelId(tabsId)}
         aria-labelledby={skillTabId(tabsId, active)}
+        aria-busy={detail.loading || raw === null || undefined}
       >
-      {editing && editorBase !== null && fileAccess.canWrite !== null ? (
+      {detail.loading ? (
+        <SkillFilePane
+          file={active}
+          raw={null}
+          suggestion={null}
+          headingLink={headingLink}
+        />
+      ) : editing && editorBase !== null && fileAccess.canWrite !== null ? (
         <SkillFileEditor
           file={active}
           base={editorBase}
@@ -463,7 +463,7 @@ export function SkillPage() {
           suggestion={null}
           onOpenLink={(href) => {
             if (!kbDirName) return;
-            openInEditor(resolveRelativePath(`${kbDirName}/${skill.path}/${active}`, href));
+            openInEditor(resolveRelativePath(`${kbDirName}/${skillPath}/${active}`, href));
           }}
           onOpenNodeId={openNodeId}
           headingLink={headingLink}
@@ -567,7 +567,7 @@ export function SkillPage() {
           the skill, so it is not about the selected tab. The boxes above only
           cover the file on screen, and without this a proposal to a file you
           are not looking at has no way to reach you. */}
-      {owned && <ChangeRequestDock crs={skillCrs} onSelect={setCompareCr} />}
+      {skill && owned && <ChangeRequestDock crs={skillCrs} onSelect={setCompareCr} />}
     </Article>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New skills now display their name, initial file tab, and file frame immediately while details load.
  * The skill page remains visible during loading, including navigation and editor loading states.

* **Bug Fixes**
  * Improved the transition into editing a newly created skill.
  * Prevented skill-specific controls and dialogs from appearing before skill details are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->