### PR TITLE
Dev

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -238,6 +238,8 @@ function renderPage(
   routerState?: Record<string, unknown>,
   /** Catalog-state overrides — e.g. `{ loading: true }` for the early case. */
   library?: Partial<LibraryContextValue>,
+  /** Props the canonical /workspace mount passes; the legacy route passes none. */
+  pageProps?: { provisional?: boolean },
 ) {
   libraryMock.value = { ...libraryValue(owned, crs, mine), ...library };
   return render(
@@ -255,7 +257,10 @@ function renderPage(
                 leave the one assertion that matters unmakeable. */}
             <LibraryToastProvider>
               <Routes>
-                <Route path="/skills-and-tools/skills/:name" element={<SkillPage />} />
+                <Route
+                  path="/skills-and-tools/skills/:name"
+                  element={<SkillPage {...(pageProps ?? {})} />}
+                />
               </Routes>
             </LibraryToastProvider>
           </EventBusContext.Provider>
@@ -618,16 +623,53 @@ describe('SkillPage', () => {
    * not evidence the skill is missing, just that we asked with the wrong name.
    * GroupPage already refuses to decide this early; this is the same call.
    */
-  it('does not cry "doesn\'t exist" while the catalog is still loading', async () => {
-    apiMock.getSkill.mockRejectedValueOnce(new Error('nope'));
-    renderPage(false, [], [], makeFakeBus(), undefined, { loading: true, items: [] });
+  describe('a PROVISIONAL name — one the route guessed from the URL', () => {
+    // The route reads the folder name when the catalog can't resolve a URL,
+    // and that is the id only when no frontmatter declares one. So a failed
+    // lookup may just mean we asked with the wrong name.
+    const early = { loading: true, items: [] };
+    const failed = { loading: false, error: "Couldn't load the catalog.", items: [] };
 
-    // The lookup failed and the catalog has not answered — so we were possibly
-    // asking with the wrong name, and saying "doesn't exist" would be a guess.
-    await waitFor(() => expect(apiMock.getSkill).toHaveBeenCalled());
-    expect(
-      screen.queryByText(/doesn't exist, or you don't have access to it/),
-    ).not.toBeInTheDocument();
+    it.each([
+      ['still loading', early],
+      // `loading: false` also describes a catalog that FAILED — "we couldn't
+      // ask" is not "there is no such skill", so absence stays unconcluded and
+      // a valid declared-id skill never turns into a permanent error page.
+      ['failed to load', failed],
+    ])('holds the "doesn\'t exist" verdict while the catalog %s', async (_label, lib) => {
+      apiMock.getSkill.mockRejectedValueOnce(new Error('nope'));
+      renderPage(false, [], [], makeFakeBus(), undefined, lib, { provisional: true });
+
+      await waitFor(() => expect(apiMock.getSkill).toHaveBeenCalled());
+      expect(
+        screen.queryByText(/doesn't exist, or you don't have access to it/),
+      ).not.toBeInTheDocument();
+      // …and says so as a LOADING state, not a blank page: an empty render
+      // would satisfy the assertion above while telling the reader nothing.
+      expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('does conclude absence once the catalog has answered', async () => {
+      apiMock.getSkill.mockRejectedValueOnce(new Error('nope'));
+      renderPage(false, [], [], makeFakeBus(), undefined, { loading: false, error: null }, {
+        provisional: true,
+      });
+
+      expect(
+        await screen.findByText(/doesn't exist, or you don't have access to it/),
+      ).toBeInTheDocument();
+    });
+
+    it('never holds it for a name the catalog confirmed', async () => {
+      // A confirmed name's detail error is real — report it immediately, even
+      // mid-refresh. Suppressing it would hide a genuine access failure.
+      apiMock.getSkill.mockRejectedValueOnce(new Error('nope'));
+      renderPage(false, [], [], makeFakeBus(), undefined, early);
+
+      expect(
+        await screen.findByText(/doesn't exist, or you don't have access to it/),
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -236,8 +236,10 @@ function renderPage(
   mine: number[] = [],
   bus: EventBusContextValue = makeFakeBus(),
   routerState?: Record<string, unknown>,
+  /** Catalog-state overrides — e.g. `{ loading: true }` for the early case. */
+  library?: Partial<LibraryContextValue>,
 ) {
-  libraryMock.value = libraryValue(owned, crs, mine);
+  libraryMock.value = { ...libraryValue(owned, crs, mine), ...library };
   return render(
     <MemoryRouter
       initialEntries={[
@@ -607,6 +609,25 @@ describe('SkillPage', () => {
     expect(
       await screen.findByText(/doesn't exist, or you don't have access to it/),
     ).toBeInTheDocument();
+  });
+
+  /**
+   * The name can be PROVISIONAL. A URL the catalog hasn't answered for is
+   * resolved by reading the folder name, which is the skill's id only when no
+   * frontmatter declares one — so a failed fetch under a loading catalog is
+   * not evidence the skill is missing, just that we asked with the wrong name.
+   * GroupPage already refuses to decide this early; this is the same call.
+   */
+  it('does not cry "doesn\'t exist" while the catalog is still loading', async () => {
+    apiMock.getSkill.mockRejectedValueOnce(new Error('nope'));
+    renderPage(false, [], [], makeFakeBus(), undefined, { loading: true, items: [] });
+
+    // The lookup failed and the catalog has not answered — so we were possibly
+    // asking with the wrong name, and saying "doesn't exist" would be a guess.
+    await waitFor(() => expect(apiMock.getSkill).toHaveBeenCalled());
+    expect(
+      screen.queryByText(/doesn't exist, or you don't have access to it/),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -168,6 +168,93 @@ describe('WorkspaceItemRoute', () => {
     );
   });
 
+  /**
+   * A group may carry CATEGORY folders: `skills.service` walks until it finds
+   * a `SKILL.md` and treats that folder as the skill, so `Groups/Engineering/
+   * coding/create-ticket/SKILL.md` is a skill named `create-ticket`.
+   *
+   * Reading the first segment below the group asked for the category —
+   * "coding", which no skill answers to — so every nested skill listed
+   * perfectly and then reported "doesn't exist, or you don't have access to
+   * it" on click. Every fixture here used to be flat, which is exactly why
+   * that shipped.
+   */
+  describe('a skill nested under a category folder', () => {
+    const NESTED: LibraryData = {
+      ...CATALOG,
+      skills: [
+        { name: 'create-ticket', description: '', path: 'Groups/Engineering/coding/create-ticket' },
+        {
+          name: 'architecture-review',
+          description: '',
+          path: 'Groups/Engineering/review/architecture-review',
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      dataMock.useLibraryData.mockReturnValue(NESTED);
+    });
+
+    it('resolves its SKILL.md to the folder holding it, not the category', async () => {
+      renderAt(itemUrl('Groups/Engineering/coding/create-ticket/SKILL.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'create-ticket::SKILL.md',
+      );
+    });
+
+    it('resolves a bundled file below a category folder', async () => {
+      renderAt(itemUrl('Groups/Engineering/review/architecture-review/check-vocab.mjs'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'architecture-review::check-vocab.mjs',
+      );
+    });
+
+    it('resolves a bare nested skill folder to SKILL.md', async () => {
+      renderAt(itemUrl('Groups/Engineering/coding/create-ticket'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'create-ticket::SKILL.md',
+      );
+    });
+
+    it('resolves a nested SKILL.md with no catalog at all', async () => {
+      // The SKILL.md rule reads the URL alone, so the just-created case above
+      // keeps working at depth: the folder holding SKILL.md IS the skill.
+      dataMock.useLibraryData.mockReturnValue({ ...CATALOG, loading: true, skills: [], tools: [] });
+      renderAt(itemUrl('Groups/Engineering/coding/brand-new-skill/SKILL.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'brand-new-skill::SKILL.md',
+      );
+    });
+
+    it('resolves a `.tool` filed under a category folder', async () => {
+      // `walkFiles` finds manuals at ANY depth, so this is a real listed tool;
+      // matching only the group's top level listed it and 404'd the click.
+      renderAt(itemUrl('Groups/Engineering/coding/deploy.tool'));
+      expect(await screen.findByLabelText('tool-page')).toHaveTextContent('deploy');
+    });
+
+    it('does not let a prefix-sharing sibling claim a bundled file', async () => {
+      // Ownership compares whole segments: `create-ticket-v2` shares a string
+      // prefix with `create-ticket` and must not swallow its files.
+      dataMock.useLibraryData.mockReturnValue({
+        ...NESTED,
+        skills: [
+          ...NESTED.skills,
+          {
+            name: 'create-ticket-v2',
+            description: '',
+            path: 'Groups/Engineering/coding/create-ticket-v2',
+          },
+        ],
+      });
+      renderAt(itemUrl('Groups/Engineering/coding/create-ticket-v2/notes.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'create-ticket-v2::notes.md',
+      );
+    });
+  });
+
   it('a non-default branch never renders an item page', async () => {
     renderAt(itemUrl('Groups/Sales/create-sales-deck/SKILL.md', 'razvan/some-draft'));
     await waitFor(() =>

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -227,11 +227,48 @@ describe('WorkspaceItemRoute', () => {
       );
     });
 
-    it('resolves a `.tool` filed under a category folder', async () => {
+    it('resolves a `.tool` filed under a category folder, by its catalog slug', async () => {
       // `walkFiles` finds manuals at ANY depth, so this is a real listed tool;
-      // matching only the group's top level listed it and 404'd the click.
+      // matching only the group's top level listed it and 404'd the click. The
+      // slug is the manual's declared `id`, which need not match the filename —
+      // so a fixture whose slug equals its filename would prove nothing.
+      dataMock.useLibraryData.mockReturnValue({
+        ...NESTED,
+        tools: [
+          {
+            slug: 'internal_deploy',
+            name: 'internal_deploy',
+            path: 'Groups/Engineering/coding/deploy.tool',
+            type: 'mcp' as const,
+            setup: null,
+            canWrite: false,
+            variables: [],
+          },
+        ],
+      });
       renderAt(itemUrl('Groups/Engineering/coding/deploy.tool'));
-      expect(await screen.findByLabelText('tool-page')).toHaveTextContent('deploy');
+      expect(await screen.findByLabelText('tool-page')).toHaveTextContent('internal_deploy');
+    });
+
+    it("sends a category folder's own access.md to the group page", async () => {
+      // The same answer a stray file at the group's top level gets. Before, it
+      // fell through to a SkillPage named after the category.
+      renderAt(itemUrl('Groups/Engineering/coding/access.md'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent(
+          '/skills-and-tools/groups/Engineering',
+        ),
+      );
+    });
+
+    it('waits for the catalog rather than guessing a category is the skill', async () => {
+      // A bare nested folder is ambiguous without the catalog. Guessing sent
+      // SkillPage after a skill named "coding" and flashed a not-found error;
+      // the catalog is what settles it, so hold the slot until it lands.
+      dataMock.useLibraryData.mockReturnValue({ ...NESTED, loading: true, skills: [], tools: [] });
+      renderAt(itemUrl('Groups/Engineering/coding/create-ticket'));
+      expect(await screen.findByRole('button', { name: /^All groups/ })).toBeInTheDocument();
+      expect(screen.queryByLabelText('skill-page')).toBeNull();
     });
 
     it('does not let a prefix-sharing sibling claim a bundled file', async () => {
@@ -253,6 +290,29 @@ describe('WorkspaceItemRoute', () => {
         'create-ticket-v2::notes.md',
       );
     });
+  });
+
+  /**
+   * A skill's id is its frontmatter `id`/`name`, and only FALLS BACK to the
+   * folder name — so the URL cannot be trusted to spell it. The catalog can.
+   */
+  it('resolves a skill whose declared id differs from its folder name', async () => {
+    dataMock.useLibraryData.mockReturnValue({
+      ...CATALOG,
+      skills: [{ name: 'deck-builder', description: '', path: 'Groups/Sales/create-sales-deck' }],
+    });
+    renderAt(itemUrl('Groups/Sales/create-sales-deck/SKILL.md'));
+    expect(await screen.findByLabelText('skill-page')).toHaveTextContent('deck-builder::SKILL.md');
+  });
+
+  it("keeps a SKILL.md bundled INSIDE a skill as that skill's file", async () => {
+    // `skills.service` stops at the first `SKILL.md` and treats that folder as
+    // the skill, so a nested one is a bundled asset — never a skill called
+    // `examples`.
+    renderAt(itemUrl('Groups/Sales/create-sales-deck/examples/SKILL.md'));
+    expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+      'create-sales-deck::examples/SKILL.md',
+    );
   });
 
   it('a non-default branch never renders an item page', async () => {

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -291,6 +291,33 @@ describe('WorkspaceItemRoute', () => {
       );
     });
 
+    it('opens a bundled file of a skill the catalog has not caught up with', async () => {
+      // STALE, not failed: the catalog loaded fine, it just predates the skill.
+      // Concluding "nothing owns this file, so it is not a page" bounced the
+      // reader to the group — the very symptom this change exists to remove,
+      // reached through a different unsettled state. Absence proves nothing;
+      // only positive evidence (a known category above it) redirects.
+      renderAt(itemUrl('Groups/Engineering/coding/brand-new-skill/notes.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'brand-new-skill::notes.md',
+      );
+    });
+
+    it('still routes a known category by its CACHED skills after a failed refresh', async () => {
+      // `useLibraryData` keeps the previous entries when a refresh fails, and
+      // what the catalog KNOWS stays true — a category is still a category.
+      dataMock.useLibraryData.mockReturnValue({
+        ...NESTED,
+        error: "Couldn't refresh the catalog.",
+      });
+      renderAt(itemUrl('Groups/Engineering/coding'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent(
+          '/skills-and-tools/groups/Engineering',
+        ),
+      );
+    });
+
     it('does not let a prefix-sharing sibling claim a bundled file', async () => {
       // Ownership compares whole segments: `create-ticket-v2` shares a string
       // prefix with `create-ticket` and must not swallow its files.

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -271,6 +271,26 @@ describe('WorkspaceItemRoute', () => {
       expect(screen.queryByLabelText('skill-page')).toBeNull();
     });
 
+    it('sends a bare CATEGORY folder to its group, not to a skill page', async () => {
+      // A category is not a skill, and `coding` names none. What tells it apart
+      // from a just-created skill the catalog hasn't caught up with is that the
+      // catalog knows skills UNDER it.
+      renderAt(itemUrl('Groups/Engineering/coding'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent(
+          '/skills-and-tools/groups/Engineering',
+        ),
+      );
+      expect(screen.queryByLabelText('skill-page')).toBeNull();
+    });
+
+    it('still opens a folder the catalog has no skills under — a stale new skill', async () => {
+      renderAt(itemUrl('Groups/Engineering/coding/brand-new-skill'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+        'brand-new-skill::SKILL.md',
+      );
+    });
+
     it('does not let a prefix-sharing sibling claim a bundled file', async () => {
       // Ownership compares whole segments: `create-ticket-v2` shares a string
       // prefix with `create-ticket` and must not swallow its files.
@@ -312,6 +332,30 @@ describe('WorkspaceItemRoute', () => {
     renderAt(itemUrl('Groups/Sales/create-sales-deck/examples/SKILL.md'));
     expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
       'create-sales-deck::examples/SKILL.md',
+    );
+  });
+
+  /**
+   * A failed catalog is "we couldn't ask", not "no such item" — the same
+   * distinction GroupPage draws. Reading it as proof that nothing owns the
+   * file would bounce every bundled-file deep link to the group page during a
+   * transient outage, losing the URL; the skill detail comes from a different
+   * endpoint and can still answer.
+   */
+  it('keeps a bundled-file deep link on the skill page when the catalog failed', async () => {
+    dataMock.useLibraryData.mockReturnValue({
+      ...CATALOG,
+      loading: false,
+      error: "Couldn't load the catalog.",
+      skills: [],
+      tools: [],
+    });
+    // The file's own folder is the best available reading without a catalog
+    // (an asset nested deeper simply cannot be attributed) — the point is that
+    // the reader stays on a skill page instead of being bounced to the group.
+    renderAt(itemUrl('Groups/Sales/create-sales-deck/notes.md'));
+    expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
+      'create-sales-deck::notes.md',
     );
   });
 

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -56,6 +56,7 @@ import { isBinaryFile } from '../../../workspace/components/renderers';
 export function SkillPage({
   name: nameProp,
   activeFile,
+  provisional = false,
 }: {
   /**
    * Both provided when the page is mounted at its CANONICAL address — the
@@ -66,6 +67,14 @@ export function SkillPage({
    */
   name?: string;
   activeFile?: string;
+  /**
+   * Whether `name` is a GUESS the catalog never confirmed — read off the URL's
+   * folder name, which is the skill's id only when no frontmatter declares
+   * one. A failed lookup for a provisional name is not evidence of absence
+   * until the catalog has actually answered; it may simply be the wrong name.
+   * Default `false`: a caller that says nothing is naming a skill it knows.
+   */
+  provisional?: boolean;
 } = {}) {
   const { name: rawName = '' } = useParams<{ name: string }>();
   const name = nameProp ?? safeDecode(rawName);
@@ -377,12 +386,18 @@ export function SkillPage({
     </Button>
   );
 
-  // `data.loading` joins the guard because the NAME may be provisional: when
-  // the catalog hasn't answered for a URL yet, the route resolves it by
-  // reading the folder name, which is the id only when no frontmatter declares
-  // one. Deciding "doesn't exist" before the catalog can correct that flashes
-  // it at somebody who is simply early — the call GroupPage already makes.
-  if (!detail.loading && !data.loading && (detail.error || !skill)) {
+  // "Doesn't exist" is a VERDICT, and a provisional name has not earned one:
+  // the route guessed it from the URL's folder name, so a failed lookup may
+  // just mean we asked with the wrong name. Only the catalog can correct that,
+  // and only a SUCCESSFUL catalog response counts — `loading: false` also
+  // describes a catalog that failed, which is "we couldn't ask", not "there is
+  // no such skill". The same distinction GroupPage draws a few files over.
+  //
+  // A confirmed name (the catalog resolved this URL to it) is unaffected: its
+  // detail error is real and gets reported immediately.
+  const catalogAnswered = !data.loading && !data.error;
+  const mayConcludeAbsence = !provisional || catalogAnswered;
+  if (!detail.loading && mayConcludeAbsence && (detail.error || !skill)) {
     return (
       <Article>
         {backLink}

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -377,7 +377,12 @@ export function SkillPage({
     </Button>
   );
 
-  if (!detail.loading && (detail.error || !skill)) {
+  // `data.loading` joins the guard because the NAME may be provisional: when
+  // the catalog hasn't answered for a URL yet, the route resolves it by
+  // reading the folder name, which is the id only when no frontmatter declares
+  // one. Deciding "doesn't exist" before the catalog can correct that flashes
+  // it at somebody who is simply early — the call GroupPage already makes.
+  if (!detail.loading && !data.loading && (detail.error || !skill)) {
     return (
       <Article>
         {backLink}

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -60,41 +60,49 @@ export function WorkspaceItemRoute() {
     return <ToolPage slug={catalogSlug ?? last.slice(0, -'.tool'.length)} />;
   }
 
-  // A `SKILL.md` names its own skill: the folder holding it, at any depth.
-  // Groups may nest (`Groups/Engineering/coding/create-ticket/SKILL.md`) —
-  // `skills.service` walks until it finds a `SKILL.md` and treats THAT folder
-  // as the skill, so the id is the parent of the file, never the first segment
-  // below the group. Reading the first segment sent every nested skill to a
-  // lookup for its CATEGORY name ("coding"), which no skill answers to.
-  //
-  // No catalog needed, which is the point: a skill created a moment ago opens
-  // from its URL alone, exactly as the flat case always has.
-  if (last === 'SKILL.md' && tail.length >= 2) {
-    return <SkillPage name={tail[tail.length - 2]!} activeFile="SKILL.md" />;
-  }
-
-  // A bundled file (`reference/LESSONS.md`, `check-vocab.mjs`) or a bare skill
-  // folder. Which prefix is the skill is genuinely ambiguous from the URL —
-  // both `<skill>/reference/x.md` and `<category>/<skill>/x.md` are four
-  // segments — so this is the one case that asks the catalog, taking the
-  // DEEPEST skill whose folder contains the path (a category folder is never
-  // itself a skill, so the deepest match is the owner).
+  // THE CATALOG IS THE AUTHORITY on which folder is a skill and what its id
+  // is. Groups may nest (`Groups/Engineering/coding/create-ticket/SKILL.md`),
+  // and a skill's id is its frontmatter `id`/`name` — only FALLING BACK to the
+  // folder name — so neither the depth nor the id can be read off the URL with
+  // certainty. Take the DEEPEST skill whose folder contains this path: a
+  // category folder is never itself a skill, so the deepest match is the owner,
+  // and a `SKILL.md` bundled inside a skill (`<skill>/examples/SKILL.md`)
+  // stays that skill's file instead of inventing a skill called `examples`.
   const owner = deepestSkillOwning(data.items, repoRel);
   if (owner) {
     const file = repoRel.slice(owner.path.length + 1);
     return <SkillPage name={owner.id} activeFile={file || 'SKILL.md'} />;
   }
 
-  // A direct FILE in the group folder (`access.md`, a stray upload) is the
-  // group's business, not a page of its own.
-  if (tail.length === 1 && /\.[a-z0-9]+$/i.test(last)) {
+  // Not in the catalog. A `SKILL.md` still names its own skill structurally —
+  // the folder holding it — and that is deliberately catalog-FREE: a skill
+  // created a moment ago opens from its URL alone, before any reload lands.
+  // (`Groups/<group>/SKILL.md` makes the group folder itself the skill, which
+  // is what the backend's walk would report for it.)
+  if (last === 'SKILL.md') {
+    return <SkillPage name={tail.length >= 2 ? tail[tail.length - 2]! : group} activeFile="SKILL.md" />;
+  }
+
+  // Below here the URL is genuinely ambiguous — `<skill>/reference/x.md` and
+  // `<category>/<skill>/x.md` are the same shape — and the catalog is the only
+  // thing that can settle it. While it is still loading, WAIT: guessing sends
+  // SkillPage to fetch a skill named after a category folder, which flashes a
+  // not-found error and then corrects itself. The layout (and its sidebar) is
+  // already on screen around this.
+  if (data.loading) return null;
+
+  // The catalog has spoken and no skill owns this file, so it is not a page:
+  // a group's `access.md`, a category folder's own `access.md`, a stray
+  // upload. That belongs to the group — at ANY depth, not just the group's
+  // top level.
+  if (/\.[a-z0-9]+$/i.test(last)) {
     return <Navigate to={pathForGroup(group)} replace />;
   }
 
-  // Catalog silent (still loading, or the caller can't read this one): fall
-  // back to the structural reading. Wrong only for a nested bundled file,
-  // which then resolves on the next render once the catalog lands.
-  return <SkillPage name={tail[0]!} activeFile={tail.slice(1).join('/') || 'SKILL.md'} />;
+  // A FOLDER the catalog doesn't know: most likely a skill whose reload hasn't
+  // landed yet (the catalog can be settled but stale). Its own name is the id
+  // — the same rule the backend applies when no frontmatter declares one.
+  return <SkillPage name={last} activeFile="SKILL.md" />;
 }
 
 /**

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -42,26 +42,83 @@ export function WorkspaceItemRoute() {
     return <Navigate to={LIBRARY_ROOT} replace />;
   }
 
-  const [, , group, entry, ...rest] = segments;
-  if (!group || !entry) {
+  const [, , group, ...tail] = segments;
+  const last = tail[tail.length - 1];
+  if (!group || !last) {
     return <Navigate to={LIBRARY_ROOT} replace />;
   }
+  const repoRel = `${GROUPS_DIR}/${group}/${tail.join('/')}`;
 
-  if (rest.length === 0 && entry.toLowerCase().endsWith('.tool')) {
-    const repoRel = `${GROUPS_DIR}/${group}/${entry}`;
+  // A `.tool` is a tool page wherever it sits. The backend finds manuals at
+  // ANY depth below `Groups/` (`walkFiles` over the whole tree), so a manual
+  // filed inside a category folder is a real, listed tool — matching only at
+  // the group's top level would list it and then 404 the click.
+  if (last.toLowerCase().endsWith('.tool')) {
     const catalogSlug = data.items.find(
       (i) => i.kind === 'integration' && i.path === repoRel,
     )?.id;
-    return <ToolPage slug={catalogSlug ?? entry.slice(0, -'.tool'.length)} />;
+    return <ToolPage slug={catalogSlug ?? last.slice(0, -'.tool'.length)} />;
+  }
+
+  // A `SKILL.md` names its own skill: the folder holding it, at any depth.
+  // Groups may nest (`Groups/Engineering/coding/create-ticket/SKILL.md`) —
+  // `skills.service` walks until it finds a `SKILL.md` and treats THAT folder
+  // as the skill, so the id is the parent of the file, never the first segment
+  // below the group. Reading the first segment sent every nested skill to a
+  // lookup for its CATEGORY name ("coding"), which no skill answers to.
+  //
+  // No catalog needed, which is the point: a skill created a moment ago opens
+  // from its URL alone, exactly as the flat case always has.
+  if (last === 'SKILL.md' && tail.length >= 2) {
+    return <SkillPage name={tail[tail.length - 2]!} activeFile="SKILL.md" />;
+  }
+
+  // A bundled file (`reference/LESSONS.md`, `check-vocab.mjs`) or a bare skill
+  // folder. Which prefix is the skill is genuinely ambiguous from the URL —
+  // both `<skill>/reference/x.md` and `<category>/<skill>/x.md` are four
+  // segments — so this is the one case that asks the catalog, taking the
+  // DEEPEST skill whose folder contains the path (a category folder is never
+  // itself a skill, so the deepest match is the owner).
+  const owner = deepestSkillOwning(data.items, repoRel);
+  if (owner) {
+    const file = repoRel.slice(owner.path.length + 1);
+    return <SkillPage name={owner.id} activeFile={file || 'SKILL.md'} />;
   }
 
   // A direct FILE in the group folder (`access.md`, a stray upload) is the
   // group's business, not a page of its own.
-  if (rest.length === 0 && /\.[a-z0-9]+$/i.test(entry)) {
+  if (tail.length === 1 && /\.[a-z0-9]+$/i.test(last)) {
     return <Navigate to={pathForGroup(group)} replace />;
   }
 
-  return <SkillPage name={entry} activeFile={rest.join('/') || 'SKILL.md'} />;
+  // Catalog silent (still loading, or the caller can't read this one): fall
+  // back to the structural reading. Wrong only for a nested bundled file,
+  // which then resolves on the next render once the catalog lands.
+  return <SkillPage name={tail[0]!} activeFile={tail.slice(1).join('/') || 'SKILL.md'} />;
+}
+
+/**
+ * The catalog skill whose folder contains `repoRel`, deepest first — the skill
+ * a bundled file belongs to. Deepest wins because a category folder is never a
+ * skill itself, so between `Groups/E/coding` and `Groups/E/coding/create-ticket`
+ * only the latter can be a real entry; taking the shallower match would hand
+ * the file to whichever skill sat nearest the group root.
+ *
+ * Compares on whole segments (`path + '/'`), never a bare `startsWith`: a
+ * sibling named `create-ticket-v2` shares a prefix with `create-ticket` and
+ * must not claim its files.
+ */
+function deepestSkillOwning(
+  items: readonly { kind: string; id: string; path: string }[],
+  repoRel: string,
+): { id: string; path: string } | null {
+  let best: { id: string; path: string } | null = null;
+  for (const item of items) {
+    if (item.kind !== 'skill') continue;
+    if (repoRel !== item.path && !repoRel.startsWith(`${item.path}/`)) continue;
+    if (!best || item.path.length > best.path.length) best = { id: item.id, path: item.path };
+  }
+  return best;
 }
 
 /** A malformed escape is a bad link, not a crash — fall back to the raw segment. */

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -49,6 +49,17 @@ export function WorkspaceItemRoute() {
   }
   const repoRel = `${GROUPS_DIR}/${group}/${tail.join('/')}`;
 
+  /**
+   * `key={name}` is load-bearing. A provisional name gets CORRECTED once the
+   * catalog lands (folder name → declared id), and without a remount the page
+   * would render once with the new name still holding the old name's failed
+   * detail state — the "doesn't exist" flash, one frame before the corrected
+   * request even starts. Remounting discards it.
+   */
+  const skillPage = (name: string, activeFile: string, provisional: boolean) => (
+    <SkillPage key={name} name={name} activeFile={activeFile} provisional={provisional} />
+  );
+
   // A `.tool` is a tool page wherever it sits. The backend finds manuals at
   // ANY depth below `Groups/` (`walkFiles` over the whole tree), so a manual
   // filed inside a category folder is a real, listed tool — matching only at
@@ -71,7 +82,7 @@ export function WorkspaceItemRoute() {
   const owner = deepestSkillOwning(data.items, repoRel);
   if (owner) {
     const file = repoRel.slice(owner.path.length + 1);
-    return <SkillPage name={owner.id} activeFile={file || 'SKILL.md'} />;
+    return skillPage(owner.id, file || 'SKILL.md', false);
   }
 
   // Not in the catalog. A `SKILL.md` still names its own skill structurally —
@@ -80,50 +91,48 @@ export function WorkspaceItemRoute() {
   // (`Groups/<group>/SKILL.md` makes the group folder itself the skill, which
   // is what the backend's walk would report for it.)
   if (last === 'SKILL.md') {
-    return <SkillPage name={tail.length >= 2 ? tail[tail.length - 2]! : group} activeFile="SKILL.md" />;
+    return skillPage(tail.length >= 2 ? tail[tail.length - 2]! : group, 'SKILL.md', true);
   }
 
-  // Below here the URL is genuinely ambiguous — `<skill>/reference/x.md` and
-  // `<category>/<skill>/x.md` are the same shape — and the catalog is the only
-  // thing that can settle it. While it is still loading, WAIT: guessing sends
-  // SkillPage to fetch a skill named after a category folder, which flashes a
-  // not-found error and then corrects itself. The layout (and its sidebar) is
-  // already on screen around this.
-  if (data.loading) return null;
-
-  // An `error` is "we could not ask", NOT "there is no such item" — the same
-  // distinction GroupPage draws. A failed catalog must not be read as proof
-  // that nothing owns this file, or a transient outage would bounce every
-  // bundled-file deep link to the group page and lose the URL the reader
-  // opened. SkillPage fetches the detail through a DIFFERENT endpoint, so it
-  // can still succeed (or recover on retry) once we hand it a name.
-  const catalogSpoke = !data.error;
+  // Everything below is decided on POSITIVE evidence only. What the catalog
+  // KNOWS is trustworthy whenever it is there — cached entries survive a
+  // failed refresh — but what it does NOT know proves nothing: it may be
+  // loading, stale (a skill created seconds ago), or have failed outright.
+  // Reading absence as "this is not a page" is what bounced valid deep links
+  // to the group, so this no longer draws that inference at all.
 
   // A folder with catalog skills UNDER it is a category, not a skill. That is
   // the discriminator between a category folder and a just-created skill whose
-  // catalog reload hasn't landed: the former has known descendants, the latter
-  // has none. A category has no page of its own; its group does.
-  if (catalogSpoke && !hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
+  // reload hasn't landed: the former has known descendants, the latter has
+  // none. A category has no page of its own; its group does.
+  if (!hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
     return <Navigate to={pathForGroup(group)} replace />;
   }
 
-  // The catalog has spoken and no skill owns this FILE, so it is not a page:
-  // a group's `access.md`, a category folder's own `access.md`, a stray
-  // upload. That belongs to the group — at ANY depth, not just the group's
-  // top level.
-  if (catalogSpoke && hasExtension(last)) {
+  // A FILE is the group's business when it cannot be a skill's file: either it
+  // sits directly in the group folder (structurally never inside a skill), or
+  // its own folder is a known category. `access.md` at either level, a stray
+  // upload. A file under an UNKNOWN folder is left alone — that folder is most
+  // likely a skill the catalog hasn't caught up with.
+  const parentRel = repoRel.slice(0, repoRel.length - last.length - 1);
+  if (hasExtension(last) && (tail.length === 1 || containsCatalogSkill(data.items, parentRel))) {
     return <Navigate to={pathForGroup(group)} replace />;
   }
 
-  // Nothing settled it: a stale catalog that hasn't caught up with a new
-  // skill, or one that failed to load. Read the URL structurally — a file
-  // belongs to the folder holding it, a bare folder names itself, which is
-  // the same rule the backend applies when no frontmatter declares an id.
-  return hasExtension(last) ? (
-    <SkillPage name={tail.length >= 2 ? tail[tail.length - 2]! : group} activeFile={last} />
-  ) : (
-    <SkillPage name={last} activeFile="SKILL.md" />
-  );
+  // Nothing positive settled it. While the catalog is still loading, WAIT: the
+  // evidence above may be one render away, and guessing flashes a page for a
+  // name that is about to change. The layout and its sidebar are already on
+  // screen around this.
+  if (data.loading) return null;
+
+  // Read the URL structurally — a file belongs to the folder holding it, a
+  // bare folder names itself, the same rule the backend applies when no
+  // frontmatter declares an id. Provisional: the catalog never confirmed it,
+  // so SkillPage must not turn a failed lookup into "doesn't exist" until the
+  // catalog has actually answered.
+  return hasExtension(last)
+    ? skillPage(tail.length >= 2 ? tail[tail.length - 2]! : group, last, true)
+    : skillPage(last, 'SKILL.md', true);
 }
 
 /** Whether a path segment names a file rather than a folder. */

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -91,18 +91,55 @@ export function WorkspaceItemRoute() {
   // already on screen around this.
   if (data.loading) return null;
 
-  // The catalog has spoken and no skill owns this file, so it is not a page:
-  // a group's `access.md`, a category folder's own `access.md`, a stray
-  // upload. That belongs to the group — at ANY depth, not just the group's
-  // top level.
-  if (/\.[a-z0-9]+$/i.test(last)) {
+  // An `error` is "we could not ask", NOT "there is no such item" — the same
+  // distinction GroupPage draws. A failed catalog must not be read as proof
+  // that nothing owns this file, or a transient outage would bounce every
+  // bundled-file deep link to the group page and lose the URL the reader
+  // opened. SkillPage fetches the detail through a DIFFERENT endpoint, so it
+  // can still succeed (or recover on retry) once we hand it a name.
+  const catalogSpoke = !data.error;
+
+  // A folder with catalog skills UNDER it is a category, not a skill. That is
+  // the discriminator between a category folder and a just-created skill whose
+  // catalog reload hasn't landed: the former has known descendants, the latter
+  // has none. A category has no page of its own; its group does.
+  if (catalogSpoke && !hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
     return <Navigate to={pathForGroup(group)} replace />;
   }
 
-  // A FOLDER the catalog doesn't know: most likely a skill whose reload hasn't
-  // landed yet (the catalog can be settled but stale). Its own name is the id
-  // — the same rule the backend applies when no frontmatter declares one.
-  return <SkillPage name={last} activeFile="SKILL.md" />;
+  // The catalog has spoken and no skill owns this FILE, so it is not a page:
+  // a group's `access.md`, a category folder's own `access.md`, a stray
+  // upload. That belongs to the group — at ANY depth, not just the group's
+  // top level.
+  if (catalogSpoke && hasExtension(last)) {
+    return <Navigate to={pathForGroup(group)} replace />;
+  }
+
+  // Nothing settled it: a stale catalog that hasn't caught up with a new
+  // skill, or one that failed to load. Read the URL structurally — a file
+  // belongs to the folder holding it, a bare folder names itself, which is
+  // the same rule the backend applies when no frontmatter declares an id.
+  return hasExtension(last) ? (
+    <SkillPage name={tail.length >= 2 ? tail[tail.length - 2]! : group} activeFile={last} />
+  ) : (
+    <SkillPage name={last} activeFile="SKILL.md" />
+  );
+}
+
+/** Whether a path segment names a file rather than a folder. */
+function hasExtension(segment: string): boolean {
+  return /\.[a-z0-9]+$/i.test(segment);
+}
+
+/**
+ * Whether the catalog knows any skill BELOW this path — i.e. whether it is a
+ * container. Only meaningful once the catalog has actually loaded.
+ */
+function containsCatalogSkill(
+  items: readonly { kind: string; path: string }[],
+  repoRel: string,
+): boolean {
+  return items.some((i) => i.kind === 'skill' && i.path.startsWith(`${repoRel}/`));
 }
 
 /**

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix workspace item routing so nested skills, deep `.tool` manuals, and declared skill IDs resolve correctly, and prevent false "doesn't exist" errors while the catalog loads or fails. This makes deep links and just-created skill URLs reliable.

- **Bug Fixes**
  - Resolve the owner by the deepest catalog skill containing the path; do not treat category folders as skills.
  - Use catalog slug for `.tool` pages at any depth; fallback to filename when missing.
  - Treat `SKILL.md` as the holding folder’s skill at any depth, so new skills open before a catalog refresh.
  - Keep bundled-file deep links on the skill page during catalog failures; only redirect to the group on positive evidence (file in group root or under a known category). Wait when the catalog is loading to avoid flashes.
  - Add `provisional` handling in `SkillPage` to hold the "doesn't exist" verdict until the catalog answers; key the page by name to avoid a one-frame error flash when the name corrects.

- **Dependencies**
  - Bump `@bevel-software/platform-core-frontend`, `@bevel-software/platform-core-backend`, and `@bevel-software/platform-shared` to `0.7.4`.

<sup>Written for commit ea0fa08acae23581f556a0390b5c65ca1f632985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

