### PR TITLE
fix(review): give the diff panel a full-width scroller

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/src/modules/review/components/MarkdownDiffViewer.tsx
+++ b/packages/core-frontend/src/modules/review/components/MarkdownDiffViewer.tsx
@@ -29,6 +29,23 @@ interface MarkdownDiffViewerProps {
   onOpenFile?: (href: string) => void;
   /** Same contract as {@link onOpenFile}, for bare node-id links. */
   onOpenNodeId?: (id: string) => void;
+  /**
+   * Whether this view owns a scroller and its own padding. `true` (the
+   * default) keeps the self-contained box the change-request dialog and the
+   * file-history panel rely on.
+   *
+   * Pass `false` when the PARENT is the scroller. The review panel is: a
+   * centred column whose CHILD scrolls leaves the gutters either side outside
+   * the scroll hit area, so the wheel does nothing over them. Making the
+   * panel-width parent scroll and putting the measure on an inner container
+   * fixes that — but only if this stops owning `overflow-auto`, since two
+   * nested `h-full overflow-auto` boxes leave the outer one unable to scroll
+   * and stack both paddings.
+   *
+   * Mirrors `KbMarkdownView.scroll`, for the same reason and with the same
+   * default.
+   */
+  scroll?: boolean;
 }
 
 /**
@@ -50,7 +67,7 @@ interface MarkdownDiffViewerProps {
  * routes, which sit outside those providers entirely. A `useNavigate()` in
  * here would be a runtime crash in all three.
  */
