### PR TITLE
Scope the review panel's group guard to the default branch

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
@@ -10,7 +10,7 @@ import {
   stripJunkBeforeKbDir,
   KB_ROUTE_PREFIX,
 } from '../../workspace/routing/kb-routes';
-import { groupOfPath } from '@bevel-software/platform-shared';
+import { groupOfPath, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { cn } from '../../../lib/utils';
 import { DOCUMENT_COLUMN } from '../../../shared/theme/measure';
 import { ReviewFileRow } from './ReviewFileRow';
@@ -45,6 +45,41 @@ export function isGroupItemPath(path: string, kbDirName: string | null): boolean
       ? withoutJunk.slice(kbDirName.length + 1)
       : withoutJunk;
   return groupOfPath(repoRelative) !== null;
+}
+
+/**
+ * Whether selecting `change` should also open its file beside the diff.
+ *
+ * The whole decision in one place, and exported, because the call site sits
+ * behind a dropdown the component harness cannot open — everything asserted
+ * about it through the UI passed with the guard deleted.
+ *
+ * Two reasons not to:
+ *   - DELETED: navigating to a missing path lands FileRoute on its
+ *     file-not-found state.
+ *   - a group item ON THE DEFAULT BRANCH: that URL is a library location, so
+ *     opening it switches the whole shell to Skills & Tools and the panel,
+ *     the diff and the review vanish because someone clicked a row in a list.
+ *
+ * The branch is part of it, and this is the easy half to get wrong: only the
+ * DEFAULT branch's `Groups/` URLs are library locations (`isLibraryLocation`
+ * tests `segments[1] === DEFAULT_BRANCH`). The same skill on a draft branch
+ * opens in Knowledge like any other file and switches nothing, so refusing to
+ * open it there would cost the context this call exists to give and buy
+ * nothing.
+ *
+ * `DEFAULT_BRANCH` is read here rather than captured at module scope — it is
+ * a live binding configured during boot.
+ */
+export function shouldOpenBesideDiff(input: {
+  kind: PendingChange['kind'];
+  path: string;
+  kbDirName: string | null;
+  branch: string | null;
+}): boolean {
+  if (input.kind === 'deleted') return false;
+  const switchesApp = input.branch === DEFAULT_BRANCH && isGroupItemPath(input.path, input.kbDirName);
+  return !switchesApp;
 }
 
 function basename(p: string): string {
@@ -147,22 +182,18 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
       setPickerOpen(false);
       await selectPath(path);
       // Also surface the file in the editor so the user can see context
-      // alongside the diff.
-      //
-      // Skipped in two cases, both of which take the reader somewhere they did
-      // not ask to go:
-      //   - a DELETED file: navigating to a missing path lands FileRoute on
-      //     the file-not-found state.
-      //   - anything under `Groups/`: a skill or tool file's canonical URL is
-      //     a LIBRARY location, so opening it switches the whole shell to the
-      //     Skills & Tools app — the panel, the diff and the rest of the
-      //     review vanish because you clicked a row in a list. The diff is
-      //     already on screen next to the row; that is the context this call
-      //     exists to provide, and for group items it is the only context
-      //     that can be shown without leaving.
+      // alongside the diff — unless doing so would take the reader somewhere
+      // they did not ask to go. See `shouldOpenBesideDiff`.
       const change = session?.changes.find((c) => c.path === path);
-      const isGroupItem = isGroupItemPath(path, kbDirName);
-      if (change && change.kind !== 'deleted' && !isGroupItem) {
+      if (
+        change &&
+        shouldOpenBesideDiff({
+          kind: change.kind,
+          path,
+          kbDirName,
+          branch: session?.branchName ?? null,
+        })
+      ) {
         openFile(path);
       }
     },

--- a/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
+++ b/packages/core-frontend/src/modules/review/components/__tests__/isGroupItemPath.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from 'vitest';
-import { isGroupItemPath } from '../ReviewPanel';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { configureBranchModel } from '@bevel-software/platform-shared';
+import { isGroupItemPath, shouldOpenBesideDiff } from '../ReviewPanel';
+
+const DEFAULT = 'target-company-state';
+const DRAFT = 'razvan/onboarding-tweaks';
+
+beforeEach(() => {
+  configureBranchModel({
+    defaultBranch: DEFAULT,
+    protectedBranches: ['current-company-state', DEFAULT],
+  });
+});
 
 const KB = 'knowledge-base';
 
@@ -68,5 +79,49 @@ describe('isGroupItemPath', () => {
   it('handles a null kbDirName', () => {
     expect(isGroupItemPath('Groups/GTM/x/SKILL.md', null)).toBe(true);
     expect(isGroupItemPath('KnowledgeBase/Thing.md', null)).toBe(false);
+  });
+});
+
+/**
+ * The full decision behind "selecting a row also opens the file beside the
+ * diff". Tested here for the same reason as the predicate above: the call
+ * site is behind a dropdown the component harness cannot open.
+ */
+describe('shouldOpenBesideDiff', () => {
+  const base = { kbDirName: KB, branch: DEFAULT } as const;
+  const SKILL = `${KB}/Groups/GTM/update-website/SKILL.md`;
+  const DOC = `${KB}/KnowledgeBase/Product/Thing.md`;
+
+  it('opens an ordinary knowledge document', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'modified', path: DOC })).toBe(true);
+  });
+
+  it('does NOT open a skill on the default branch — that switches apps', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'modified', path: SKILL })).toBe(false);
+  });
+
+  /**
+   * Only the DEFAULT branch's `Groups/` URLs are library locations
+   * (`isLibraryLocation` tests `segments[1] === DEFAULT_BRANCH`). On a draft
+   * branch the same skill opens in Knowledge and switches nothing, so the
+   * guard must not fire — refusing there would cost the context this call
+   * exists to give and buy nothing.
+   */
+  it('DOES open the same skill on a draft branch', () => {
+    expect(shouldOpenBesideDiff({ ...base, branch: DRAFT, kind: 'modified', path: SKILL })).toBe(true);
+  });
+
+  it.each(['modified', 'added', 'renamed'] as const)('opens a %s knowledge file', (kind) => {
+    expect(shouldOpenBesideDiff({ ...base, kind, path: DOC })).toBe(true);
+  });
+
+  it('never opens a deleted file, wherever it lives', () => {
+    expect(shouldOpenBesideDiff({ ...base, kind: 'deleted', path: DOC })).toBe(false);
+    expect(shouldOpenBesideDiff({ ...base, kind: 'deleted', path: SKILL })).toBe(false);
+    expect(shouldOpenBesideDiff({ ...base, branch: DRAFT, kind: 'deleted', path: SKILL })).toBe(false);
+  });
+
+  it('treats an unknown branch as not-the-default, so it opens', () => {
+    expect(shouldOpenBesideDiff({ ...base, branch: null, kind: 'modified', path: SKILL })).toBe(true);
   });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Addresses cubic's **P2** on [#62](https://github.com/Bevel-Software/Hexis/pull/62). Valid — the guard was too broad.

