### PR TITLE
Don't let the 👀 acknowledgement abort the architecture review

### DIFF
--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -84,13 +84,23 @@ jobs:
 
       # Instant sign of life: react 👀 to the triggering comment so the author
       # knows the command was seen while the agent (~3 min) spins up.
+      #
+      # It is cosmetic, so it must never be able to gate the review. Reacting
+      # needs a permission the job token is not reliably granted — it returned
+      # `Resource not accessible by integration` (403) here even with
+      # `issues: write` in scope — and steps run under `bash -e`, so that 403
+      # took down `start` before it could open the check. `publish` is gated on
+      # `needs.start.result == 'success'`, so the whole review died and the PR
+      # kept whatever stale status it already had. Swallow the failure into a
+      # warning: losing the 👀 is a papercut, losing the review is not.
       - name: Acknowledge the command
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api -X POST \
             "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -f content=eyes
+            -f content=eyes \
+            || echo "::warning::Could not react to the triggering comment — continuing with the review."
 
       - name: Resolve PR head branch
         id: pr


### PR DESCRIPTION
`/bevel-review` is currently broken on this repo — every invocation, on every PR.

## What happens

The `start` job's **Acknowledge the command** step posts a cosmetic 👀 reaction to the triggering comment. It runs under `shell: bash -e`, so when the reactions API returns 403 the step exits 1 and takes the whole job with it — before it reaches *Mark review status pending*.

From run [31688895603](https://github.com/Bevel-Software/Hexis/actions/runs/31688895603) (died 7s in):

```
gh api -X POST repos/Bevel-Software/Hexis/issues/comments/5278799757/reactions -f content=eyes
gh: Resource not accessible by integration (HTTP 403)
##[error]Process completed with exit code 1.
```

`publish` is gated on `needs.start.result == 'success'`, so nothing publishes either. The PR silently keeps whatever commit status it already had.

That failure mode is the dangerous part. On #60 it left a `bevel/architecture-review` **failure from two days earlier** sitting on the head commit, looking for all the world like a fresh verdict — while the agent had in fact never run at all. Nothing in the PR indicated the review hadn't happened.

## The fix

Let a failed reaction degrade to a `::warning::` instead of killing the job:

```yaml
gh api -X POST \
  ".../issues/comments/${{ github.event.comment.id }}/reactions" \
  -f content=eyes \
  || echo "::warning::Could not react to the triggering comment — continuing with the review."
```

No change to permissions, job structure, or the `start` / `review` / `publish` security split.

## What this does not fix

The 403 itself. `start` grants `issues: write`, which *is* the documented scope for creating a reaction on an issue comment, so the 403 is anomalous and I couldn't explain it from the run log alone — worth chasing separately.

But the reaction is a sign of life for the author, not a precondition for reviewing. It shouldn't be able to gate the review whatever the cause, so this is the right change either way.

## Base branch

Targeting `main` rather than `dev` on purpose: `issue_comment` workflows only ever run from the default branch, so the fix is inert anywhere else. `dev` (`2bd102a`) also predates the three-job restructure, which landed on `main` directly in `29d1556` — so `main` is both the branch that matters and the one that yields a clean one-commit diff.

## Verification

YAML re-parsed after the edit: all three jobs present, `start` retains its four steps in order. The change is 11 insertions / 1 deletion, confined to the one step.

Not verifiable until this is on `main` — the workflow can't run from a feature branch, so the first real proof will be the next `/bevel-review` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYQpReb6ztHcAM5UCzCufD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYQpReb6ztHcAM5UCzCufD)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the cosmetic 👀 acknowledgement from aborting the architecture review. A failed reaction now emits a warning instead of failing the `start` job, so the check opens and the review proceeds.

- Old: A 403 from the reactions API caused `start` to exit before marking review pending; `publish` never ran and stale commit status could persist.
- New: The reaction failure degrades to `::warning::`, and `start` continues; review and publish behavior are unchanged. The 403 cause is not addressed, so the reaction may still be missing.

**Reviewer notes**
- Change is limited to `.github/workflows/kb-architecture-review.yml` “Acknowledge the command” step: add `|| echo "::warning::…"` after the `gh api` call.
- No permission, job structure, or `start`/`review`/`publish` security split changes.

**Rollout**
- Merge to `main` only; `issue_comment` workflows run from the default branch.
- Verify on the next `/bevel-review`: expect the pending check and review to run even if the 👀 reaction does not appear.

<sup>Written for commit 9ffafee6812ac450349b10eb218c273006d4f0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

