### PR TITLE
Fix disabled cancel button in Knowledge UI for changed-file owners

### DIFF
--- a/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.viewer-can-cancel.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.viewer-can-cancel.test.ts
@@ -14,6 +14,7 @@ describe('computeViewerCanCancel', () => {
         authorId: AUTHOR_HASH,
         viewerEmail: undefined,
         viewerCanBypassMerge: false,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(false);
   });
@@ -25,6 +26,7 @@ describe('computeViewerCanCancel', () => {
         authorId: AUTHOR_HASH,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: false,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(true);
   });
@@ -36,8 +38,36 @@ describe('computeViewerCanCancel', () => {
         authorId: OTHER_AUTHOR_HASH,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: true,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(true);
+  });
+
+  it('returns true when the viewer writes every changed file (neither author nor admin)', () => {
+    // The reject route's third grant — mirrors WorkflowService.rejectChangeRequest,
+    // which is what lets a knowledge/skill owner send a CR back without being
+    // its author or a roles.yaml admin.
+    expect(
+      computeViewerCanCancel({
+        state: 'open',
+        authorId: OTHER_AUTHOR_HASH,
+        viewerEmail: EMAIL,
+        viewerCanBypassMerge: false,
+        viewerWritesAllFiles: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('fails closed for an anonymous viewer even when viewerWritesAllFiles is true', () => {
+    expect(
+      computeViewerCanCancel({
+        state: 'open',
+        authorId: OTHER_AUTHOR_HASH,
+        viewerEmail: undefined,
+        viewerCanBypassMerge: false,
+        viewerWritesAllFiles: true,
+      }),
+    ).toBe(false);
   });
 
   it('returns true when viewer is both author AND admin', () => {
@@ -47,6 +77,7 @@ describe('computeViewerCanCancel', () => {
         authorId: AUTHOR_HASH,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: true,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(true);
   });
@@ -58,6 +89,7 @@ describe('computeViewerCanCancel', () => {
         authorId: AUTHOR_HASH,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: false,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(false);
   });
@@ -69,6 +101,19 @@ describe('computeViewerCanCancel', () => {
         authorId: OTHER_AUTHOR_HASH,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: true,
+        viewerWritesAllFiles: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when state is closed even for a viewer who writes all files', () => {
+    expect(
+      computeViewerCanCancel({
+        state: 'closed',
+        authorId: OTHER_AUTHOR_HASH,
+        viewerEmail: EMAIL,
+        viewerCanBypassMerge: false,
+        viewerWritesAllFiles: true,
       }),
     ).toBe(false);
   });
@@ -80,6 +125,7 @@ describe('computeViewerCanCancel', () => {
         authorId: undefined,
         viewerEmail: EMAIL,
         viewerCanBypassMerge: false,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(false);
   });
@@ -95,6 +141,7 @@ describe('computeViewerCanCancel', () => {
         authorId: AUTHOR_HASH,
         viewerEmail: '  Juan@Bevel.Software  ',
         viewerCanBypassMerge: false,
+        viewerWritesAllFiles: false,
       }),
     ).toBe(true);
   });

--- a/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
@@ -373,11 +373,24 @@ export class PullRequestService implements IPullRequestService {
       }
     }
 
+    // The reject route grants a third path beyond author/admin: write access
+    // to every changed file at `origin/<base>` (see
+    // `WorkflowService.rejectChangeRequest`). `approvals[].viewerCanApprove`
+    // is that exact predicate (`canWriteBatchAtRef` against `origin/<base>`),
+    // already computed per file above — reuse it rather than issuing a second
+    // batch lookup. Length equality guards the enricher-failure fallback,
+    // where `approvals` comes back empty while `files` is populated.
+    const viewerWritesAllFiles =
+      files.length > 0 &&
+      approvals.length === files.length &&
+      approvals.every((a) => a.viewerCanApprove);
+
     const viewerCanCancel = computeViewerCanCancel({
       state: summary.state,
       authorId: summary.authorId,
       viewerEmail: opts.viewerEmail,
       viewerCanBypassMerge,
+      viewerWritesAllFiles,
     });
 
     const detail: PullRequestDetail = {
@@ -423,23 +436,25 @@ export class PullRequestService implements IPullRequestService {
 }
 
 /**
- * Pure predicate for the cancel-button's enabled state. The viewer can cancel
- * iff the PR is open AND they're either the author (hash-match against the
- * stored author) or an admin (`viewerCanBypassMerge` is the proxy — same
- * `canWriteAtRef('roles.yaml')` predicate). Fail-closed defaults: missing
- * email → false.
+ * Pure predicate for the cancel-button's enabled state. Mirrors the reject
+ * route's full authorization set (`WorkflowService.rejectChangeRequest`): the
+ * viewer can cancel iff the PR is open AND they're the author (hash-match
+ * against the stored author), an admin (`viewerCanBypassMerge` is the proxy —
+ * same `canWriteAtRef('roles.yaml')` predicate), or they hold write on every
+ * changed file at `origin/<base>` (`viewerWritesAllFiles`). Fail-closed
+ * defaults: missing email → false.
  */
 export function computeViewerCanCancel(input: {
   state: PullRequestState;
   authorId: string | undefined;
   viewerEmail: string | undefined;
   viewerCanBypassMerge: boolean;
+  viewerWritesAllFiles: boolean;
 }): boolean {
   if (input.state !== 'open') return false;
-  const viewerIsAuthor = !!(
-    input.authorId && input.viewerEmail && input.authorId === hashEmail(input.viewerEmail)
-  );
-  return viewerIsAuthor || input.viewerCanBypassMerge;
+  if (!input.viewerEmail) return false;
+  const viewerIsAuthor = !!(input.authorId && input.authorId === hashEmail(input.viewerEmail));
+  return viewerIsAuthor || input.viewerCanBypassMerge || input.viewerWritesAllFiles;
 }
 
 export const __testing = {

--- a/packages/core-backend/src/modules/workflow/review-workflow/__tests__/cancel-pr.test.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/__tests__/cancel-pr.test.ts
@@ -100,7 +100,7 @@ describe('ReviewWorkflowService.cancelPr', () => {
     ).rejects.toMatchObject({
       name: 'CancelAuthError',
       status: 403,
-      message: expect.stringMatching(/only the author or an admin/i),
+      message: expect.stringMatching(/only the author, an admin, or someone with edit access/i),
     });
     expect(updateReturning).not.toHaveBeenCalled();
   });

--- a/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
@@ -106,7 +106,7 @@ class CancelStateError extends WorkflowDomainError {
 class CancelAuthError extends WorkflowDomainError {
   constructor() {
     super(
-      "You can't cancel this change request — only the author or an admin can.",
+      "You can't cancel this change request — only the author, an admin, or someone with edit access to every changed file can.",
       403,
     );
     this.name = 'CancelAuthError';

--- a/packages/core-frontend/src/modules/pr/__tests__/PrCancelButton.test.tsx
+++ b/packages/core-frontend/src/modules/pr/__tests__/PrCancelButton.test.tsx
@@ -61,7 +61,7 @@ describe('PrCancelButton', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('marks the button aria-disabled with the only-author-or-admin tooltip when viewerCanCancel is false', () => {
+  it('marks the button aria-disabled with the unauthorized tooltip when viewerCanCancel is false', () => {
     render(
       <PrCancelButton
         detail={detail({ viewerCanCancel: false })}
@@ -73,7 +73,7 @@ describe('PrCancelButton', () => {
     // for keyboard users and screen readers announce the unauthorized state.
     expect(btn).toHaveAttribute('aria-disabled', 'true');
     expect(btn).not.toBeDisabled();
-    expect(btn.getAttribute('title')).toMatch(/only the author or an admin/i);
+    expect(btn.getAttribute('title')).toMatch(/only the author, an admin, or someone with edit access/i);
     // Click should still be a no-op (component-level guard).
     fireEvent.click(btn);
     expect(cancelMock).not.toHaveBeenCalled();

--- a/packages/core-frontend/src/modules/pr/components/PrCancelButton.tsx
+++ b/packages/core-frontend/src/modules/pr/components/PrCancelButton.tsx
@@ -18,9 +18,11 @@ interface Props {
  * double-click guard, dispatches the `bevel:pr-stale` refresh event), but with
  * red text-button styling so the primary purple Apply action stays the focus.
  *
- * Authority is server-computed via `detail.viewerCanCancel` (author OR admin on
- * the base). The button disables — not hides — when the viewer can't cancel,
- * so the affordance is discoverable but its absence-of-permission is explicit.
+ * Authority is server-computed via `detail.viewerCanCancel` (author, admin on
+ * the base, or write access to every changed file — the same set the reject
+ * route enforces). The button disables — not hides — when the viewer can't
+ * cancel, so the affordance is discoverable but its absence-of-permission is
+ * explicit.
  */
 export function PrCancelButton({ detail, onCancelled }: Props) {
   const [busy, setBusy] = useState(false);
@@ -35,7 +37,7 @@ export function PrCancelButton({ detail, onCancelled }: Props) {
   const allowed = detail.viewerCanCancel;
   const tooltip = allowed
     ? 'Cancel this change request without applying it'
-    : 'Only the author or an admin can cancel this change request';
+    : 'Only the author, an admin, or someone with edit access to every changed file can cancel this change request';
 
   async function runCancel() {
     if (cancellingRef.current) return;

--- a/packages/core-frontend/src/modules/pr/services/pr-cancel.api.ts
+++ b/packages/core-frontend/src/modules/pr/services/pr-cancel.api.ts
@@ -4,9 +4,10 @@ import { handleApiResponse } from '../../git/services/git.api';
 
 /**
  * Close the change request without merging. The backend re-validates that the
- * caller is the author or a base-branch admin (same predicate driving the
- * `viewerCanCancel` UI hint), refuses if the PR is already merged/closed, and
- * shells out to `gh pr close`. No body needed — author/admin gate is server-side.
+ * caller is the author, a base-branch admin, or holds write on every changed
+ * file (the same set driving the `viewerCanCancel` UI hint), refuses if the
+ * PR is already merged/closed, and flips the row to `closed`. No body needed —
+ * the authorization gate is server-side.
  */
 export async function cancelPullRequest(prNumber: number): Promise<CancelPrResult> {
   return handleApiResponse(

--- a/packages/shared/src/git/pr.types.ts
+++ b/packages/shared/src/git/pr.types.ts
@@ -212,13 +212,14 @@ export interface PullRequestDetail extends PullRequestSummary {
   viewerCanBypassMerge: boolean;
   /**
    * True iff the viewer is allowed to cancel this change request: the PR is
-   * open AND the viewer is either its author (hash-matched against the body
-   * marker) or an admin (write on `roles.yaml` at `origin/<base>` — same
-   * predicate `viewerCanBypassMerge` uses). The frontend renders the Cancel
-   * button as disabled when this is false; the backend re-checks server-side
-   * on `POST /pr/:n/cancel`, so this is a UX hint, not a security boundary.
-   * False when no viewer was passed, the state isn't `open`, or the access
-   * tree can't be resolved.
+   * open AND the viewer is its author (hash-matched against the body marker),
+   * an admin (write on `roles.yaml` at `origin/<base>` — same predicate
+   * `viewerCanBypassMerge` uses), or holds write on every changed file at
+   * `origin/<base>` (the reject route's owner grant). The frontend renders
+   * the Cancel button as disabled when this is false; the backend re-checks
+   * server-side on the reject route, so this is a UX hint, not a security
+   * boundary. False when no viewer was passed, the state isn't `open`, or
+   * the access tree can't be resolved.
    */
   viewerCanCancel: boolean;
 }


### PR DESCRIPTION
## Problem

In the Skills & Tools view, a skill owner can refuse a change request ("Send back"), but in the Knowledge UI the same person sees the "Cancel change request" button permanently disabled.

Both views hit the same reject endpoint, which authorizes three groups: the CR's **author**, an **admin**, or **anyone with write access to every changed file** (the owner grant — see `WorkflowService.rejectChangeRequest`). The Skills view calls the endpoint unconditionally, so it worked. The Knowledge UI's button obeys the server-computed `viewerCanCancel` hint, which only covered author-or-admin — so knowledge owners were locked out of an action the server would have accepted.

## Fix

- **`computeViewerCanCancel`** now includes the third grant (`viewerWritesAllFiles`). `getPrDetail` derives it from the per-file `viewerCanApprove` flags it already computes — the exact same `canWriteBatchAtRef` predicate the reject route enforces — so no extra access lookup is added and the hint can't drift from enforcement.
- **Tooltip and 403 copy** updated to name the full authorization set (author, admin, or edit access to every changed file).
- **Stale docs** fixed: `pr-cancel.api.ts` still claimed cancel shells out to `gh pr close`; the shared `PullRequestDetail.viewerCanCancel` doc described the old two-group rule.

## Tests

- New `computeViewerCanCancel` cases: owner grant enabled, fail-closed for anonymous viewers even with the grant, terminal states still refuse.
- Updated assertions pinned to the old tooltip/error text.
- Full suites pass: backend (1058 tests), frontend (388 tests), typecheck across the workspace, eslint on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMMcmVgh3z8puxYdZcYd4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMMcmVgh3z8puxYdZcYd4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users with edit access to every changed file can now cancel open change requests.
  * Cancellation eligibility continues to include request authors and administrators.
* **Bug Fixes**
  * Improved cancellation permission checks for closed, merged, anonymous, and incomplete requests.
  * Updated cancellation messages and tooltips to accurately describe who can cancel.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->