### PR TITLE
Fix SPDX policy bypass, per-version attribution and CRLF non-determinism

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Vendored licence texts are compared byte-for-byte against the licence files
+# packages ship (which are LF), so git must not rewrite their line endings on
+# checkout — CRLF here silently defeats the dedupe in
+# scripts/generate-license-notices.mjs.
+scripts/license-texts/*.txt text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ backups/
 tool-chain-spills/
 *.tsbuildinfo
 
-# Generated at build time by scripts/generate-license-notices.mjs. Not committed:
-# `pnpm licenses list` reports the optional platform binaries installed on the
-# current host, so a checked-in copy would read as dirty on any other OS.
+# Generated at build time by scripts/generate-license-notices.mjs. A ~500 KB
+# build artifact fully derived from the lockfile; generating it in the same step
+# that ships it keeps it matching the artifact. The output is deterministic
+# across platforms, so committing it with a drift check is a viable alternative.
 THIRD-PARTY-NOTICES.md

--- a/scripts/generate-license-notices.mjs
+++ b/scripts/generate-license-notices.mjs
@@ -16,11 +16,13 @@
  * (see DENIED), because a build that would ship GPL/AGPL code must not
  * succeed. `--check` is the same gate without the writes, for PR CI.
  *
- * Deliberately NOT committed to git (see .gitignore). `pnpm licenses list`
- * reports the optional platform binaries that are installed on the CURRENT
- * host — @esbuild/win32-x64 here, @esbuild/linux-x64 in CI — so a committed
- * copy would show as dirty on whichever machine did not generate it. Always
- * generating means the file always matches the artifact being shipped.
+ * Not committed to git (see .gitignore): it is a ~500 KB build artifact fully
+ * derived from the lockfile, and generating it in the same step that ships it
+ * guarantees it describes the artifact actually being shipped. The output IS
+ * deterministic — byte-identical on Windows and Linux for the same lockfile —
+ * so committing it with a drift check is a viable alternative if the file is
+ * ever wanted in review. That determinism depends on `normalise()` below;
+ * without it, line endings alone changed the output between platforms.
  *
  * Usage:
  *   node scripts/generate-license-notices.mjs         # write notice files
@@ -99,10 +101,99 @@ function readLicenseData(filter) {
 }
 
 /**
- * Reduce an SPDX-ish expression to the single licence we ship under.
- * `A OR B` elects the most permissive allowed option; `A AND B` requires all
- * of them to be allowed and keeps the conjunction.
+ * Parse an SPDX expression into a tree. Splitting on OR/AND textually cannot
+ * work: `(MIT OR X) AND GPL-3.0-only` would match MIT and drop the mandatory
+ * GPL term entirely, letting copyleft through the gate. OR binds looser than
+ * AND in SPDX, so the grammar is
+ *   expr := and ( 'OR' and )* ;  and := term ( 'AND' term )* ;
+ *   term := IDENT | '(' expr ')'
+ * Returns null on anything it cannot parse, so callers fail closed.
  */
