### PR TITLE
Dev

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/src/core/registry.ts
+++ b/packages/core-frontend/src/core/registry.ts
@@ -306,6 +306,26 @@ export interface AppRegistry {
    * neither is provided the FileViewer hides its suggested-prompt buttons.
    */
   suggestedPromptSeed?: (prompt: string) => void;
+  /**
+   * Where the welcome page's exits go, and what the secondary one is called.
+   *
+   * The welcome page ends by sending a new person somewhere they can start,
+   * and WHERE that is, is a property of the product rather than of the page.
+   * Core sends them to their own skills shelf, because on a core deployment
+   * that is the product and a fresh knowledge base is empty. A distribution
+   * whose centre of gravity is the knowledge graph wants the opposite, and
+   * would otherwise greet every new user and then leave them in a surface
+   * they did not come for.
+   *
+   * Both exits use the value, so they cannot drift apart. A pending deep link
+   * still outranks it — someone who followed a link is owed that link, and
+   * onboarding must never eat an intention.
+   *
+   * The label travels WITH the path deliberately: "Go to your skills →"
+   * pointing at a knowledge base is a lie, and a caller changing one without
+   * the other is the likeliest way to produce it.
+   */
+  welcomeExit?: { path: string; label: string };
 }
 
 export const EMPTY_REGISTRY: AppRegistry = {

--- a/packages/core-frontend/src/modules/onboarding/__tests__/onboarding.test.tsx
+++ b/packages/core-frontend/src/modules/onboarding/__tests__/onboarding.test.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from '../../auth/state/auth.context';
 import { authValue } from '../../library/__tests__/auth-harness';
 import { LibraryToastProvider } from '../../library/state/toast';
 import { WelcomePage } from '../components/WelcomePage';
+import { AppRegistryContext, EMPTY_REGISTRY } from '../../../core/registry';
 import { ConnectAgentPill } from '../components/ConnectAgentPill';
 import { RootLanding } from '../components/RootLanding';
 import { POST_LOGIN_REDIRECT_KEY } from '../../auth/services/sso';
@@ -453,6 +454,78 @@ describe('WelcomePage', () => {
       expect.objectContaining({ method: 'POST' }),
     );
     expect(screen.getByTestId('pathname')).toHaveTextContent(DEEP);
+  });
+
+  /**
+   * `AppRegistry.welcomeExit` moves where a new person starts. WHERE that is,
+   * is a property of the product: core sends them to their own skills shelf,
+   * because on a core deployment that is the product and a fresh knowledge
+   * base is empty. A distribution built around the knowledge graph wants the
+   * opposite and would otherwise greet someone and then leave them in a
+   * surface they did not come for.
+   *
+   * The tests above deliberately mount WITHOUT a registry, so they pin the
+   * default: the seam must be invisible to a deployment that does not use it.
+   */
+  describe('welcomeExit', () => {
+    const mountWithExit = (
+      welcomeExit: { path: string; label: string } | undefined,
+      // Same shape `mount` accepts — `typeof greeted` would pin `state` to
+      // `{ greeting: boolean }` and reject the deep-link case below.
+      route: string | { pathname: string; state?: unknown } = greeted,
+    ) =>
+      mount(
+        <AppRegistryContext.Provider value={{ ...EMPTY_REGISTRY, welcomeExit }}>
+          <Routes>
+            <Route path={WELCOME_PATH} element={<WelcomePage />} />
+            <Route path="/skills-and-tools/yours" element={<div>your group</div>} />
+            <Route path="/workspace" element={<div>knowledge</div>} />
+          </Routes>
+        </AppRegistryContext.Provider>,
+        newUser(),
+        route,
+      );
+
+    it('sends both exits to the configured destination', async () => {
+      mountWithExit({ path: '/workspace', label: 'Go to your knowledge base' });
+      await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/workspace');
+    });
+
+    /**
+     * The label travels WITH the path. "Go to your skills →" pointing at a
+     * knowledge base is a lie, and letting a caller set one without the other
+     * is the likeliest way to produce it.
+     */
+    it('labels the skip link with the configured destination', () => {
+      mountWithExit({ path: '/workspace', label: 'Go to your knowledge base' });
+      expect(
+        screen.getByRole('button', { name: /Go to your knowledge base/ }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Go to your skills/ })).not.toBeInTheDocument();
+    });
+
+    it('falls back to the skills shelf when a registry sets nothing', async () => {
+      mountWithExit(undefined);
+      expect(screen.getByRole('button', { name: /Go to your skills/ })).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+      expect(screen.getByTestId('pathname')).toHaveTextContent('/skills-and-tools/yours');
+    });
+
+    /**
+     * A deep link still outranks it. Someone who followed a link is owed that
+     * link, and no amount of deployment configuration may eat an intention.
+     */
+    it('does not override a carried deep link', async () => {
+      const DEEP = '/workspace/main/knowledge-base/KnowledgeBase/Start here.md';
+      mountWithExit(
+        { path: '/skills-and-tools/yours', label: 'Go to your skills' },
+        { pathname: WELCOME_PATH, state: { greeting: true, returnTo: DEEP } },
+      );
+      expect(screen.getByRole('button', { name: /Continue to your link/ })).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+      expect(screen.getByTestId('pathname')).toHaveTextContent(DEEP);
+    });
   });
 });
 

