### PR TITLE
Let the deployment owner repair roles.yaml

### DIFF
--- a/docs/hero-dark.svg
+++ b/docs/hero-dark.svg
@@ -6,8 +6,8 @@
     </radialGradient>
   </defs>
 
-  <rect width="1600" height="400" fill="#0d1117"/>
-  <rect width="1600" height="400" fill="url(#glow)"/>
+  <rect width="1600" height="400" rx="28" fill="#0d1117"/>
+  <rect width="1600" height="400" rx="28" fill="url(#glow)"/>
 
   <!-- logo tile + wordmark -->
   <rect x="124" y="100" width="96" height="96" rx="22" fill="#1b76d0"/>

--- a/docs/hero-light.svg
+++ b/docs/hero-light.svg
@@ -6,8 +6,8 @@
     </radialGradient>
   </defs>
 
-  <rect width="1600" height="400" fill="#ffffff"/>
-  <rect width="1600" height="400" fill="url(#glow)"/>
+  <rect width="1600" height="400" rx="28" fill="#ffffff"/>
+  <rect width="1600" height="400" rx="28" fill="url(#glow)"/>
 
   <!-- logo tile + wordmark -->
   <rect x="124" y="100" width="96" height="96" rx="22" fill="#1b76d0"/>

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -235,7 +235,15 @@ export async function createCoreServices(
   // Shared, workspace-independent store for oversized `call_tool_chain` results,
   // read back via `read_file`. Sibling of `workspacesRoot`, never committed.
   const spillStore = new SpillStore(config.spillRoot);
-  const accessControl = new AccessControlService(workspaceService, kbDirName);
+  // The deployment owner counts as Admin for the two hardcoded `write`
+  // rescues (`roles.yaml` and any `access.md`) — the SAME list
+  // `AdminAccessService` below is given, so the admin surfaces and the write
+  // gate cannot disagree about who the owner is. They did: the owner could
+  // open Roles & Members and then be refused the save, with the UI showing
+  // them as an admin and the gate saying "Eligible: Admin".
+  const accessControl = new AccessControlService(workspaceService, kbDirName, [
+    config.adminEmail,
+  ]);
   // Creator read-grant on creation: read is default-deny, so every surface
   // that creates KB files/folders (human routes, agent tools, upload apply)
   // consults this planner to keep creations visible to their creator.

--- a/packages/core-backend/src/modules/access/__tests__/access-control.service.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.service.test.ts
@@ -1008,4 +1008,76 @@ describe('AccessControlService', () => {
       });
     });
   });