+function parseSpdx(expression) {
+  const tokens = expression.match(/\(|\)|[^\s()]+/g) ?? [];
+  let pos = 0;
+  const peek = () => tokens[pos];
+  const isOp = (word) => (peek() ?? '').toUpperCase() === word;
+
+  const parseExpr = () => {
+    const options = [parseAnd()];
+    while (isOp('OR')) {
+      pos += 1;
+      options.push(parseAnd());
+    }
+    return options.length === 1 ? options[0] : { op: 'OR', children: options };
+  };
+
+  const parseAnd = () => {
+    const parts = [parseTerm()];
+    while (isOp('AND')) {
+      pos += 1;
+      parts.push(parseTerm());
+    }
+    return parts.length === 1 ? parts[0] : { op: 'AND', children: parts };
+  };
+
+  const parseTerm = () => {
+    if (peek() === '(') {
+      pos += 1;
+      const inner = parseExpr();
+      if (peek() !== ')') return null;
+      pos += 1;
+      return inner;
+    }
+    const word = peek();
+    if (!word || word === ')' || isOp('AND') || isOp('OR')) return null;
+    pos += 1;
+    // `GPL-2.0+` and `... WITH Classpath-exception` attach to the preceding id.
+    if ((peek() ?? '').toUpperCase() === 'WITH') {
+      pos += 2;
+      return { id: `${word} WITH ${tokens[pos - 1]}` };
+    }
+    return { id: word };
+  };
+
+  const tree = parseExpr();
+  if (!tree || pos !== tokens.length) return null;
+  return tree;
+}
+
+/**
+ * Walk the tree bottom-up. A leaf is shippable only if it is allow-listed and
+ * not denied; AND requires EVERY operand (so a denied operand always sinks the
+ * whole node); OR picks the allowed branch that ranks most permissive. `rank`
+ * is the index into ALLOWED, so lower is more permissive.
+ */
+function evaluate(node) {
+  if (node.id) {
+    const ok = ALLOWED.includes(node.id) && !DENIED.test(node.id);
+    return { ok, license: node.id, rank: ALLOWED.indexOf(node.id), denied: DENIED.test(node.id) };
+  }
+
+  const results = node.children.map(evaluate);
+
+  if (node.op === 'AND') {
+    const ok = results.every((r) => r.ok);
+    return {
+      ok,
+      license: results.map((r) => r.license).join(' AND '),
+      rank: Math.max(...results.map((r) => r.rank)),
+      denied: results.some((r) => r.denied),
+    };
+  }
+
+  const viable = results.filter((r) => r.ok).sort((a, b) => a.rank - b.rank);
+  if (viable.length) return viable[0];
+  return {
+    ok: false,
+    license: results.map((r) => r.license).join(' OR '),
+    rank: -1,
+    // Only a denial if EVERY branch is denied — an unrecognised alternative
+    // means we simply could not classify it, which is a different problem.
+    denied: results.every((r) => r.denied),
+  };
+}
+
+/** Reduce an SPDX expression to the single licence we ship the package under. */
 function elect(expression, pkgName) {
   const raw = (expression ?? '').trim();
   if (!raw || raw === 'Unknown') {
@@ -112,27 +203,18 @@ function elect(expression, pkgName) {
       : { license: 'UNKNOWN', unresolved: true };
   }
 
-  const bare = raw.replace(/^\(|\)$/g, '').trim();
+  const tree = parseSpdx(raw);
+  if (!tree) return { license: raw, unresolved: true };
 
-  if (/\sOR\s/i.test(bare)) {
-    const options = bare.split(/\s+OR\s+/i).map((o) => o.trim());
-    for (const preferred of ALLOWED) {
-      if (options.includes(preferred)) {
-        return { license: preferred, note: `elected from \`${raw}\`` };
-      }
-    }
-    return { license: raw, denied: true };
+  const result = evaluate(tree);
+  if (!result.ok) {
+    return result.denied ? { license: raw, denied: true } : { license: raw, unresolved: true };
   }
 
-  if (/\sAND\s/i.test(bare)) {
-    const parts = bare.split(/\s+AND\s+/i).map((p) => p.trim());
-    const bad = parts.filter((p) => DENIED.test(p) || !ALLOWED.includes(p));
-    return bad.length ? { license: raw, denied: true } : { license: bare };
-  }
-
-  if (DENIED.test(bare)) return { license: bare, denied: true };
-  if (!ALLOWED.includes(bare)) return { license: bare, unresolved: true };
-  return { license: bare };
+  const normalised = raw.replace(/^\((.*)\)$/, '$1').trim();
+  return result.license === normalised
+    ? { license: result.license }
+    : { license: result.license, note: `elected from \`${raw}\`` };
 }
 
 /**
@@ -143,9 +225,21 @@ function elect(expression, pkgName) {
  */
 const BOILERPLATE = new Set(['Apache-2.0', 'MPL-2.0']);
 
+/**
+ * Licence texts are deduplicated by exact content, so line endings decide
+ * whether two copies of the same licence collapse into one block. They vary for
+ * reasons that have nothing to do with the licence: packages ship whichever
+ * ending their author committed, and git's autocrlf rewrites our own vendored
+ * texts to CRLF on a Windows checkout — which stopped them matching the LF
+ * copies shipped inside packages and emitted the same Apache-2.0 text twice.
+ * Normalising on read makes the dedupe content-correct and the output
+ * byte-identical on every platform.
+ */
+const normalise = (text) => text.replace(/\r\n/g, '\n').trim();
+
 const canonicalText = (license) => {
   try {
-    return readFileSync(join(ROOT, 'scripts', 'license-texts', `${license}.txt`), 'utf8').trim();
+    return normalise(readFileSync(join(ROOT, 'scripts', 'license-texts', `${license}.txt`), 'utf8'));
   } catch {
     return null;
   }
@@ -155,7 +249,7 @@ function readFileIfPresent(pkgPath, file) {
   try {
     const full = join(pkgPath, file);
     if (!statSync(full).isFile()) return null;
-    return readFileSync(full, 'utf8').trim() || null;
+    return normalise(readFileSync(full, 'utf8')) || null;
   } catch {
     return null;
   }
@@ -204,26 +298,40 @@ function readLicenseText(pkgPath, license) {
   return { text, synthesised };
 }
 
-/** Flatten pnpm's licence->packages map into one record per package. */
+/**
+ * Flatten pnpm's licence->packages map into one record per RESOLVED VERSION.
+ * pnpm reports `versions` and `paths` as parallel arrays, and 19 packages in
+ * this tree resolve to more than one version. Collapsing them into a single
+ * record would attribute every version using the licence file of whichever one
+ * happened to come first — and versions legitimately differ in copyright year,
+ * holder, or licence outright.
+ */
 function collect(data) {
   const packages = [];
   for (const [expression, entries] of Object.entries(data)) {
     for (const entry of entries) {
       const verdict = elect(expression === 'Unknown' ? null : expression, entry.name);
-      const { text, synthesised } = readLicenseText((entry.paths ?? [])[0] ?? '', verdict.license);
-      packages.push({
-        name: entry.name,
-        version: (entry.versions ?? []).join(', '),
-        declared: expression,
-        homepage: entry.homepage ?? '',
-        author: typeof entry.author === 'string' ? entry.author : '',
-        text,
-        synthesised,
-        ...verdict,
-      });
+      const versions = entry.versions ?? [];
+      const paths = entry.paths ?? [];
+      // Pair by index; fall back so a malformed entry still yields one record.
+      const count = Math.max(versions.length, paths.length, 1);
+
+      for (let i = 0; i < count; i += 1) {
+        const { text, synthesised } = readLicenseText(paths[i] ?? paths[0] ?? '', verdict.license);
+        packages.push({
+          name: entry.name,
+          version: versions[i] ?? versions.join(', '),
+          declared: expression,
+          homepage: entry.homepage ?? '',
+          author: typeof entry.author === 'string' ? entry.author : '',
+          text,
+          synthesised,
+          ...verdict,
+        });
+      }
     }
   }
-  return packages.sort((a, b) => a.name.localeCompare(b.name));
+  return packages.sort((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
 }
 
 function render(title, packages) {

--- a/scripts/license-texts/Apache-2.0.txt
+++ b/scripts/license-texts/Apache-2.0.txt
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2012-present   SheetJS LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Follow-up to #50. Three defects — two of them surfaced by actually building the Docker image and diffing its output against a local run, which #50 shipped without.

## 1. The licence gate could be bypassed 🔴

`elect()` tested for `OR` before `AND` and split the expression textually. After `replace(/^\(|\)$/g,'')` stripped the outer parens, the OR-split matched an allowed term out of the *middle* of a conjunction:

```
(MIT OR X) AND GPL-3.0-only   ->  ALLOW, elected MIT
```

The mandatory `GPL-3.0-only` term was dropped entirely. Replaced with a recursive-descent SPDX parser (`expr := and ('OR' and)*`, `and := term ('AND' term)*`, `term := IDENT | '(' expr ')'`) and a bottom-up evaluator: AND requires **every** operand, OR picks the lowest-ranked allowed branch, unparseable input fails closed as `unresolved`.

| expression | before | after |
| --- | --- | --- |
| `(MIT OR X) AND GPL-3.0-only` | ALLOW → MIT | **DENIED** |
| `(MIT OR GPL-3.0-only) AND GPL-3.0-only` | ALLOW → MIT | **DENIED** |
| `MIT AND (GPL-3.0-only OR Apache-2.0)` | ALLOW → Apache-2.0 *(MIT dropped)* | ALLOW → `MIT AND Apache-2.0` |
| `((MIT OR ISC) AND Apache-2.0) OR GPL-3.0-only` | — | ALLOW → `MIT AND Apache-2.0` |
| `MIT OR GPL-3.0-or-later` | ALLOW → MIT | ALLOW → MIT *(unchanged)* |

12/12 cases pass. No package in the current tree used a nested expression, so nothing was actually mis-shipped — this was a latent hole in a safety mechanism.

## 2. Multi-version packages were under-attributed

pnpm reports `versions` and `paths` as parallel arrays, and **19 packages here resolve to more than one version** (I verified 0 length mismatches tree-wide, so index pairing is safe). `collect()` joined the versions into one string and read the licence text from `paths[0]`, so all three `@ai-sdk/provider` versions were attributed from whichever came first. Now one record per version/path pair:

```
- **@ai-sdk/provider@1.1.3**    - **zod@3.25.76**    - **cookie@0.7.2**
- **@ai-sdk/provider@3.0.10**   - **zod@4.4.3**      - **cookie@1.1.1**
- **@ai-sdk/provider@3.0.14**
```

Record count 488 → 510.

## 3. Output was not deterministic across platforms

Licence texts are deduped by exact content, and git's `autocrlf` rewrote our vendored canonical texts to CRLF on a Windows checkout (11523 bytes / 201 CRLF vs the LF copies packages ship at 11355 bytes / 0 CRLF). They stopped matching, so the same Apache-2.0 text was emitted **twice** and CRLF leaked into the output.

`normalise()` strips CRLF on read so the dedupe is content-correct, and `.gitattributes` pins `scripts/license-texts/*.txt` to `eol=lf` so git cannot reintroduce it. Windows and Linux now produce byte-identical output — `sha 5fddf636bb76d1ae`, 517563 bytes, 0 CRLF, verified by extracting the file from the built image and hashing both.

Legally this was cosmetic (every notice was present and correct), but it broke the determinism property #50 claimed.

## Also: SheetJS's copyright was in our canonical Apache text

The vendored `Apache-2.0.txt` was taken from `xlsx`, which had substituted `Copyright (C) 2012-present   SheetJS LLC` into the appendix boilerplate. Restored the official `Copyright [yyyy] [name of copyright owner]`. **#50's verification missed this because the regex was case-sensitive** (`Copyright \(c\) 20`), so the claim there that the vendored texts were "pure boilerplate with no embedded copyright holder" was wrong for Apache-2.0. MPL-2.0.txt re-checked and is genuinely clean.

Correct knock-on: the canonical text no longer byte-matches xlsx's own LICENSE, so xlsx regains its own text block and the SheetJS copyright now appears exactly once, attached to their package where it belongs.

> Minor: the appendix preamble in this copy says fields are enclosed by brackets `"{}"` while the official ASF text says `"[]"`, so it is now slightly inconsistent with the `[yyyy]` placeholder. Left as-is to keep the change minimal — happy to align it.

## And a correction to #50's rationale

#50 justified gitignoring the notices by claiming `pnpm licenses list` reports host-specific optional binaries. **That was wrong** — those are devDependencies, excluded by `--prod`; the package lists are identical on both platforms. The real reason to leave it uncommitted is simply that it is a generated ~500 KB artifact. Comments in the script and `.gitignore` are corrected, and both now note that committing it with a drift check is a viable alternative given the output is deterministic.

## Verification

- SPDX parser: 12/12 cases, including the reproduced bypass
- `pnpm run notices` clean across all four trees; `eslint` clean
- Docker image rebuilt (exit 0); notices extracted from it and hashed against the local run → **byte-identical**
- Multi-version splitting and the Apache placeholder confirmed in the generated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