--- a/packages/core-frontend/src/modules/onboarding/components/WelcomePage.tsx
+++ b/packages/core-frontend/src/modules/onboarding/components/WelcomePage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '../../auth/state/auth.context';
 import { useLibraryToast } from '../../library/state/toast.context';
 import { copyToClipboard, COPY_FAILED_TOAST } from '../../library/utils/clipboard';
 import { pathForLibraryFilter } from '../../library/routes/library-paths';
+import { useAppRegistry } from '../../../core/registry';
 import { displayFirstName } from '../../library/utils/personal-group';
 import { setSidebarCollapsed } from '../../layout/state/sidebar';
 import { AGENT_CLIENTS, mcpUrlFromOrigin, type AgentClient } from '../agent-clients';
@@ -214,12 +215,20 @@ export function WelcomePage() {
     resetTimer.current = window.setTimeout(() => setCopied('idle'), 1500);
   }
 
-  // Both exits land in the same place — the person's own group. Whether you
-  // connected an agent or walked past it, where you want to be next is your
-  // own shelf, not the whole company's catalog. Unless a deep link brought
-  // them here: then both exits keep its promise instead.
-  const yourGroup = pathForLibraryFilter({ kind: 'ungrouped' });
-  const exitTo = returnTo ?? yourGroup;
+  // Both exits land in the same place. Whether you connected an agent or
+  // walked past it, where you want to be next is somewhere you can start —
+  // by default your own shelf, not the whole company's catalog. A deep link
+  // still outranks it: someone who followed a link is owed that link.
+  //
+  // `welcomeExit` lets a distribution move that destination, because WHERE a
+  // new person should start is a property of the product. A deployment built
+  // around the knowledge graph would otherwise greet someone and then leave
+  // them in a surface they did not come for. The label travels with the path
+  // so the two cannot contradict each other.
+  const { welcomeExit } = useAppRegistry();
+  const defaultExit = { path: pathForLibraryFilter({ kind: 'ungrouped' }), label: 'Go to your skills' };
+  const exit = welcomeExit ?? defaultExit;
+  const exitTo = returnTo ?? exit.path;
 
   /**
    * Conclude the onboarding and leave. The toast says where the setup went,
@@ -346,16 +355,17 @@ export function WelcomePage() {
             Done
           </Button>
           {/* The same destination Done goes to — one value drives both exits,
-              so they cannot drift apart. Ordinarily that is your own shelf
-              ("your skills" over "your library": the library is the whole
-              company's); when a deep link brought you here, both exits keep
-              its promise instead, and the label says so. */}
+              so they cannot drift apart. Ordinarily that is wherever the
+              deployment says a new person should start (core: your own shelf
+              — "your skills" over "your library", since the library is the
+              whole company's); when a deep link brought you here, both exits
+              keep its promise instead, and the label says so. */}
           <button
             type="button"
             onClick={() => navigate(exitTo)}
             className="text-detail text-ink-faint transition-colors hover:text-ink"
           >
-            {returnTo ? 'Continue to your link →' : 'Go to your skills →'}
+            {returnTo ? 'Continue to your link →' : `${exit.label} →`}
           </button>
         </div>
       </div>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Welcome pages can now use a configured destination and custom label for their exit link.
  - Deep-link destinations continue to take priority when available.
  - A default skills destination remains available when no custom exit is configured.

- **Bug Fixes**
  - Exit navigation labels now accurately reflect the configured destination instead of always showing the default wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->