Selecting a changed skill skips opening the file beside the diff, because that URL is a library location and opening it swaps the shell to Skills & Tools. But it applied on **every** branch, and only the DEFAULT branch's `Groups/` URLs are library locations — `isLibraryLocation` tests `segments[1] === DEFAULT_BRANCH`. On a draft branch the same skill opens in Knowledge and switches nothing, so refusing there cost the context the call exists to give and bought nothing.

The whole decision now lives in one exported `shouldOpenBesideDiff` — kind, path, kb dir, branch in; one boolean out. That's not tidiness: the call site is behind a dropdown the component harness cannot open, and **every earlier attempt to assert this through the UI passed with the guard deleted**. 8 cases on the decision, on top of 11 on the path predicate.

`DEFAULT_BRANCH` is read inside the function rather than captured at module scope — live binding, applied at boot.

## cubic's P3 (dead scroll gutters) — not fixed, and I'd like a decision

Also valid: the wrapper centres an 880px column and `MarkdownDiffViewer` is the scroller, so the gutters either side aren't in its hit area and the wheel does nothing over them.

The fix cubic suggests — panel-width scroller, inner content container — requires the scroller to be the **outer** element, which means `MarkdownDiffViewer` must stop owning its own. That is exactly the `scroll` prop I added and then **removed at review request**, on the grounds that a container bug shouldn't change a component three surfaces share.

So the options are:

1. **Reinstate the `scroll` prop.** Fixes it properly; touches shared code (opt-in, default unchanged, other two callers unaffected).
2. **Leave it.** Scrolling works over the text, which is where the pointer usually is. Dead gutters on wide screens.
3. A CSS workaround (`h-full` degrading to `auto` inside an indefinite-height parent) — **not recommended**: it relies on a subtle resolution rule and is the kind of thing that silently breaks later.

I've left it as-is rather than reverse an explicit decision on a P3. Happy to do (1) if the gutters bother you in practice.

## Gate

typecheck, build, **2437 tests** (1358 core-backend / 1079 core-frontend) and `ds:check` green. Released as **0.7.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the review panel so group items only skip opening beside the diff on the default branch. On draft branches, selecting a changed skill now opens the file beside the diff to preserve context.

- **Bug Fixes**
  - Scoped the group-item guard to the default branch via `shouldOpenBesideDiff` (opens on drafts; never opens deleted files).
  - Reads `DEFAULT_BRANCH` from `@bevel-software/platform-shared` at runtime.
  - Added unit tests for branch-scoped behavior and path predicate.

- **Dependencies**
  - Bump `@bevel-software/platform-core-backend`, `@bevel-software/platform-core-frontend`, and `@bevel-software/platform-shared` to `0.7.2`.

<sup>Written for commit 2abb914dd5f9e23928328e09a6c2d5132b37d90b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