-export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId }: MarkdownDiffViewerProps) {
+export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId, scroll = true }: MarkdownDiffViewerProps) {
   const data = useMemo(() => {
     const baseline = payload.baseline ?? '';
     const current = payload.current ?? '';
@@ -96,7 +113,7 @@ export function MarkdownDiffViewer({ payload, onOpenFile, onOpenNodeId }: Markdo
   }
 
   return (
-    <div className="h-full overflow-auto bg-white px-4 py-3">
+    <div className={scroll ? 'h-full overflow-auto bg-white px-4 py-3' : 'min-w-0'}>
       {data.frontmatterChanged && (
         <FrontmatterDiffPanel
           oldData={data.oldFrontmatter}

--- a/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
+++ b/packages/core-frontend/src/modules/review/components/ReviewPanel.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../workspace/routing/kb-routes';
 import { groupOfPath, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { cn } from '../../../lib/utils';
-import { DOCUMENT_COLUMN } from '../../../shared/theme/measure';
+import { DOCUMENT_COLUMN, documentGutters } from '../../../shared/theme/measure';
 import { ReviewFileRow } from './ReviewFileRow';
 import { DiffViewer } from './DiffViewer';
 import { MarkdownDiffViewer } from './MarkdownDiffViewer';
@@ -349,32 +349,37 @@ export function ReviewPanel({ onClose }: { onClose?: () => void }) {
         )}
         {!isLoadingDiff && fileDiff && !fileDiff.isBinary && (
           isMarkdownPath(fileDiff.path) ? (
-            // The measure, and ONLY the measure. `MarkdownDiffViewer` is fine
-            // as it is — it renders a self-contained box with its own scroller
-            // and padding, which is what the change-request dialog and file
-            // history want. What was wrong is this container: it handed that
-            // box the full width of the panel, so the very document that reads
-            // at an 880px line two clicks away arrived in the review surface
-            // as a wall of text.
+            // Panel-width SCROLLER, measured INNER column.
             //
-            // So the wrapper constrains width and nothing else. Not
-            // `documentGutters`, which bundles `pb-[110px]`: the scroller is
-            // the CHILD here, so that bottom rhythm would sit outside it as
-            // permanent dead space with the scroll ending short of the panel.
-            // Not `KbDocumentShell` either — it owns a scroller, a rail track
-            // and the file lock's scroll listener, none of which belong to a
-            // floating panel that has its own header and footer.
+            // The scroller has to be the outer box: when the centred column
+            // scrolled instead, the gutters either side sat outside its hit
+            // area and the wheel did nothing over them — a dead margin on
+            // exactly the wide screens the measure exists for.
             //
-            // The child's own `px-4` becomes the gutter, so the line lands at
-            // 848px against Knowledge's 800px — near enough that the two read
-            // as the same column, and bought without reaching into a component
-            // three surfaces share.
-            <div className={cn('h-full', DOCUMENT_COLUMN)}>
-              <MarkdownDiffViewer
-                payload={fileDiff}
-                onOpenFile={openDiffLink}
-                onOpenNodeId={openNodeId}
-              />
+            // With the outer scrolling, the inner column can carry the real
+            // Knowledge contract: `DOCUMENT_COLUMN` + `documentGutters`, which
+            // bundles the 40px sides AND the 110px bottom rhythm. Both now sit
+            // INSIDE the scroller, where they belong — the earlier version had
+            // to skip the gutters entirely because that bottom padding would
+            // have become permanent dead space below a child-owned scroll.
+            // The line lands at 800px, the same as the document two clicks
+            // away, rather than the 848px approximation.
+            //
+            // `scroll={false}` is what makes it possible: two nested
+            // `h-full overflow-auto` boxes leave the outer unable to scroll
+            // and stack both paddings.
+            //
+            // `roomy` is false — this panel covers the viewer, not the nav, so
+            // the file tree is still on screen beside it.
+            <div className="h-full overflow-auto bg-white">
+              <div className={cn(DOCUMENT_COLUMN, documentGutters(false))}>
+                <MarkdownDiffViewer
+                  payload={fileDiff}
+                  onOpenFile={openDiffLink}
+                  onOpenNodeId={openNodeId}
+                  scroll={false}
+                />
+              </div>
             </div>
           ) : (
             // Left full-bleed on purpose. This is the marked-SOURCE view for

--- a/packages/core-frontend/src/modules/review/components/__tests__/MarkdownDiffViewer.test.tsx
+++ b/packages/core-frontend/src/modules/review/components/__tests__/MarkdownDiffViewer.test.tsx
@@ -36,6 +36,41 @@ describe('MarkdownDiffViewer', () => {
     expect(screen.getByRole('heading', { name: 'Old title' })).toBeInTheDocument();
   });
 
+  /**
+   * `scroll={false}` is what lets a parent be the scroller. The review panel
+   * needs that: when the centred column scrolled instead, the gutters either
+   * side sat outside the hit area and the wheel did nothing over them. Two
+   * nested `h-full overflow-auto` boxes also leave the outer one unable to
+   * scroll and stack both paddings.
+   */
+  describe('scroll', () => {
+    it('owns a scroller and padding by default', () => {
+      const { container } = render(<MarkdownDiffViewer payload={payload('a\n', 'b\n')} />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).toContain('overflow-auto');
+      expect(root.className).toContain('px-4');
+    });
+
+    it('yields both when the parent owns the scroller', () => {
+      const { container } = render(
+        <MarkdownDiffViewer payload={payload('a\n', 'b\n')} scroll={false} />,
+      );
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.className).not.toContain('overflow-auto');
+      expect(root.className).not.toContain('px-4');
+    });
+
+    it('renders the same content either way', () => {
+      for (const scroll of [true, false]) {
+        const { getByText, unmount } = render(
+          <MarkdownDiffViewer payload={payload('old line\n', 'new line\n')} scroll={scroll} />,
+        );
+        expect(getByText('new line')).toBeInTheDocument();
+        unmount();
+      }
+    });
+  });
+
   it('renders unchanged text once and changed text on both sides', () => {
     render(
       <MarkdownDiffViewer

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Follow-up to #62 — closes cubic's P3 finding on that PR.

## The problem

The rendered-diff branch of `ReviewPanel` centred `MarkdownDiffViewer` on a document measure and let that **centred column** own the scroller. The gutters either side then sat outside the scroll hit area, so the wheel did nothing over them — dead margins on exactly the wide screens the measure exists to create.

## The fix

`MarkdownDiffViewer` gets `scroll` back, as an opt-in defaulting to `true`. The change-request dialog and the file-history panel keep the self-contained box they rely on, and the embed routes are unaffected. Only the review panel passes `scroll={false}`, and becomes the scroller itself.

Handing the scroller to the panel-width parent also lets the inner column carry the **real** Knowledge contract — `DOCUMENT_COLUMN` + `documentGutters` — instead of the width-only approximation the first fix used:

| | before | after |
|---|---|---|
| line width | 848px (approximation) | **800px** — same as the document one click away |
| bottom rhythm | dropped | `pb-[110px]`, inside the scroller |
| scrollable area | centred column only | full panel width |

The gutters could not be applied before precisely because the child owned the scroll: `pb-[110px]` outside a child scroller is permanent dead space rather than end-of-document breathing room.

## Tests

Three added to `MarkdownDiffViewer.test.tsx`: the default owns `overflow-auto` + `px-4`, `scroll={false}` yields both, and content renders identically either way.

Full gate green — `typecheck`, `test` (2440 passed), `build`, `ds:check` (215, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead scroll gutters in the review diff by making the panel the scroller. The gutters now scroll, and the diff column matches the document measure.

- **Bug Fixes**
  - `ReviewPanel` now owns the scroll. The inner column uses `DOCUMENT_COLUMN` + `documentGutters(false)` for a true 800px line and proper bottom padding inside the scroller.
  - `MarkdownDiffViewer` adds a `scroll` prop (default `true`). The review surface passes `scroll={false}`; change-request dialog, file history, and embeds are unchanged.
  - Tests added for scroll class behavior and identical rendering with/without internal scrolling.

<sup>Written for commit 65273db1729bbfaf9b61460ff557d8b327dfb04a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

