### PR TITLE
Dev

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/src/modules/review/components/MarkdownDiffViewer.tsx
+++ b/packages/core-frontend/src/modules/review/components/MarkdownDiffViewer.tsx
@@ -29,6 +29,23 @@ interface MarkdownDiffViewerProps {
   onOpenFile?: (href: string) => void;
   /** Same contract as {@link onOpenFile}, for bare node-id links. */
   onOpenNodeId?: (id: string) => void;
+  /**
+   * Whether this view owns a scroller and its own padding. `true` (the
+   * default) keeps the self-contained box the change-request dialog and the
+   * file-history panel rely on.
+   *
+   * Pass `false` when the PARENT is the scroller. The review panel is: a
+   * centred column whose CHILD scrolls leaves the gutters either side outside
+   * the scroll hit area, so the wheel does nothing over them. Making the
+   * panel-width parent scroll and putting the measure on an inner container
+   * fixes that — but only if this stops owning `overflow-auto`, since two
+   * nested `h-full overflow-auto` boxes leave the outer one unable to scroll
+   * and stack both paddings.
+   *
+   * Mirrors `KbMarkdownView.scroll`, for the same reason and with the same
+   * default.
+   */
+  scroll?: boolean;
 }
 
 /**
@@ -50,7 +67,7 @@ interface MarkdownDiffViewerProps {
  * routes, which sit outside those providers entirely. A `useNavigate()` in
  * here would be a runtime crash in all three.
  */
