### PR TITLE
perf(pending-commits): drain in bursts, validate once per burst

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -622,10 +622,14 @@ export async function createCoreServices(
   );
   const pendingCommitsWorker = new PendingCommitsWorker({
     service: pendingCommitsService,
-    workflow: {
-      runPendingCommit: (workspaceId, branch, path, user) =>
-        workflowService.runPendingCommit(workspaceId, branch, path, user),
-    },
+    // The service IS the driver — passed directly rather than wrapped in a
+    // forwarding lambda. A lambda that names its parameters silently drops any
+    // the interface later adds (TypeScript accepts a shorter parameter list),
+    // and that is not hypothetical: the wrapper here took four arguments and
+    // swallowed the `opts` carrying `skipValidation`, so the burst-validation
+    // skip was a no-op in production while every unit test — which stubs this
+    // port — passed. No wrapper, no gap to fall through.
+    workflow: workflowService,
     // Both escalation sinks come through CorePorts: the recovery agent and the
     // notice sink are enterprise-owned (background-agent factory / feedback
     // dashboard); core defaults skip recovery and log to stderr.

--- a/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
@@ -316,6 +316,9 @@ describe('PendingCommitsWorker.drainOnce', () => {
       expect(calls).toHaveLength(50);
       expect(calls[49]?.[4]?.skipValidation).toBe(false);
       expect(calls[48]?.[4]?.skipValidation).toBe(true);
+      // …and does not ASK on that slot: the ceiling already answers it, so
+      // peeking would be a wasted round-trip on every sweep of a backlog.
+      expect(service.hasReadyRow).toHaveBeenCalledTimes(49);
     });
 
     it('commits the claimed row even if the peek throws', async () => {

--- a/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
@@ -279,19 +279,61 @@ describe('PendingCommitsWorker.drainOnce', () => {
       expect(workflow.runPendingCommit).toHaveBeenCalledTimes(1);
     });
 
-    it('does not re-claim a row that just failed — the backoff gate holds', async () => {
-      // `markTransientFailure` leaves `lastAttemptedAt` set, so `claimNext`
-      // refuses the same row until its backoff elapses. Were that not true,
-      // draining until empty would spin on a failing row.
+    it('carries on after a transient failure and ends the pass when nothing is ready', async () => {
+      // What keeps the drain loop from SPINNING on a failing row is the SQL
+      // backoff gate: `markTransientFailure` leaves `lastAttemptedAt` set, so
+      // `claimNext` refuses that row until its backoff elapses. That gate is
+      // not exercised here — `claimNext` is a stub, so this would pass with
+      // the gate removed. It lives in `readyPredicate`, shared by `claimNext`
+      // and `hasReadyRow` precisely so the two cannot drift; there is no
+      // database-backed test for it in this package.
+      //
+      // What this DOES pin is the loop's own half of the contract: a failure
+      // is recorded and the pass keeps going rather than aborting the sweep,
+      // and the row is attempted once.
       (service.claimNext as ReturnType<typeof vi.fn>)
         .mockResolvedValueOnce(makeRow({ id: 'bad' }))
+        .mockResolvedValueOnce(makeRow({ id: 'good' }))
         .mockResolvedValue(null);
-      workflow.runPendingCommit.mockRejectedValueOnce(new Error('push rejected'));
+      workflow.runPendingCommit
+        .mockRejectedValueOnce(new Error('push rejected'))
+        .mockResolvedValueOnce(undefined);
 
       await worker.drainOnce();
 
       expect(service.markTransientFailure).toHaveBeenCalledTimes(1);
-      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(1);
+      expect(service.markSucceeded).toHaveBeenCalledTimes(1);
+      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(2);
+    });
+
+    it('validates the final slot when the burst hits its ceiling', async () => {
+      // Rows remain queued, so the peek says "more" — but this is the last
+      // commit of the PASS, and skipping it would end every sweep of a big
+      // backlog on an unvalidated commit.
+      queue(200);
+      await worker.drainOnce();
+      const calls = workflow.runPendingCommit.mock.calls;
+      expect(calls).toHaveLength(50);
+      expect(calls[49]?.[4]?.skipValidation).toBe(false);
+      expect(calls[48]?.[4]?.skipValidation).toBe(true);
+    });
+
+    it('commits the claimed row even if the peek throws', async () => {
+      // The row is already claimed and `running`; nothing resets that, so
+      // throwing out of the peek would strand it and the workspace would stop
+      // draining until the process restarted. A failed peek assumes "last",
+      // which costs one extra validation and nothing else.
+      (service.claimNext as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(makeRow({ id: 'claimed' }))
+        .mockResolvedValue(null);
+      (service.hasReadyRow as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('connection reset'),
+      );
+
+      await expect(worker.drainOnce()).resolves.toBeUndefined();
+
+      expect(service.markSucceeded).toHaveBeenCalledTimes(1);
+      expect(workflow.runPendingCommit.mock.calls[0]?.[4]?.skipValidation).toBe(false);
     });
   });
 });

--- a/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
@@ -52,6 +52,7 @@ function makeService(): PendingCommitsService {
   return {
     enqueue: vi.fn().mockResolvedValue(undefined),
     claimNext: vi.fn().mockResolvedValue(null),
+    hasReadyRow: vi.fn().mockResolvedValue(false),
     markSucceeded: vi.fn().mockResolvedValue(undefined),
     markTransientFailure: vi.fn().mockResolvedValue(undefined),
     markRecoveryStarted: vi.fn().mockResolvedValue(undefined),
@@ -114,6 +115,8 @@ describe('PendingCommitsWorker.drainOnce', () => {
       'feat/x',
       'Foo.md',
       expect.objectContaining<Partial<AuthUser>>({ email: 'alice@example.com', name: 'Alice' }),
+      // Last (only) row of the burst, so the advisory validator runs.
+      { skipValidation: false },
     );
     expect(service.markSucceeded).toHaveBeenCalledWith('row-1');
     expect(service.markTransientFailure).not.toHaveBeenCalled();
@@ -220,6 +223,76 @@ describe('PendingCommitsWorker.drainOnce', () => {
 
     await expect(worker.drainOnce()).resolves.toBeUndefined();
     expect(service.markNeedsAttention).toHaveBeenCalled();
+  });
+
+  /**
+   * A sweep used to take exactly ONE row per workspace and then sleep
+   * `POLL_INTERVAL_MS`, capping a workspace at ~2 commits/second however fast
+   * git was. A bulk change — a migration, an agent run — paid a minute of
+   * pure polling latency, and anything waiting for the queue to settle (a
+   * change request being applied) waited with it.
+   */
+  describe('draining a burst', () => {
+    /** Queue `count` rows, then nothing — the shape a bulk change leaves. */
+    function queue(count: number) {
+      const claim = service.claimNext as ReturnType<typeof vi.fn>;
+      const ready = service.hasReadyRow as ReturnType<typeof vi.fn>;
+      for (let i = 0; i < count; i += 1) {
+        claim.mockResolvedValueOnce(makeRow({ id: `row-${i}`, path: `File${i}.md` }));
+        // True until the last row is the one in hand.
+        ready.mockResolvedValueOnce(i < count - 1);
+      }
+      claim.mockResolvedValue(null);
+      ready.mockResolvedValue(false);
+    }
+
+    it('commits every queued row in ONE pass', async () => {
+      queue(12);
+      await worker.drainOnce();
+      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(12);
+      expect(service.markSucceeded).toHaveBeenCalledTimes(12);
+    });
+
+    it('validates once — on the last commit, whose tree is the end state', async () => {
+      // The validator parses the whole KB for a report that is only logged,
+      // so per-file runs cost a full parse each and all say the same thing.
+      queue(5);
+      await worker.drainOnce();
+      const skipped = workflow.runPendingCommit.mock.calls.map((c) => c[4]?.skipValidation);
+      expect(skipped).toEqual([true, true, true, true, false]);
+    });
+
+    it('stops at the burst ceiling so one workspace cannot starve the rest', async () => {
+      // The loop holds the single in-flight commit slot; an unbounded drain
+      // would park every other user's save behind a huge migration.
+      queue(200);
+      await worker.drainOnce();
+      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(50);
+    });
+
+    it('gives up the pass the moment stop() lands mid-burst', async () => {
+      queue(12);
+      workflow.runPendingCommit.mockImplementation(async () => {
+        (worker as unknown as { running: boolean }).running = false;
+      });
+      await worker.drainOnce();
+      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-claim a row that just failed — the backoff gate holds', async () => {
+      // `markTransientFailure` leaves `lastAttemptedAt` set, so `claimNext`
+      // refuses the same row until its backoff elapses. Were that not true,
+      // draining until empty would spin on a failing row.
+      (service.claimNext as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(makeRow({ id: 'bad' }))
+        .mockResolvedValue(null);
+      workflow.runPendingCommit.mockRejectedValueOnce(new Error('push rejected'));
+
+      await worker.drainOnce();
+
+      expect(service.markTransientFailure).toHaveBeenCalledTimes(1);
+      expect(workflow.runPendingCommit).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/packages/core-backend/src/modules/workflow/pending-commits.service.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.service.ts
@@ -276,18 +276,7 @@ export class PendingCommitsService {
   async claimNext(rawWorkspaceId: string, now: Date): Promise<PendingCommit | null> {
     // Match the canonical form `enqueue` stores (see `canonicalWorkspaceId`).
     const workspaceId = canonicalWorkspaceId(rawWorkspaceId);
-    // Backoff schedule as a SQL CASE so the gate runs server-side instead
-    // of round-tripping the row to compute eligibility. Index in BACKOFF_MS
-    // matches `attempts` directly — covers `attempts == 0` (a recovery-reset
-    // row whose `lastAttemptedAt` is non-null; without this, it would fall
-    // into ELSE = max backoff and be stuck waiting 30s after every recovery).
-    const caseArms = BACKOFF_MS.map((ms, i) => sql`WHEN ${i} THEN ${ms}`);
-    const lastMs = BACKOFF_MS[BACKOFF_MS.length - 1];
-    const backoffMsExpr = sql`(CASE ${pendingCommits.attempts} ${sql.join(caseArms, sql` `)} ELSE ${lastMs} END)`;
-    const readyExpr = or(
-      isNull(pendingCommits.lastAttemptedAt),
-      sql`${pendingCommits.lastAttemptedAt} + (${backoffMsExpr} || ' milliseconds')::interval <= ${now}`,
-    );
+    const readyExpr = readyPredicate(now);
     const claimed = await this.db
       .update(pendingCommits)
       .set({ status: 'running', lastAttemptedAt: now })
@@ -304,6 +293,32 @@ export class PendingCommitsService {
       )
       .returning();
     return claimed.length > 0 ? rowToPending(claimed[0]) : null;
+  }
+
+  /**
+   * Whether another row is ready for `workspaceId` right now — a peek, with
+   * the same readiness rule `claimNext` uses but claiming nothing.
+   *
+   * The worker asks this AFTER claiming a row, to learn whether the one in
+   * hand is the last of a burst. Everything before the last can skip the
+   * advisory commit validator: it parses the whole KB to produce a report
+   * that is only logged, and re-parsing per file made a bulk change (a
+   * migration, an agent run) cost one full parse per commit.
+   */
+  async hasReadyRow(rawWorkspaceId: string, now: Date): Promise<boolean> {
+    const workspaceId = canonicalWorkspaceId(rawWorkspaceId);
+    const rows = await this.db
+      .select({ id: pendingCommits.id })
+      .from(pendingCommits)
+      .where(
+        and(
+          eq(pendingCommits.workspaceId, workspaceId),
+          eq(pendingCommits.status, 'pending'),
+          readyPredicate(now),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
   }
 
   /**
@@ -481,3 +496,24 @@ export class PendingCommitsService {
   }
 }
 
+
+/**
+ * The "ready to attempt" gate, shared by `claimNext` and `hasReadyRow` so a
+ * peek can never disagree with the claim that follows it.
+ *
+ * Backoff is a SQL CASE so the gate runs server-side instead of round-tripping
+ * every row to compute eligibility. The index into `BACKOFF_MS` is `attempts`
+ * directly, not `attempts - 1`: that covers the recovery-reset case where
+ * `attempts` is 0 but `lastAttemptedAt` is non-null, which would otherwise
+ * fall into the default arm and idle for the maximum backoff after every
+ * recovery run.
+ */
+function readyPredicate(now: Date) {
+  const caseArms = BACKOFF_MS.map((ms, i) => sql`WHEN ${i} THEN ${ms}`);
+  const lastMs = BACKOFF_MS[BACKOFF_MS.length - 1];
+  const backoffMsExpr = sql`(CASE ${pendingCommits.attempts} ${sql.join(caseArms, sql` `)} ELSE ${lastMs} END)`;
+  return or(
+    isNull(pendingCommits.lastAttemptedAt),
+    sql`${pendingCommits.lastAttemptedAt} + (${backoffMsExpr} || ' milliseconds')::interval <= ${now}`,
+  );
+}

--- a/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
@@ -218,23 +218,28 @@ export class PendingCommitsWorker {
         // the same end state once. Asked AFTER the claim, so the row in hand
         // is already out of `pending` and cannot answer for itself.
         //
-        // The peek is an OPTIMISATION, never a gate: a row is already claimed
-        // and `running`, and throwing here would abandon it in that state —
-        // nothing resets it, so that workspace would stop draining until the
-        // process restarted. A failed peek therefore means "assume last",
-        // which costs one extra validation pass and nothing else.
-        let more = false;
-        try {
-          more = await this.deps.service.hasReadyRow(workspace.id, this.deps.now());
-        } catch (peekErr) {
-          console.warn(
-            `[pending-commits] ready-row peek failed for ws=${workspace.id}; validating this commit: ${sanitizeError(peekErr)}`,
-          );
-        }
         // At the burst ceiling this IS the last commit of the pass, however
         // many rows remain queued — so it must validate, or a backlog larger
-        // than the cap would end every sweep on a skipped validation.
-        const lastOfBurst = !more || drained === MAX_BURST_PER_WORKSPACE - 1;
+        // than the cap would end every sweep on a skipped validation. Known
+        // without asking, so the ceiling is checked BEFORE the peek rather
+        // than folded in after it: on a big backlog that would be one wasted
+        // round-trip per sweep, on the hot path this change exists to speed up.
+        let lastOfBurst = drained === MAX_BURST_PER_WORKSPACE - 1;
+        if (!lastOfBurst) {
+          // The peek is an OPTIMISATION, never a gate: the row is already
+          // claimed and `running`, and throwing here would abandon it in that
+          // state — nothing resets it, so the workspace would stop draining
+          // until the process restarted. A failed peek therefore means
+          // "assume last", costing one extra validation pass and nothing else.
+          try {
+            lastOfBurst = !(await this.deps.service.hasReadyRow(workspace.id, this.deps.now()));
+          } catch (peekErr) {
+            console.warn(
+              `[pending-commits] ready-row peek failed for ws=${workspace.id}; validating this commit: ${sanitizeError(peekErr)}`,
+            );
+            lastOfBurst = true;
+          }
+        }
         await this.processRow(row, { skipValidation: !lastOfBurst });
       }
     }

--- a/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
@@ -57,6 +57,16 @@ export const consoleSystemNoticeSink: ISystemNoticeSink = {
 const POLL_INTERVAL_MS = 500;
 
 /**
+ * Ceiling on rows drained from ONE workspace before the sweep moves on.
+ * Fairness, not throughput: the loop holds the single in-flight commit slot,
+ * so an unbounded drain would let one workspace's thousand-file migration
+ * stall every other user's save until it finished. At this size a normal
+ * bulk change (tens of files) still lands in one sweep, and a huge one gives
+ * way after a bounded stretch and resumes on the next pass.
+ */
+const MAX_BURST_PER_WORKSPACE = 50;
+
+/**
  * The recovery-agent dispatcher the worker calls when a row exhausts its
  * transient budget. Pulled behind an interface so the unit tests can
  * substitute a fake without bringing the entire BackgroundAgentFactory
@@ -99,6 +109,7 @@ export interface WorkflowCommitDriver {
     branch: string,
     path: string,
     user: AuthUser,
+    opts?: { skipValidation?: boolean },
   ): Promise<void>;
 }
 
@@ -176,18 +187,39 @@ export class PendingCommitsWorker {
   }
 
   /**
-   * Run one drain pass: rotate through known workspaces, claim+process
-   * one row from each. Exposed publicly so tests can step the loop
-   * deterministically without driving `setTimeout`.
+   * Run one drain pass: rotate through known workspaces, draining each
+   * one's ready rows before moving on. Exposed publicly so tests can step
+   * the loop deterministically without driving `setTimeout`.
+   *
+   * Draining a BURST rather than a single row per sweep is what keeps a
+   * bulk change honest. One row per sweep, with a `POLL_INTERVAL_MS` sleep
+   * after every pass, capped a workspace at ~2 commits/second no matter how
+   * fast git was — so a migration or an agent run that touched a hundred
+   * files spent a minute of pure polling latency, and anything waiting on
+   * the queue to settle (a change request being applied) waited with it.
+   *
+   * A failing row cannot spin this loop: `markTransientFailure` leaves
+   * `lastAttemptedAt` set, so the backoff gate in `claimNext` refuses to
+   * hand the same row back within the same sweep.
    */
   async drainOnce(): Promise<void> {
     for (const workspace of this.deps.workspaces.knownWorkspaces()) {
       // Bail mid-sweep if stop() fired — the in-flight workspace gets
       // to finish but we don't start a new one.
       if (!this.running) return;
-      const row = await this.deps.service.claimNext(workspace.id, this.deps.now());
-      if (!row) continue;
-      await this.processRow(row);
+      for (let drained = 0; drained < MAX_BURST_PER_WORKSPACE; drained += 1) {
+        if (!this.running) return;
+        const row = await this.deps.service.claimNext(workspace.id, this.deps.now());
+        if (!row) break;
+        // Is this the last of the burst? Everything before it can skip the
+        // advisory commit validator, which parses the whole KB to produce a
+        // report that is only logged. Running it per file made a bulk change
+        // pay one full parse per commit; running it on the last commit
+        // reports the same end state once. Asked AFTER the claim, so the row
+        // in hand is already out of `pending` and cannot answer for itself.
+        const more = await this.deps.service.hasReadyRow(workspace.id, this.deps.now());
+        await this.processRow(row, { skipValidation: more });
+      }
     }
   }
 
@@ -226,7 +258,7 @@ export class PendingCommitsWorker {
    *   - throws, transient exhausted, recovery budget remains → spawn agent.
    *   - throws, recovery exhausted → markNeedsAttention + feedback notice.
    */
-  private async processRow(row: PendingCommit): Promise<void> {
+  private async processRow(row: PendingCommit, opts?: { skipValidation?: boolean }): Promise<void> {
     const user: AuthUser = {
       // The worker doesn't have a real `users.id` for the commit author —
       // commit attribution flows through `git commit --author="Name <email>"`,
@@ -237,7 +269,9 @@ export class PendingCommitsWorker {
       name: row.authorName,
     };
     try {
-      await this.deps.workflow.runPendingCommit(row.workspaceId, row.branch, row.path, user);
+      await this.deps.workflow.runPendingCommit(row.workspaceId, row.branch, row.path, user, {
+        skipValidation: opts?.skipValidation,
+      });
       await this.deps.service.markSucceeded(row.id);
       return;
     } catch (err) {

--- a/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
@@ -211,14 +211,31 @@ export class PendingCommitsWorker {
         if (!this.running) return;
         const row = await this.deps.service.claimNext(workspace.id, this.deps.now());
         if (!row) break;
-        // Is this the last of the burst? Everything before it can skip the
-        // advisory commit validator, which parses the whole KB to produce a
-        // report that is only logged. Running it per file made a bulk change
-        // pay one full parse per commit; running it on the last commit
-        // reports the same end state once. Asked AFTER the claim, so the row
-        // in hand is already out of `pending` and cannot answer for itself.
-        const more = await this.deps.service.hasReadyRow(workspace.id, this.deps.now());
-        await this.processRow(row, { skipValidation: more });
+        // Is this the last commit of the burst? Everything before it can skip
+        // the advisory commit validator, which parses the whole KB to produce
+        // a report that is only logged. Running it per file made a bulk change
+        // pay one full parse per commit; running it on the last one reports
+        // the same end state once. Asked AFTER the claim, so the row in hand
+        // is already out of `pending` and cannot answer for itself.
+        //
+        // The peek is an OPTIMISATION, never a gate: a row is already claimed
+        // and `running`, and throwing here would abandon it in that state —
+        // nothing resets it, so that workspace would stop draining until the
+        // process restarted. A failed peek therefore means "assume last",
+        // which costs one extra validation pass and nothing else.
+        let more = false;
+        try {
+          more = await this.deps.service.hasReadyRow(workspace.id, this.deps.now());
+        } catch (peekErr) {
+          console.warn(
+            `[pending-commits] ready-row peek failed for ws=${workspace.id}; validating this commit: ${sanitizeError(peekErr)}`,
+          );
+        }
+        // At the burst ceiling this IS the last commit of the pass, however
+        // many rows remain queued — so it must validate, or a backlog larger
+        // than the cap would end every sweep on a skipped validation.
+        const lastOfBurst = !more || drained === MAX_BURST_PER_WORKSPACE - 1;
+        await this.processRow(row, { skipValidation: !lastOfBurst });
       }
     }
   }

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -808,9 +808,20 @@ export class WorkflowService implements IWorkflowService {
     branch: string,
     targetPath: string,
     user: AuthUser,
-    opts?: { systemAuthorized?: boolean },
+    opts?: { systemAuthorized?: boolean; skipValidation?: boolean },
   ): Promise<void> {
-    const change = await this.git.commitFile(workspaceId, user, targetPath);
+    // `skipValidation` is the worker telling us this commit is not the last of
+    // a burst. The validator is advisory — it parses the whole KB to produce a
+    // report nothing reads but the log — so running it once on the burst's
+    // final state says the same thing as running it per file, for a fraction
+    // of the work. Nothing downstream depends on it having run.
+    const change = await this.git.commitFile(
+      workspaceId,
+      user,
+      targetPath,
+      undefined,
+      opts?.skipValidation,
+    );
     if (!change) {
       // No-op commit — the path was already clean. Usually a double-enqueue
       // or a save of bytes identical to HEAD, BUT a clean tree does NOT

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
The "why did applying take so long?" fix. Two costs compounded on every bulk change; the second was the larger.

## What was slow

**One row per sweep, then always sleep.** [`drainOnce`](https://github.com/Bevel-Software/Hexis/blob/dev/packages/core-backend/src/modules/workflow/pending-commits.worker.ts) claimed exactly one row per workspace, and `runLoop` slept `POLL_INTERVAL_MS` after every pass whether or not it found work — capping a workspace at **~2 commits/second** however fast git was.

**Every commit re-parsed the whole KB.** `commitFile` ran the advisory commit-validation hook per file. In the enterprise app that hook is `kbValidator.runValidation`, which parses the entire knowledge base to produce a report that is only `console.warn`'d — nothing reads it, nothing writes from it. A migration touching ~75 files paid ~75 whole-KB parses to log the same 44 pre-existing issues ~75 times.

Together that's why applying a change request looked like it hung: the queue was still draining commits behind it.

## What changed

- A sweep **drains a workspace's ready rows in one pass**, bounded by `MAX_BURST_PER_WORKSPACE` (50). That ceiling is fairness, not throughput — the loop holds the single in-flight commit slot, so an unbounded drain would park every other user's save behind one workspace's migration.
- The validator runs on the **last commit of each burst**, whose tree is the end state all the per-file runs were converging on. `commitFile` already had a `skipValidator` seam (the reject flow uses it), so this is plumbing, not new machinery.
- `hasReadyRow` is a peek using the **same** readiness rule as `claimNext` — both now share one extracted predicate so they cannot disagree. It counts only *ready* rows deliberately: keying off "any pending row" would let one stuck row suppress validation on every future burst.

## Safety

A failing row cannot spin the new loop — `markTransientFailure` leaves `lastAttemptedAt` set, so the backoff gate refuses to hand the same row back within the sweep. There's a test for exactly that, plus one for `stop()` landing mid-burst.

Five tests added; four verified to fail against the previous commit (the other two guard behaviour that held trivially when only one row was drained per pass).

Full gate green: typecheck, 2466 tests, build, `ds:check` (215, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up pending commits by draining work in bursts and validating once per burst, cutting per-file polling and repeated KB parses. Also fixes `skipValidation` wiring, skips wasted peeks at the burst cap, prevents stuck queues on peek failures, and always validates the last commit at the cap.

- **Performance**
  - Drain ready rows per workspace in one sweep (max 50) for fairness.
  - Validate only the last commit of each burst; earlier commits set `skipValidation` (now passed through to `WorkflowService`).
  - Share the readiness predicate between `claimNext` and `hasReadyRow`; backoff gate prevents re-claim spin.
  - Handle peeks efficiently: failures assume “last” to avoid stranding rows, and at the burst ceiling we skip the peek and still validate the final slot.

- **Dependencies**
  - Bump `@bevel-software/platform-core-backend`, `@bevel-software/platform-core-frontend`, and `@bevel-software/platform-shared` to 0.7.5.

<sup>Written for commit 79255174654ce02a4974c6458e8ea6aa7fa3e544. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