+
+  /**
+   * The deployment owner (`ADMIN_EMAIL`) as a rescue path.
+   *
+   * `roles.yaml` is Admin-only by a hardcoded rule, and "Admin" used to mean
+   * the `Admin` role in `roles.yaml` and nothing else. That makes the file
+   * self-sealing: a roles.yaml that loses its last Admin — a bad merge, a
+   * renamed address, a restored backup — can then be repaired only by
+   * committing to the KB repo by hand, because the one file that decides who
+   * may fix it is the one file nobody may write.
+   *
+   * It also disagreed with `AdminAccessService`, which was already given the
+   * same owner list: the owner saw every admin surface and was refused the
+   * save, with the UI calling them an admin and the gate answering
+   * "Eligible: Admin".
+   */
+  describe('deployment owner (ADMIN_EMAIL)', () => {
+    const OWNER = 'owner@bevel.software';
+    /** roles.yaml with an Admin that is NOT the deployment owner. */
+    const ROLES_WITHOUT_OWNER = `roles:
+  Admin:
+    - someone-else@example.com
+`;
+
+    async function seeded() {
+      const { workspaceDir, repo } = await seedWorkspace(root, workspaceId);
+      await writeFile(repo, 'roles.yaml', ROLES_WITHOUT_OWNER);
+      await writeFile(repo, 'access.md', '---\nwrite:\n  - Admin\n---\n');
+      return stubWorkspaceService(workspaceId, workspaceDir);
+    }
+
+    it('may write roles.yaml even when roles.yaml does not list them', async () => {
+      const ws = await seeded();
+      const svc = new AccessControlService(ws, PROCESS_MAP_DIR, [OWNER]);
+      expect(await svc.canWrite(workspaceId, OWNER, 'roles.yaml')).toBe(true);
+    });
+
+    it('may write an access.md — the same rescue the Admin role gets', async () => {
+      const ws = await seeded();
+      const svc = new AccessControlService(ws, PROCESS_MAP_DIR, [OWNER]);
+      expect(await svc.canWrite(workspaceId, OWNER, 'Knowledge/access.md')).toBe(true);
+    });
+
+    /**
+     * The rescue is exactly two files wide. It is not a general grant: the
+     * owner is admitted to the hardcoded `write` overrides and to nothing
+     * else, so ordinary content still answers to the access tree.
+     */
+    it('gets no ordinary write from being the owner', async () => {
+      const ws = await seeded();
+      const svc = new AccessControlService(ws, PROCESS_MAP_DIR, [OWNER]);
+      expect(await svc.canWrite(workspaceId, OWNER, 'Knowledge/Foo.md')).toBe(false);
+    });
+
+    it('is matched case-insensitively, like every other email here', async () => {
+      const ws = await seeded();
+      const svc = new AccessControlService(ws, PROCESS_MAP_DIR, ['OWNER@Bevel.Software']);
+      expect(await svc.canWrite(workspaceId, OWNER, 'roles.yaml')).toBe(true);
+    });
+
+    /**
+     * Unconfigured, nothing changes — which is what keeps every other test in
+     * this file (and every fixture that constructs the service with two
+     * arguments) meaningful.
+     */
+    it('changes nothing when no owner is configured', async () => {
+      const ws = await seeded();
+      const svc = new AccessControlService(ws, PROCESS_MAP_DIR);
+      expect(await svc.canWrite(workspaceId, OWNER, 'roles.yaml')).toBe(false);
+      expect(await svc.canWrite(workspaceId, 'someone-else@example.com', 'roles.yaml')).toBe(true);
+    });
+  });
 });

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -188,6 +188,20 @@ interface RolesIndex {
 interface AccessModel {
   roles: RolesIndex;
   accessFilesByDir: Map<string, AccessFile>;
+  /**
+   * Canonical emails that count as Admin whatever `roles.yaml` says — the
+   * deployment owner (`ADMIN_EMAIL`). Empty when none is configured.
+   *
+   * This exists for the two hardcoded `write` rescues below, and only those.
+   * It is NOT a general grant: it never enters scope resolution, so it gives
+   * no read, no download, and no write anywhere except `roles.yaml` and
+   * `access.md`. The deployment owner is the person who can already change
+   * `ADMIN_EMAIL` itself, so admitting them to the rescue path concedes
+   * nothing they could not already take — while withholding it turns a
+   * `roles.yaml` that has lost its last Admin into a knowledge base nobody
+   * can repair through the app.
+   */
+  deploymentOwners: ReadonlySet<string>;
 }
 
 function isBuiltInRole(canonicalRole: string): boolean {
@@ -791,6 +805,7 @@ function resolveAtPath(
 }
 
 function isAdminEmail(model: AccessModel, email: string): boolean {
+  if (model.deploymentOwners.has(email)) return true;
   const roles = model.roles.byEmail.get(email);
   return !!roles && roles.has(ADMIN_CANONICAL);
 }
@@ -816,6 +831,15 @@ function isAdminEmail(model: AccessModel, email: string): boolean {
  *     itself excludes them or fails to parse cleanly. These are the rescue
  *     mechanism for the rest of the tree — without this, a typo in
  *     `access.md` could permanently lock admins out of fixing it.
+ *
+ * "Admin" for BOTH rescues means the `Admin` role in `roles.yaml` OR the
+ * deployment owner (`ADMIN_EMAIL`). Without the second, the first rule turns
+ * into the lockout it exists to prevent: a `roles.yaml` that has lost its last
+ * Admin — a bad merge, a renamed address, a restored backup — can then be
+ * repaired only by committing to the KB repo by hand, because the one file
+ * that decides who may fix it is the one file nobody may write. The deployment
+ * owner is whoever can already set `ADMIN_EMAIL`, so this concedes no
+ * authority they did not have; it only gives it a door.
  *
  * No special-cases for `read`/`download` — they fall through to scope resolution.
  */
@@ -1167,10 +1191,28 @@ export class AccessControlService implements IAccessControl {
   >();
   private static readonly OWN_ENTRIES_TTL_MS = 5 * 60_000;
 
+  /**
+   * Canonicalised deployment-owner emails (see `AccessModel.deploymentOwners`).
+   * Held on the service rather than read per-model because it comes from the
+   * environment, not from the knowledge base.
+   */
+  private readonly deploymentOwners: ReadonlySet<string>;
+
   constructor(
     private readonly workspaceService: WorkspaceService,
     private readonly kbDirName: string,
-  ) {}
+    /**
+     * Emails that count as Admin for the two hardcoded `write` rescues,
+     * whatever `roles.yaml` says — in practice `ADMIN_EMAIL`. Optional so the
+     * many test fixtures that construct this service directly keep their
+     * current behaviour (no owner, roles.yaml is the only authority).
+     */
+    deploymentOwners: readonly string[] = [],
+  ) {
+    this.deploymentOwners = new Set(
+      deploymentOwners.filter(Boolean).map((e) => canonicalEmail(e)),
+    );
+  }
 
   /**
    * Drop a workspace's cached model + frontmatter memo. Call after operations
@@ -1642,6 +1684,7 @@ export class AccessControlService implements IAccessControl {
     const model: AccessModel = {
       roles: rolesParsed.index,
       accessFilesByDir: accessFiles,
+      deploymentOwners: this.deploymentOwners,
     };
     this.cache.set(workspaceId, { model, loadedAt: Date.now() });
     return model;
@@ -1885,6 +1928,11 @@ export class AccessControlService implements IAccessControl {
       model: {
         roles: rolesParsed.index,
         accessFilesByDir: accessFiles,
+        // Same owners as the working-tree model. The at-ref model backs the
+        // PUSH gate, so omitting them here would let the deployment owner save
+        // a roles.yaml repair locally and then be refused when it tries to
+        // land — the lockout moved one step later, not removed.
+        deploymentOwners: this.deploymentOwners,
       },
       resolvedRef,
     };

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## The report

> "I can see all of the admin only tabs, just the role one says I don't have permission which makes no sense"

It makes sense, and it is a bug: there were **two notions of admin** and they disagreed silently.

- The admin **surfaces** come from `AdminAccessService`, which is handed `[config.adminEmail]` with the comment *"the deployment owner administers accounts/roles even before the KB's roles.yaml lists them."*
- The **write gate** for `roles.yaml` is a separate hardcoded rule in `access-control.service.ts`, where "Admin" meant the `Admin` role in `roles.yaml` **and nothing else**.

So the owner sees every admin tab, opens Roles & Members, and is refused the save with *"You don't have permission to write to roles.yaml. Eligible: Admin."*

## Why it matters beyond the confusion

It makes `roles.yaml` **self-sealing**. A roles.yaml that loses its last Admin — a bad merge, a renamed address, a restored backup, a deployment repointed at a different knowledge base — can then be repaired **only by committing to the KB repo by hand**, because the one file that decides who may fix it is the one file nobody may write.

That is precisely the failure the neighbouring rescue already guards against for the rest of the tree:

> Any `access.md` file is always writable by admins, even if the file itself excludes them or fails to parse cleanly. These are the rescue mechanism for the rest of the tree — without this, a typo in… `access.md` could permanently lock admins out of fixing it.

## The change

Both now read the same owner list. The deployment owner counts as Admin for the **two hardcoded `write` rescues** — `roles.yaml` and any `access.md` — and for nothing else.

- `deploymentOwners` **never enters scope resolution**, so it confers no read, no download, and no write on ordinary content. There is a test pinning that boundary, because a rescue that quietly became a superuser would be a worse bug than the one being fixed.
- Applied to the **at-ref** model too, which backs the push gate — otherwise the owner could save a repair locally and be refused when it tried to land, moving the lockout one step later rather than removing it.
- The list is an **optional** constructor argument, so the ~15 access fixtures that construct the service directly keep `roles.yaml` as their only authority. One new test pins that unconfigured behaviour.

This concedes no authority: whoever can set `ADMIN_EMAIL` already controls the deployment. It only gives that authority a door.

## Verified, not assumed

Removing the one-line check fails **exactly** the three tests that assert the rescue and passes everything else.

## Gate

typecheck, build, **2411 tests** (1351 core-backend / 1060 core-frontend) and `ds:check` green. Released as **0.6.1** (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)