-export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId }: MarkdownDiffViewerProps) {
+export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId, scroll = true }: MarkdownDiffViewerProps) {
   const data = useMemo(() => {
     const baseline = payload.baseline ?? '';
     const current = payload.current ?? '';
@@ -96,7 +113,7 @@ export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId }: Markdo
   }
 
   return (
-    <div className="h-full overflow-auto bg-white px-4 py-3">
+    <div className={scroll ? 'h-full overflow-auto bg-white px-4 py-3' : 'min-w-0'}>
       {data.frontmatterChanged && (
         <FrontmatterDiffPanel
           oldData={data.oldFrontmatter}

--- a/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
@@ -7,8 +7,12 @@ import {
   useFileNav,
   useNodeIdNav,
   resolveRelativePath,
+  stripJunkBeforeKbDir,
   KB_ROUTE_PREFIX,
 } from '../../workspace/routing/kb-routes';
+import { groupOfPath } from '@bevel-software/platform-shared';
+import { cn } from '../../../lib/utils';
+import { DOCUMENT_COLUMN } from '../../../shared/theme/measure';
 import { ReviewFileRow } from './ReviewFileRow';
 import { DiffViewer } from './DiffViewer';
 import { MarkdownDiffViewer } from './MarkdownDiffViewer';
@@ -16,6 +20,31 @@ import { BinaryChangePlaceholder } from './BinaryChangePlaceholder';
 
 function isMarkdownPath(p: string): boolean {
   return /\.md$/i.test(p);
+}
+
+/**
+ * Whether a review-session path is a skill or tool — anything under `Groups/`.
+ *
+ * The paths in a review session are WORKSPACE-relative: the diff module
+ * resolves them against the workspace directory, so they arrive carrying the
+ * KB clone as their first segment (`knowledge-base/Groups/GTM/x/SKILL.md`).
+ * `groupOfPath` wants them REPO-relative, and `stripJunkBeforeKbDir` does not
+ * get there on its own — it only drops junk BEFORE the kb dir and keeps the
+ * segment itself, so it returns an already-well-formed path unchanged. Asking
+ * `groupOfPath` about the workspace-relative form gets `null` for every path,
+ * group or not, which is a check that silently never fires.
+ *
+ * Exported so it can be tested directly. The behaviour it guards lives behind
+ * a dropdown the component tests cannot open, and a first attempt at covering
+ * it through the UI passed with the guard deleted.
+ */
+export function isGroupItemPath(path: string, kbDirName: string | null): boolean {
+  const withoutJunk = stripJunkBeforeKbDir(path, kbDirName);
+  const repoRelative =
+    kbDirName && withoutJunk.startsWith(`${kbDirName}/`)
+      ? withoutJunk.slice(kbDirName.length + 1)
+      : withoutJunk;
+  return groupOfPath(repoRelative) !== null;
 }
 
 function basename(p: string): string {
@@ -46,7 +75,7 @@ function kindLabel(kind: PendingChange['kind']): string {
  */
 export function ReviewPanel({ onClose }: { onClose?: () => void }) {
   const review = useReview();
-  const { refreshFileTree } = useWorkspace();
+  const { refreshFileTree, kbDirName } = useWorkspace();
   const { openFile } = useFileNav();
   // Links inside a rendered diff. Both resolvers navigate relative to
   // `git.status.branch`, which is CORRECT here and only here: this panel
@@ -117,15 +146,27 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
     async (path: string) => {
       setPickerOpen(false);
       await selectPath(path);
-      // Also surface the file in the editor so the user can see context alongside
-      // the diff. Skip for deleted files — navigating to a missing path would
-      // land FileRoute on the file-not-found state.
+      // Also surface the file in the editor so the user can see context
+      // alongside the diff.
+      //
+      // Skipped in two cases, both of which take the reader somewhere they did
+      // not ask to go:
+      //   - a DELETED file: navigating to a missing path lands FileRoute on
+      //     the file-not-found state.
+      //   - anything under `Groups/`: a skill or tool file's canonical URL is
+      //     a LIBRARY location, so opening it switches the whole shell to the
+      //     Skills & Tools app — the panel, the diff and the rest of the
+      //     review vanish because you clicked a row in a list. The diff is
+      //     already on screen next to the row; that is the context this call
+      //     exists to provide, and for group items it is the only context
+      //     that can be shown without leaving.
       const change = session?.changes.find((c) => c.path === path);
-      if (change && change.kind !== 'deleted') {
+      const isGroupItem = isGroupItemPath(path, kbDirName);
+      if (change && change.kind !== 'deleted' && !isGroupItem) {
         openFile(path);
       }
     },
-    [selectPath, openFile, session],
+    [selectPath, openFile, session, kbDirName],
   );
 
   const withBusy = useCallback(
@@ -277,12 +318,38 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
         )}
         {!isLoadingDiff && fileDiff && !fileDiff.isBinary && (
           isMarkdownPath(fileDiff.path) ? (
-            <MarkdownDiffViewer
-              payload={fileDiff}
-              onOpenFile={openDiffLink}
-              onOpenNodeId={openNodeId}
-            />
+            // The measure, and ONLY the measure. `MarkdownDiffViewer` is fine
+            // as it is — it renders a self-contained box with its own scroller
+            // and padding, which is what the change-request dialog and file
+            // history want. What was wrong is this container: it handed that
+            // box the full width of the panel, so the very document that reads
+            // at an 880px line two clicks away arrived in the review surface
+            // as a wall of text.
+            //
+            // So the wrapper constrains width and nothing else. Not
+            // `documentGutters`, which bundles `pb-[110px]`: the scroller is
+            // the CHILD here, so that bottom rhythm would sit outside it as
+            // permanent dead space with the scroll ending short of the panel.
+            // Not `KbDocumentShell` either — it owns a scroller, a rail track
+            // and the file lock's scroll listener, none of which belong to a
+            // floating panel that has its own header and footer.
+            //
+            // The child's own `px-4` becomes the gutter, so the line lands at
+            // 848px against Knowledge's 800px — near enough that the two read
+            // as the same column, and bought without reaching into a component
+            // three surfaces share.
+            <div className={cn('h-full', DOCUMENT_COLUMN)}>
+              <MarkdownDiffViewer
+                payload={fileDiff}
+                onOpenFile={openDiffLink}
+                onOpenNodeId={openNodeId}
+              />
+            </div>
           ) : (
+            // Left full-bleed on purpose. This is the marked-SOURCE view for
+            // yaml, scripts and config, where a line is a line of code and
+            // wrapping it to a prose measure helps nobody — the same call
+            // `getRendererLayout` makes for those types in the file viewer.
             <DiffViewer payload={fileDiff} />
           )
         )}

--- a/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../workspace/routing/kb-routes';
 import { groupOfPath, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { cn } from '../../../lib/utils';
-import { DOCUMENT_COLUMN } from '../../../shared/theme/measure';
+import { DOCUMENT_COLUMN, documentGutters } from '../../../shared/theme/measure';
 import { ReviewFileRow } from './ReviewFileRow';
 import { DiffViewer } from './DiffViewer';
 import { MarkdownDiffViewer } from './MarkdownDiffViewer';
@@ -349,32 +349,37 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
         )}
         {!isLoadingDiff && fileDiff && !fileDiff.isBinary && (
           isMarkdownPath(fileDiff.path) ? (
-            // The measure, and ONLY the measure. `MarkdownDiffViewer` is fine
-            // as it is — it renders a self-contained box with its own scroller
-            // and padding, which is what the change-request dialog and file
-            // history want. What was wrong is this container: it handed that
-            // box the full width of the panel, so the very document that reads
-            // at an 880px line two clicks away arrived in the review surface
-            // as a wall of text.
+            // Panel-width SCROLLER, measured INNER column.
             //
-            // So the wrapper constrains width and nothing else. Not
-            // `documentGutters`, which bundles `pb-[110px]`: the scroller is
-            // the CHILD here, so that bottom rhythm would sit outside it as
-            // permanent dead space with the scroll ending short of the panel.
-            // Not `KbDocumentShell` either — it owns a scroller, a rail track
-            // and the file lock's scroll listener, none of which belong to a
-            // floating panel that has its own header and footer.
+            // The scroller has to be the outer box: when the centred column
+            // scrolled instead, the gutters either side sat outside its hit
+            // area and the wheel did nothing over them — a dead margin on
+            // exactly the wide screens the measure exists for.
             //
-            // The child's own `px-4` becomes the gutter, so the line lands at
-            // 848px against Knowledge's 800px — near enough that the two read
-            // as the same column, and bought without reaching into a component
-            // three surfaces share.
-            <div className={cn('h-full', DOCUMENT_COLUMN)}>
-              <MarkdownDiffViewer
-                payload={fileDiff}
-                onOpenFile={openDiffLink}
-                onOpenNodeId={openNodeId}
-              />
+            // With the outer scrolling, the inner column can carry the real
+            // Knowledge contract: `DOCUMENT_COLUMN` + `documentGutters`, which
+            // bundles the 40px sides AND the 110px bottom rhythm. Both now sit
+            // INSIDE the scroller, where they belong — the earlier version had
+            // to skip the gutters entirely because that bottom padding would
+            // have become permanent dead space below a child-owned scroll.
+            // The line lands at 800px, the same as the document two clicks
+            // away, rather than the 848px approximation.
+            //
+            // `scroll={false}` is what makes it possible: two nested
+            // `h-full overflow-auto` boxes leave the outer unable to scroll
+            // and stack both paddings.
+            //
+            // `roomy` is false — this panel covers the viewer, not the nav, so
+            // the file tree is still on screen beside it.
+            <div className="h-full overflow-auto bg-white">
+              <div className={cn(DOCUMENT_COLUMN, documentGutters(false))}>
+                <MarkdownDiffViewer
+                  payload={fileDiff}
+                  onOpenFile={openDiffLink}
+                  onOpenNodeId={openNodeId}
+                  scroll={false}
+                />
+              </div>
             </div>
           ) : (
             // Left full-bleed on purpose. This is the marked-SOURCE view for

--- a/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
@@ -10,7 +10,7 @@ import {
   stripJunkBeforeKbDir,
   KB_ROUTE_PREFIX,
 } from '../../workspace/routing/kb-routes';
-import { groupOfPath } from '@bevel-software/platform-shared';
+import { groupOfPath, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { cn } from '../../../lib/utils';
 import { DOCUMENT_COLUMN } from '../../../shared/theme/measure';
 import { ReviewFileRow } from './ReviewFileRow';
@@ -45,6 +45,41 @@ export function isGroupItemPath(path: string, kbDirName: string | null): boolean
       ? withoutJunk.slice(kbDirName.length + 1)
       : withoutJunk;
   return groupOfPath(repoRelative) !== null;
+}
+
+/**
+ * Whether selecting `change` should also open its file beside the diff.
+ *
+ * The whole decision in one place, and exported, because the call site sits
+ * behind a dropdown the component harness cannot open — everything asserted
+ * about it through the UI passed with the guard deleted.
+ *
+ * Two reasons not to:
+ *   - DELETED: navigating to a missing path lands FileRoute on its
+ *     file-not-found state.
+ *   - a group item ON THE DEFAULT BRANCH: that URL is a library location, so
+ *     opening it switches the whole shell to Skills & Tools and the panel,
+ *     the diff and the review vanish because someone clicked a row in a list.
+ *
+ * The branch is part of it, and this is the easy half to get wrong: only the
+ * DEFAULT branch's `Groups/` URLs are library locations (`isLibraryLocation`
+ * tests `segments[1] === DEFAULT_BRANCH`). The same skill on a draft branch
+ * opens in Knowledge like any other file and switches nothing, so refusing to
+ * open it there would cost the context this call exists to give and buy
+ * nothing.
+ *
+ * `DEFAULT_BRANCH` is read here rather than captured at module scope — it is
+ * a live binding configured during boot.
+ */
+export function shouldOpenBesideDiff(input: {
+  kind: PendingChange['kind'];
+  path: string;
+  kbDirName: string | null;
+  branch: string | null;
+}): boolean {
+  if (input.kind === 'deleted') return false;
+  const switchesApp = input.branch === DEFAULT_BRANCH && isGroupItemPath(input.path, input.kbDirName);
+  return !switchesApp;
 }
 
 function basename(p: string): string {
@@ -147,22 +182,18 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
       setPickerOpen(false);
       await selectPath(path);
       // Also surface the file in the editor so the user can see context
-      // alongside the diff.
-      //
-      // Skipped in two cases, both of which take the reader somewhere they did
-      // not ask to go:
-      //   - a DELETED file: navigating to a missing path lands FileRoute on
-      //     the file-not-found state.
-      //   - anything under `Groups/`: a skill or tool file's canonical URL is
-      //     a LIBRARY location, so opening it switches the whole shell to the
-      //     Skills & Tools app — the panel, the diff and the rest of the
-      //     review vanish because you clicked a row in a list. The diff is
-      //     already on screen next to the row; that is the context this call
-      //     exists to provide, and for group items it is the only context
-      //     that can be shown without leaving.
+      // alongside the diff — unless doing so would take the reader somewhere
+      // they did not ask to go. See `shouldOpenBesideDiff`.
       const change = session?.changes.find((c) => c.path === path);
-      const isGroupItem = isGroupItemPath(path, kbDirName);
-      if (change && change.kind !== 'deleted' && !isGroupItem) {
+      if (
+        change &&
+        shouldOpenBesideDiff({
+          kind: change.kind,
+          path,
+          kbDirName,
+          branch: session?.branchName ?? null,
+        })
+      ) {
         openFile(path);
       }
     },

--- a/packages/core-frontend/src/modules/review/components/__tests__/MarkdownDiffViewer.test.tsx
+++ b/packages/core-frontend/src/modules/review/components/__tests__/MarkdownDiffViewer.test.tsx
@@ -36,6 +36,41 @@ describe('MarkdownDiffViewer', () => {
     expect(screen.getByRole('heading', { name: 'Old title' })).toBeInTheDocument();
   });
 
+  /**
+   * `scroll={false}` is what lets a parent be the scroller. The review panel
+   * needs that: when the centred column scrolled instead, the gutters either
+   * side sat outside the hit area and the wheel did nothing over them. Two
+   * nested `h-full overflow-auto` boxes also leave the outer one unable to
+   * scroll and stack both paddings.
+   */
+  describe('scroll', () => {
+    it('owns a scroller and padding by default', () => {
+      const { container } = render(<MarkdownDiffViewer payload={payload('a\n', 'b\n')} />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toContain('overflow-auto');
+      expect(root.className).toContain('px-4');
+    });
+
+    it('yields both when the parent owns the scroller', () => {
+      const { container } = render(
+        <MarkdownDiffViewer payload={payload('a\n', 'b\n')} scroll={false} />,
+      );
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain('overflow-auto');
+      expect(root.className).not.toContain('px-4');
+    });
+
+    it('renders the same content either way', () => {
+      for (const scroll of [true, false]) {
+        const { getByText, unmount } = render(
+          <MarkdownDiffViewer payload={payload('old line\n', 'new line\n')} scroll={scroll} />,
+        );
+        expect(getByText('new line')).toBeInTheDocument();
+        unmount();
+      }
+    });
+  });
+
   it('renders unchanged text once and changed text on both sides', () => {
     render(
       <MarkdownDiffViewer

--- a/packages/core-frontend/src/modules/review/components/__tests__/ReviewPanel.test.tsx
+++ b/packages/core-frontend/src/modules/review/components/__tests__/ReviewPanel.test.tsx
@@ -39,7 +39,10 @@ function makeReview(overrides: Partial<ReviewContextValue> = {}): ReviewContextV
 }
 
 function renderPanel(review: ReviewContextValue) {
-  const workspace = { refreshFileTree: vi.fn(async () => null) } as unknown as WorkspaceContextValue;
+  const workspace = {
+    refreshFileTree: vi.fn(async () => null),
+    kbDirName: 'knowledge-base',
+  } as unknown as WorkspaceContextValue;
   const git = { status: { branch: session.branchName } } as unknown as GitContextValue;
   const wrapper = ({ children }: { children: ReactNode }) => (
     <MemoryRouter>
@@ -52,6 +55,7 @@ function renderPanel(review: ReviewContextValue) {
   );
   return render(<ReviewPanel />, { wrapper });
 }
+
 
 describe('ReviewPanel top-bar actions (BEVA-77)', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
+++ b/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { isGroupItemPath } from '../ReviewPanel';
+
+const KB = 'knowledge-base';
+
+/**
+ * The predicate behind "selecting a changed skill must not switch apps".
+ *
+ * Tested here rather than through the panel because the panel's file picker
+ * does not open under the component harness — an earlier attempt to cover this
+ * through the UI passed with the guard DELETED, which is worse than no test.
+ *
+ * The first version of this check shipped broken for exactly the reason the
+ * first case below pins: review-session paths are WORKSPACE-relative, so they
+ * carry the KB clone as their first segment, and `stripJunkBeforeKbDir` keeps
+ * that segment rather than removing it. `groupOfPath` then saw
+ * `knowledge-base` where it wanted `Groups` and answered `null` for every
+ * path — a guard that could never fire.
+ */
+describe('isGroupItemPath', () => {
+  it.each([
+    ['skill, workspace-relative', `${KB}/Groups/GTM/update-website/SKILL.md`],
+    ['tool, workspace-relative', `${KB}/Groups/Engineering/notion.tool`],
+    ['personal group', `${KB}/Groups/personal-u1/my-skill/SKILL.md`],
+  ])('recognises a %s', (_name, path) => {
+    expect(isGroupItemPath(path, KB)).toBe(true);
+  });
+
+  it.each([
+    ['knowledge document', `${KB}/KnowledgeBase/Product/Thing.md`],
+    ['repo-root file', `${KB}/roles.yaml`],
+    ['data record', `${KB}/Data/Engineering/Knowledge/Ticket.md`],
+  ])('leaves a %s alone', (_name, path) => {
+    expect(isGroupItemPath(path, KB)).toBe(false);
+  });
+
+  /**
+   * Not every caller hands over a workspace-relative path — the panel's own
+   * fixtures use repo-relative ones — so both shapes have to work.
+   */
+  it('accepts an already repo-relative path', () => {
+    expect(isGroupItemPath('Groups/GTM/x/SKILL.md', KB)).toBe(true);
+    expect(isGroupItemPath('KnowledgeBase/Product/Thing.md', KB)).toBe(false);
+  });
+
+  it('tolerates junk before the kb dir, which is what strip exists for', () => {
+    expect(isGroupItemPath(`some/prefix/${KB}/Groups/GTM/x/SKILL.md`, KB)).toBe(true);
+  });
+
+  it('does not treat the Groups folder itself as an item', () => {
+    // `groupOfPath` needs a segment BELOW the group; `Groups/GTM` is the
+    // folder, and a bare `Groups/x.tool` names no group at all.
+    expect(isGroupItemPath(`${KB}/Groups/GTM`, KB)).toBe(false);
+    expect(isGroupItemPath(`${KB}/Groups/slack.tool`, KB)).toBe(false);
+  });
+
+  /**
+   * A sibling directory whose name merely STARTS with the kb dir is not the
+   * clone, so nothing inside it is a group item. Both the segment-exact match
+   * in `stripJunkBeforeKbDir` and the `${kbDirName}/` prefix test added here
+   * have to agree on that — a `startsWith(kbDirName)` in either would strip
+   * `-backup/…` down to `Groups/…` and call a backup copy a live skill.
+   */
+  it('is not fooled by a directory whose name merely starts with the kb dir', () => {
+    expect(isGroupItemPath(`${KB}-backup/Groups/GTM/x/SKILL.md`, KB)).toBe(false);
+  });
+
+  it('handles a null kbDirName', () => {
+    expect(isGroupItemPath('Groups/GTM/x/SKILL.md', null)).toBe(true);
+    expect(isGroupItemPath('KnowledgeBase/Thing.md', null)).toBe(false);
+  });
+});

--- a/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
+++ b/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest';
-import { isGroupItemPath } from '../ReviewPanel';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { configureBranchModel } from '@bevel-software/platform-shared';
+import { isGroupItemPath, shouldOpenBesideDiff } from '../ReviewPanel';
+
+const DEFAULT = 'target-company-state';
+const DRAFT = 'razvan/onboarding-tweaks';
+
+beforeEach(() => {
+  configureBranchModel({
+    defaultBranch: DEFAULT,
+    protectedBranches: ['current-company-state', DEFAULT],
+  });
+});
 
 const KB = 'knowledge-base';
 
@@ -68,5 +79,49 @@ describe('isGroupItemPath', () => {
   it('handles a null kbDirName', () => {
     expect(isGroupItemPath('Groups/GTM/x/SKILL.md', null)).toBe(true);
     expect(isGroupItemPath('KnowledgeBase/Thing.md', null)).toBe(false);
+  });
+});
+
+/**
+ * The full decision behind "selecting a row also opens the file beside the
+ * diff". Tested here for the same reason as the predicate above: the call
+ * site is behind a dropdown the component harness cannot open.
+ */
+describe('shouldOpenBesideDiff', () => {
+  const base = { kbDirName: KB, branch: DEFAULT } as const;
+  const SKILL = `${KB}/Groups/GTM/update-website/SKILL.md`;
+  const DOC = `${KB}/KnowledgeBase/Product/Thing.md`;
+
+  it('opens an ordinary knowledge document', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'modified', path: DOC })).toBe(true);
+  });
+
+  it('does NOT open a skill on the default branch — that switches apps', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'modified', path: SKILL })).toBe(false);
+  });
+
+  /**
+   * Only the DEFAULT branch's `Groups/` URLs are library locations
+   * (`isLibraryLocation` tests `segments[1] === DEFAULT_BRANCH`). On a draft
+   * branch the same skill opens in Knowledge and switches nothing, so the
+   * guard must not fire — refusing there would cost the context this call
+   * exists to give and buy nothing.
+   */
+  it('DOES open the same skill on a draft branch', () => {
+    expect(shouldOpenBesideDiff({ ...base, branch: DRAFT, kind: 'modified', path: SKILL })).toBe(true);
+  });
+
+  it.each(['modified', 'added', 'renamed'] as const)('opens a %s knowledge file', (kind) => {
+    expect(shouldOpenBesideDiff({ ...base, kind, path: DOC })).toBe(true);
+  });
+
+  it('never opens a deleted file, wherever it lives', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'deleted', path: DOC })).toBe(false);
+    expect(shouldOpenBesideDiff({ ...base, kind: 'deleted', path: SKILL })).toBe(false);
+    expect(shouldOpenBesideDiff({ ...base, branch: DRAFT, kind: 'deleted', path: SKILL })).toBe(false);
+  });
+
+  it('treats an unknown branch as not-the-default, so it opens', () => {
+    expect(shouldOpenBesideDiff({ ...base, branch: null, kind: 'modified', path: SKILL })).toBe(true);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the Review panel: selecting changed skills/tools no longer switches apps on the default branch; draft branches still open beside the diff. Markdown diffs now use the document measure with a full-width scroller so gutters scroll correctly.

- **Bug Fixes**
  - Prevent app switch when selecting `Groups/...` items on the default branch; add `isGroupItemPath` (workspace-relative via `kbDirName`) and branch-aware `shouldOpenBesideDiff`, with focused tests.
  - Make the panel the scroller and center markdown diffs at the document measure; add `scroll` to `MarkdownDiffViewer` (panel passes `false`) and use `DOCUMENT_COLUMN` + `documentGutters`; code diffs remain full-bleed.

- **Dependencies**
  - Bump `@bevel-software/platform-core-backend`, `@bevel-software/platform-core-frontend`, and `@bevel-software/platform-shared` to `0.7.3`.

<sup>Written for commit 38bec25e7f0e0febe04fd409ea63b728befad3b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

