### PR TITLE
Stop the design-system ratchet recursing through symlinks

### DIFF
--- a/scripts/design-system-ratchet.mjs
+++ b/scripts/design-system-ratchet.mjs
@@ -20,7 +20,7 @@
  *   node scripts/design-system-ratchet.mjs --update # re-baseline after a codemod
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -58,13 +58,24 @@ const EXEMPT = [
   'shared/components/Menu.tsx',
 ];
 
+/**
+ * `withFileTypes` + an explicit symlink skip, rather than `statSync`.
+ *
+ * `statSync` FOLLOWS links, so a link pointing at any ancestor directory makes
+ * this recurse forever, and a link pointing outside the scanned tree silently
+ * widens the scan — either way the gate stops being a gate. `Dirent.isDirectory()`
+ * reports the link itself, not its target, so a link is never descended into.
+ *
+ * Not hypothetical in this repo: pnpm builds `node_modules` out of symlinks and
+ * `apps/web/node_modules/@bevel-software/*` links straight back into `packages/`.
+ */
 function walk(dir, out = []) {
   if (!existsSync(dir)) return out;
-  for (const entry of readdirSync(dir)) {
-    if (entry === 'node_modules' || entry === 'dist') continue;
-    const full = join(dir, entry);
-    if (statSync(full).isDirectory()) walk(full, out);
-    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.isSymbolicLink()) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(full);
   }
   return out;
 }


### PR DESCRIPTION
`statSync` **follows** links, so the ratchet's directory walk had two failure modes: a link pointing at any ancestor recurses forever, and a link pointing outside the scanned tree silently widens the scan. Either way the gate stops being a gate — it either hangs CI or counts files it was never meant to see.

Not hypothetical in this repo: pnpm builds `node_modules` out of symlinks, and `apps/web/node_modules/@bevel-software/*` links straight back into `packages/`. The `node_modules` name check happens to catch that one today, which is exactly the kind of accident worth not relying on.

`readdirSync(..., { withFileTypes: true })` reports the link itself rather than its target, so `entry.isDirectory()` is false for a link and it is never descended into.

Counts are unchanged on this tree (215, same six rules) — that is the point: behaviour-preserving here, and no longer dependent on the shape of the tree it is pointed at.

Found by CodeRabbit on the counterpart script in `bevel-platform`, which was ported from this one and carried the same bug. Fixed there in [bevel-platform#296](https://github.com/Bevel-Software/bevel-platform/pull/296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved design-system scanning to safely skip symbolic links and avoid unintended directory traversal.
  * Preserved existing exclusions for dependency and build-output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->