### PR TITLE
Plugin page: server editor, manifest access, extension browsing

### DIFF
--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -30,7 +30,7 @@ import {
 import { createAdminAccessRoutes } from '../modules/admin/admin-access.routes.js';
 import { createAccountRoutes } from '../modules/auth/account.routes.js';
 import { createSetupRoutes } from '../modules/settings/setup.routes.js';
-import { DEFAULT_BRANCH, PROTECTED_BRANCHES } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, PROTECTED_BRANCHES, type AuthUser } from '@bevel-software/platform-shared';
 import { GIT_SHA } from '../version.js';
 import type { CoreServices } from './create-core-services.js';
 
@@ -415,7 +415,13 @@ export async function createCoreServer(
   // workspace — it has to work on a deployment that has no knowledge base yet,
   // which is the whole reason it exists.
   app.use('/api', core.authMiddleware, createSetupRoutes(core.settings, core.adminAccess));
-  app.use('/api', core.authMiddleware, createToolManualsBrowserRoutes(core.toolManualService));
+  app.use('/api', core.authMiddleware, createToolManualsBrowserRoutes(core.toolManualService, {
+    service: core.mcpServerEditService,
+    getUser: async (userId) => {
+      const u = await core.authService.getUserById(userId);
+      return u ? ({ id: u.id, email: u.email, name: u.name } as AuthUser) : undefined;
+    },
+  }));
   app.use('/api', core.authMiddleware, createSecretsVaultRoutes(secretsVaultRoutesDeps));
   // The authed tail of the MCP OAuth flow: /connect calls these to describe
   // the pending authorization and, on Finish, to mint the one-time code. The

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -33,6 +33,7 @@ import { AccessControlService } from '../modules/access/access-control.service.j
 import { CreatorAccessService } from '../modules/access/creator-access.js';
 import { PendingSkillsService, SkillService } from '../modules/skills/index.js';
 import { ToolManualService } from '../modules/tool-manuals/index.js';
+import { McpServerEditService } from '../modules/tool-manuals/mcp-server-edit.service.js';
 import { PluginIndexService, PluginProvisionService, JoinRequestsService } from '../modules/plugins/index.js';
 import {
   DbSecretsVaultService,
@@ -102,6 +103,7 @@ export interface CoreServices {
   skillService: SkillService;
   pendingSkillsService: PendingSkillsService;
   toolManualService: ToolManualService;
+  mcpServerEditService: McpServerEditService;
   pluginIndexService: PluginIndexService;
   pluginProvisionService: PluginProvisionService;
   joinRequestsService: JoinRequestsService;
@@ -393,6 +395,14 @@ export async function createCoreServices(
   // folders into existence (named plugins and personal folders alike). Commits
   // INLINE through the same pipeline the pending-commits worker uses, so the
   // folder's rules are at HEAD before the endpoint answers.
+  const mcpServerEditService = new McpServerEditService(
+    workspaceService,
+    workflowService,
+    accessControl,
+    toolManualService,
+    kbDirName,
+  );
+
   const pluginProvisionService = new PluginProvisionService(
     workspaceService,
     workflowService,
@@ -675,6 +685,7 @@ export async function createCoreServices(
   return {
     config,
     db,
+    mcpServerEditService,
     workspaceService,
     kbSeedService,
     settings,

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DEFAULT_BRANCH, type AuthUser } from '@bevel-software/platform-shared';
+import { workspaceIdForBranch } from '../../workspace/workspace.service.js';
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import type { IAccessControl } from '../../access/access-control.interface.js';
+import type { IToolManualService, ToolManualSummary } from '../tool-manuals.contract.js';
+import { McpServerEditService } from '../mcp-server-edit.service.js';
+
+const KB = 'knowledge-base';
+const USER: AuthUser = { id: 'u-1', email: 'ali@example.com', name: 'Ali' } as AuthUser;
+
+let root: string;
+let repo: string;
+let svc: McpServerEditService;
+let commits: { runPendingCommit: ReturnType<typeof vi.fn> };
+let canWrite: boolean;
+let invalidated: number;
+
+/** Summaries the locate step reads — mirrors what mcp.json discovery yields. */
+const summaries: ToolManualSummary[] = [
+  { slug: 'vendor', name: 'vendor', path: 'Plugins/GTM/mcp.json', type: 'mcp' },
+  { slug: 'legacy', name: 'legacy', path: 'Plugins/GTM/software.bevel.hexis/tools/legacy.tool', type: 'mcp' },
+];
+
+async function write(rel: string, content: unknown): Promise<void> {
+  const abs = path.join(repo, rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, JSON.stringify(content, null, 2), 'utf-8');
+}
+
+async function readJson(rel: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await fs.readFile(path.join(repo, rel), 'utf-8'));
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-mcp-edit-'));
+  const wsDir = path.join(root, workspaceIdForBranch(DEFAULT_BRANCH));
+  repo = path.join(wsDir, KB);
+  canWrite = true;
+  invalidated = 0;
+  commits = { runPendingCommit: vi.fn(async () => undefined) };
+
+  await write('Plugins/GTM/mcp.json', {
+    mcpServers: {
+      vendor: { type: 'streamable-http', url: 'https://v.example/mcp', headers: { 'X-V': '2' } },
+    },
+  });
+  await write('Plugins/GTM/plugin.json', {
+    name: 'gtm',
+    extensions: {
+      'software.bevel.hexis': {
+        mcpServers: {
+          vendor: {
+            headers: { Authorization: 'Bearer ${VENDOR_KEY}' },
+            variables: [{ name: 'VENDOR_KEY', scope: 'user' }],
+          },
+        },
+      },
+    },
+  });
+
+  const workspaceService = {
+    getOrCreateForBranch: vi.fn(async () => ({ id: workspaceIdForBranch(DEFAULT_BRANCH) })),
+    getWorkspacePath: vi.fn(async () => wsDir),
+  } as unknown as WorkspaceService;
+  const accessControl = {
+    canWrite: vi.fn(async () => canWrite),
+  } as unknown as IAccessControl;
+  const toolManuals = {
+    listAccessible: vi.fn(async () => summaries),
+    invalidate: vi.fn(() => {
+      invalidated += 1;
+    }),
+  } as unknown as IToolManualService;
+
+  svc = new McpServerEditService(workspaceService, commits, accessControl, toolManuals, KB);
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('getServer', () => {
+  it('merges both files into one view', async () => {
+    const view = await svc.getServer(USER.email, 'vendor');
+    expect(view).toMatchObject({
+      name: 'vendor',
+      transport: 'streamable-http',
+      url: 'https://v.example/mcp',
+      literalHeaders: { 'X-V': '2' },
+      authHeaders: { Authorization: 'Bearer ${VENDOR_KEY}' },
+      variables: [{ name: 'VENDOR_KEY', scope: 'user' }],
+      local: false,
+      canWrite: true,
+    });
+  });
+
+  it('answers null for an unknown slug and for a legacy .tool-backed manual alike', async () => {
+    expect(await svc.getServer(USER.email, 'nope')).toBeNull();
+    // A `.tool`-backed mcp manual predates the authoritative file; the form
+    // has no pair of files to edit for it, so it is not editable here.
+    expect(await svc.getServer(USER.email, 'legacy')).toBeNull();
+  });
+});
+
+describe('putServer', () => {
+  it('rewrites both files and commits the folder once', async () => {
+    await svc.putServer(USER, 'vendor', {
+      transport: 'streamable-http',
+      url: 'https://v2.example/mcp',
+      literalHeaders: { 'X-V': '3' },
+      authHeaders: { Authorization: 'Bearer ${VENDOR_KEY}' },
+      variables: [{ name: 'VENDOR_KEY', scope: 'user' }],
+    });
+    const mcp = await readJson('Plugins/GTM/mcp.json');
+    expect((mcp.mcpServers as Record<string, unknown>).vendor).toEqual({
+      type: 'streamable-http',
+      url: 'https://v2.example/mcp',
+      headers: { 'X-V': '3' },
+    });
+    expect(commits.runPendingCommit).toHaveBeenCalledTimes(1);
+    expect(commits.runPendingCommit).toHaveBeenCalledWith(
+      workspaceIdForBranch(DEFAULT_BRANCH),
+      DEFAULT_BRANCH,
+      `${KB}/Plugins/GTM`,
+      USER,
+    );
+    expect(invalidated).toBe(1);
+  });
+
+  it('reroutes a ${VAR} that arrives in the literal headers — mcp.json never carries one', async () => {
+    await svc.putServer(USER, 'vendor', {
+      transport: 'streamable-http',
+      url: 'https://v.example/mcp',
+      literalHeaders: { 'X-Key': '${SNEAKY}' },
+    });
+    const mcp = await readJson('Plugins/GTM/mcp.json');
+    expect((mcp.mcpServers as Record<string, { headers?: unknown }>).vendor.headers).toBeUndefined();
+    const manifest = await readJson('Plugins/GTM/plugin.json');
+    const ext = (manifest.extensions as Record<string, { mcpServers: Record<string, { headers?: unknown }> }>)[
+      'software.bevel.hexis'
+    ];
+    expect(ext.mcpServers.vendor.headers).toEqual({ 'X-Key': '${SNEAKY}' });
+  });
+
+  it('renames across BOTH files, refusing a taken key', async () => {
+    await svc.putServer(USER, 'vendor', {
+      newName: 'vendor_eu',
+      transport: 'streamable-http',
+      url: 'https://v.example/mcp',
+      authHeaders: { Authorization: 'Bearer ${VENDOR_KEY}' },
+    });
+    const mcp = await readJson('Plugins/GTM/mcp.json');
+    expect(Object.keys(mcp.mcpServers as object)).toEqual(['vendor_eu']);
+    const manifest = await readJson('Plugins/GTM/plugin.json');
+    const servers = (manifest.extensions as Record<string, { mcpServers: object }>)['software.bevel.hexis']
+      .mcpServers;
+    expect(Object.keys(servers)).toEqual(['vendor_eu']);
+  });
+
+  it('refuses without write access, an invalid name, and a bad URL', async () => {
+    canWrite = false;
+    await expect(
+      svc.putServer(USER, 'vendor', { transport: 'streamable-http', url: 'https://v.example' }),
+    ).rejects.toMatchObject({ status: 403 });
+    canWrite = true;
+    await expect(
+      svc.putServer(USER, 'vendor', { newName: 'Bad Name', transport: 'streamable-http', url: 'https://v.example' }),
+    ).rejects.toMatchObject({ status: 422 });
+    await expect(
+      svc.putServer(USER, 'vendor', { transport: 'streamable-http', url: 'not-a-url' }),
+    ).rejects.toMatchObject({ status: 422 });
+    expect(commits.runPendingCommit).not.toHaveBeenCalled();
+  });
+
+  it('writes a stdio entry with command/args and no url', async () => {
+    await svc.putServer(USER, 'vendor', {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'indexer'],
+    });
+    const mcp = await readJson('Plugins/GTM/mcp.json');
+    expect((mcp.mcpServers as Record<string, unknown>).vendor).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'indexer'],
+    });
+  });
+});

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
@@ -162,6 +162,23 @@ describe('putServer', () => {
     expect(Object.keys(servers)).toEqual(['vendor_eu']);
   });
 
+  it('refuses a rename onto a taken key with 409, committing nothing', async () => {
+    // A second server occupies the target name.
+    const mcp = await readJson('Plugins/GTM/mcp.json');
+    (mcp.mcpServers as Record<string, unknown>).vendor_eu = {
+      type: 'streamable-http',
+      url: 'https://eu.example/mcp',
+    };
+    await fs.writeFile(path.join(repo, 'Plugins/GTM/mcp.json'), JSON.stringify(mcp), 'utf-8');
+    await expect(
+      svc.putServer(USER, 'vendor', { newName: 'vendor_eu', transport: 'streamable-http', url: 'https://v.example/mcp' }),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(commits.runPendingCommit).not.toHaveBeenCalled();
+    // The original key survives untouched.
+    const after = await readJson('Plugins/GTM/mcp.json');
+    expect(Object.keys(after.mcpServers as object).sort()).toEqual(['vendor', 'vendor_eu']);
+  });
+
   it('refuses without write access, an invalid name, and a bad URL', async () => {
     canWrite = false;
     await expect(

--- a/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
@@ -9,6 +9,7 @@ import {
   type AuthUser,
 } from '@bevel-software/platform-shared';
 import { workspaceIdForBranch, type WorkspaceService } from '../workspace/workspace.service.js';
+import { assertSafeFetchUrl } from '../../shared/ssrf.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
 import type { IToolManualService, ToolVariable } from './tool-manuals.contract.js';
 
@@ -143,6 +144,11 @@ export class McpServerEditService {
     const servers = mcp.mcpServers as Record<string, unknown>;
     if (!(name in servers)) throw new McpServerEditError('No such server.', 404);
 
+    if (write.transport !== 'streamable-http' && write.transport !== 'sse' && write.transport !== 'stdio') {
+      // Persisting an unknown transport would save an entry discovery then
+      // refuses — an unusable server with no error at the moment it was made.
+      throw new McpServerEditError(`Unknown transport "${String(write.transport)}".`, 422);
+    }
     const target = write.newName?.trim() || name;
     if (!SERVER_NAME_RE.test(target)) {
       throw new McpServerEditError(
@@ -186,6 +192,21 @@ export class McpServerEditService {
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         throw new McpServerEditError('The server needs a valid http(s) URL.', 422);
       }
+      // The same SSRF gate discovery applies on read: without it here, a save
+      // succeeds and the server then silently disappears from the catalog —
+      // an edit flow that eats its own output. Local-only servers are exempt;
+      // loopback is what local means.
+      if (write.local !== true) {
+        try {
+          assertSafeFetchUrl(write.url ?? '', { label: 'Server URL' });
+        } catch (err) {
+          throw new McpServerEditError(
+            `${err instanceof Error ? err.message : 'The URL is not reachable from the workspace'} — ` +
+              'mark the server local-only if it is deliberately private.',
+            422,
+          );
+        }
+      }
       entry = {
         type: write.transport,
         url: write.url,
@@ -209,7 +230,18 @@ export class McpServerEditService {
       throw new McpServerEditError(`${PLUGIN_MANIFEST_FILE} is missing or unparsable — fix the file first.`, 422);
     }
     if (manifest !== null) {
+      // A wrong-TYPED extensions chain (a string, an array) would throw a
+      // TypeError below and surface as a 500. It is also not ours to silently
+      // replace: an array `extensions` may be another tool's data, malformed
+      // or not, and a save aimed at one server should not discard it.
+      const badShape = (v: unknown): boolean => v !== undefined && (typeof v !== 'object' || v === null || Array.isArray(v));
       const ext = (manifest.extensions ??= {}) as Record<string, unknown>;
+      if (badShape(manifest.extensions)) {
+        throw new McpServerEditError(`${PLUGIN_MANIFEST_FILE} has a malformed \`extensions\` block — fix the file first.`, 422);
+      }
+      if (badShape(ext[HEXIS_EXTENSION_NS]) || badShape((ext[HEXIS_EXTENSION_NS] as Record<string, unknown> | undefined)?.mcpServers)) {
+        throw new McpServerEditError(`${PLUGIN_MANIFEST_FILE} has a malformed \`extensions\` block — fix the file first.`, 422);
+      }
       const ns = (ext[HEXIS_EXTENSION_NS] ??= {}) as Record<string, unknown>;
       const extServers = (ns.mcpServers ??= {}) as Record<string, unknown>;
       delete extServers[name];

--- a/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
@@ -1,0 +1,291 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_BRANCH,
+  HEXIS_EXTENSION_NS,
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  PLUGIN_MCP_FILE,
+  type AuthUser,
+} from '@bevel-software/platform-shared';
+import { workspaceIdForBranch, type WorkspaceService } from '../workspace/workspace.service.js';
+import type { IAccessControl } from '../access/access-control.interface.js';
+import type { IToolManualService, ToolVariable } from './tool-manuals.contract.js';
+
+/**
+ * Server-scoped editing of one MCP server — the form the tool page uses
+ * instead of dropping a writer into raw `mcp.json`.
+ *
+ * One server's truth spans TWO files (the spec's split, not ours): the
+ * portable half in `mcp.json` (transport, url, literal headers) and our half
+ * in `plugin.json`'s `extensions["software.bevel.hexis"].mcpServers[<name>]`
+ * (auth headers carrying `${VAR}` vault references, variable declarations,
+ * description, `local`). This service is the ONE writer that keeps the two in
+ * step: a save rewrites both entries and commits them together, because a
+ * server whose auth landed without its url — or the reverse — is a broken
+ * tool with no author to blame.
+ *
+ * RENAME IS DESTRUCTIVE BY DESIGN and the route says so: the `mcpServers` key
+ * is the namespace vault secrets bind to (`<name>_<VAR>`), so renaming a
+ * server orphans every configured secret and completed sign-in under the old
+ * key. The frontend counts what disconnects (it already holds per-variable
+ * status) and confirms; this service just refuses a rename onto a taken key.
+ */
+
+export type McpTransport = 'streamable-http' | 'sse' | 'stdio';
+
+export interface McpServerView {
+  name: string;
+  transport: McpTransport;
+  url?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  /** Portable headers, stored in mcp.json. Never carry a `${VAR}`. */
+  literalHeaders: Record<string, string>;
+  /** Auth headers with vault references, stored in the extensions block. */
+  authHeaders: Record<string, string>;
+  variables: ToolVariable[];
+  description?: string;
+  local: boolean;
+  canWrite: boolean;
+}
+
+export interface McpServerWrite {
+  newName?: string;
+  transport: McpTransport;
+  url?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  literalHeaders?: Record<string, string>;
+  authHeaders?: Record<string, string>;
+  variables?: ToolVariable[];
+  description?: string;
+  local?: boolean;
+}
+
+export class McpServerEditError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'McpServerEditError';
+  }
+}
+
+/** Same shape the discovery accepts: the key is a namespace, not prose. */
+const SERVER_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+const hasVarRef = (v: string): boolean => /\$\{[^}]+\}/.test(v);
+
+interface CommitDriver {
+  runPendingCommit(
+    workspaceId: string,
+    branch: string,
+    targetPath: string,
+    user: AuthUser,
+    opts?: { systemAuthorized?: boolean },
+  ): Promise<void>;
+}
+
+export class McpServerEditService {
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly commits: CommitDriver,
+    private readonly accessControl: IAccessControl,
+    private readonly toolManuals: IToolManualService,
+    private readonly kbDirName: string,
+  ) {}
+
+  /** The merged view of one server, or null when unknown/unreadable (indistinguishable, fail closed). */
+  async getServer(userEmail: string, slug: string): Promise<McpServerView | null> {
+    const located = await this.locate(userEmail, slug);
+    if (!located) return null;
+    const { folder, name, wsId, mcpJsonPath } = located;
+    const { mcp, manifest } = await this.readFiles(folder);
+    const entry = (mcp?.mcpServers as Record<string, unknown> | undefined)?.[name];
+    if (!entry || typeof entry !== 'object') return null;
+    const raw = entry as Record<string, unknown>;
+    const ext = this.extensionEntry(manifest, name);
+    return {
+      name,
+      transport: (raw.type as McpTransport) ?? 'streamable-http',
+      ...(typeof raw.url === 'string' ? { url: raw.url } : {}),
+      ...(typeof raw.command === 'string' ? { command: raw.command } : {}),
+      ...(Array.isArray(raw.args) ? { args: raw.args.map(String) } : {}),
+      ...(typeof raw.cwd === 'string' ? { cwd: raw.cwd } : {}),
+      ...(raw.env && typeof raw.env === 'object' ? { env: raw.env as Record<string, string> } : {}),
+      literalHeaders: (raw.headers as Record<string, string>) ?? {},
+      authHeaders: (ext.headers as Record<string, string>) ?? {},
+      variables: (ext.variables as ToolVariable[]) ?? [],
+      ...(typeof ext.description === 'string' ? { description: ext.description } : {}),
+      local: ext.local === true || raw.type === 'stdio',
+      canWrite: await this.accessControl.canWrite(wsId, userEmail, mcpJsonPath),
+    };
+  }
+
+  /** Rewrite one server across both files, in one commit. Returns the (possibly new) name. */
+  async putServer(user: AuthUser, slug: string, write: McpServerWrite): Promise<{ name: string }> {
+    const located = await this.locate(user.email, slug);
+    if (!located) throw new McpServerEditError('No such tool.', 404);
+    const { folder, name, wsId, mcpJsonPath } = located;
+    if (!(await this.accessControl.canWrite(wsId, user.email, mcpJsonPath))) {
+      throw new McpServerEditError("You don't have permission to edit this plugin's servers.", 403);
+    }
+    const { mcp, manifest, mcpAbs, manifestAbs } = await this.readFiles(folder);
+    if (!mcp?.mcpServers || typeof mcp.mcpServers !== 'object') {
+      throw new McpServerEditError(`${PLUGIN_MCP_FILE} is missing or unparsable — fix the file first.`, 422);
+    }
+    const servers = mcp.mcpServers as Record<string, unknown>;
+    if (!(name in servers)) throw new McpServerEditError('No such server.', 404);
+
+    const target = write.newName?.trim() || name;
+    if (!SERVER_NAME_RE.test(target)) {
+      throw new McpServerEditError(
+        'A server name is its secret namespace: lowercase alphanumeric with `_`/`-`.',
+        422,
+      );
+    }
+    if (target !== name && target in servers) {
+      throw new McpServerEditError(`A server named "${target}" already exists here.`, 409);
+    }
+
+    // Defense in depth on the portable file: a `${VAR}` in mcp.json would be
+    // transmitted literally by a conformant client AND violate the spec's
+    // no-credentials rule — reroute it to the extensions block instead of
+    // trusting the frontend's split.
+    const literal: Record<string, string> = {};
+    const auth: Record<string, string> = { ...(write.authHeaders ?? {}) };
+    for (const [k, v] of Object.entries(write.literalHeaders ?? {})) {
+      if (hasVarRef(v)) auth[k] = v;
+      else literal[k] = v;
+    }
+
+    let entry: Record<string, unknown>;
+    if (write.transport === 'stdio') {
+      const command = write.command?.trim();
+      if (!command) throw new McpServerEditError('A stdio server needs a command.', 422);
+      entry = {
+        type: 'stdio',
+        command,
+        ...(write.args && write.args.length > 0 ? { args: write.args } : {}),
+        ...(write.env && Object.keys(write.env).length > 0 ? { env: write.env } : {}),
+        ...(write.cwd ? { cwd: write.cwd } : {}),
+      };
+    } else {
+      let parsed: URL;
+      try {
+        parsed = new URL(write.url ?? '');
+      } catch {
+        throw new McpServerEditError('The server needs a valid http(s) URL.', 422);
+      }
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new McpServerEditError('The server needs a valid http(s) URL.', 422);
+      }
+      entry = {
+        type: write.transport,
+        url: write.url,
+        ...(Object.keys(literal).length > 0 ? { headers: literal } : {}),
+      };
+    }
+
+    if (target !== name) delete servers[name];
+    servers[target] = entry;
+
+    // The extensions half: rewrite our entry, drop the old key on rename.
+    // A missing/unparsable manifest refuses the save when there is auth to
+    // store — silently dropping a credential mapping is worse than an error.
+    const extEntry = {
+      ...(Object.keys(auth).length > 0 ? { headers: auth } : {}),
+      ...(write.variables && write.variables.length > 0 ? { variables: write.variables } : {}),
+      ...(write.description ? { description: write.description } : {}),
+      ...(write.local === true && write.transport !== 'stdio' ? { local: true } : {}),
+    };
+    if (manifest === null && Object.keys(extEntry).length > 0) {
+      throw new McpServerEditError(`${PLUGIN_MANIFEST_FILE} is missing or unparsable — fix the file first.`, 422);
+    }
+    if (manifest !== null) {
+      const ext = (manifest.extensions ??= {}) as Record<string, unknown>;
+      const ns = (ext[HEXIS_EXTENSION_NS] ??= {}) as Record<string, unknown>;
+      const extServers = (ns.mcpServers ??= {}) as Record<string, unknown>;
+      delete extServers[name];
+      if (Object.keys(extEntry).length > 0) extServers[target] = extEntry;
+    }
+
+    await fs.writeFile(mcpAbs, `${JSON.stringify(mcp, null, 2)}\n`, 'utf8');
+    if (manifest !== null) {
+      await fs.writeFile(manifestAbs, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    }
+    // One folder-scoped commit, ungated beyond the caller's own write access —
+    // both files or neither. The catalog cache is stale the moment it lands.
+    await this.commits.runPendingCommit(
+      workspaceIdForBranch(DEFAULT_BRANCH),
+      DEFAULT_BRANCH,
+      `${this.kbDirName}/${PLUGINS_DIR}/${folder}`,
+      user,
+    );
+    this.toolManuals.invalidate();
+    return { name: target };
+  }
+
+  /** Resolve a slug to an mcp.json-backed server the caller can READ; null otherwise. */
+  private async locate(
+    userEmail: string,
+    slug: string,
+  ): Promise<{ folder: string; name: string; wsId: string; mcpJsonPath: string } | null> {
+    const summaries = await this.toolManuals.listAccessible(userEmail);
+    const found = summaries.find((s) => s.slug === slug);
+    if (!found || found.type !== 'mcp' || !found.path.endsWith(`/${PLUGIN_MCP_FILE}`)) return null;
+    const segments = found.path.split('/');
+    const folder = segments[1];
+    if (!folder) return null;
+    return {
+      folder,
+      name: found.name,
+      wsId: workspaceIdForBranch(DEFAULT_BRANCH),
+      mcpJsonPath: found.path,
+    };
+  }
+
+  private async readFiles(folder: string): Promise<{
+    mcp: Record<string, unknown> | null;
+    manifest: Record<string, unknown> | null;
+    mcpAbs: string;
+    manifestAbs: string;
+  }> {
+    const wsId = workspaceIdForBranch(DEFAULT_BRANCH);
+    await this.workspaceService.getOrCreateForBranch(DEFAULT_BRANCH);
+    const wsDir = await this.workspaceService.getWorkspacePath(wsId);
+    const pluginDir = path.join(wsDir, this.kbDirName, PLUGINS_DIR, folder);
+    const mcpAbs = path.join(pluginDir, PLUGIN_MCP_FILE);
+    const manifestAbs = path.join(pluginDir, PLUGIN_MANIFEST_FILE);
+    return {
+      mcp: await readJson(mcpAbs),
+      manifest: await readJson(manifestAbs),
+      mcpAbs,
+      manifestAbs,
+    };
+  }
+
+  private extensionEntry(manifest: Record<string, unknown> | null, name: string): Record<string, unknown> {
+    const ns = (manifest?.extensions as Record<string, unknown> | undefined)?.[HEXIS_EXTENSION_NS];
+    const servers = (ns as Record<string, unknown> | undefined)?.mcpServers;
+    const entry = (servers as Record<string, unknown> | undefined)?.[name];
+    return entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : {};
+  }
+}
+
+async function readJson(p: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(p, 'utf-8'));
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.routes.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.routes.ts
@@ -8,6 +8,8 @@ import type { IAccessControl } from '../access/access-control.interface.js';
 import '@utcp/http'; // side effect: register the 'http' call-template type
 import { CallTemplateSerializer, type CallTemplate } from '@utcp/sdk';
 import { type IToolManualService, EXTERNAL_KB_MANUAL_NAME } from './tool-manuals.contract.js';
+import { McpServerEditError, type McpServerEditService, type McpServerWrite } from './mcp-server-edit.service.js';
+import type { AuthUser } from '@bevel-software/platform-shared';
 import '../auth/auth.middleware.js'; // Express Request augmentation (req.userId / req.userEmail)
 import '../tool-auth/tool-auth.middleware.js'; // Express Request augmentation (req.toolAuth)
 
@@ -205,8 +207,53 @@ export function createToolManualsAgentRoutes(
  *                            literal sibling is shadowed by the param segment;
  *                            `preview` is POST-only, so it never collides.
  */
-export function createToolManualsBrowserRoutes(toolManualService: IToolManualService): express.Router {
+export function createToolManualsBrowserRoutes(
+  toolManualService: IToolManualService,
+  serverEdit?: { service: McpServerEditService; getUser: (userId: string) => Promise<AuthUser | undefined> },
+): express.Router {
   const router = express.Router();
+
+  /**
+   * Server-scoped read/write of one MCP server — the tool page's edit form.
+   * One server's truth spans mcp.json AND plugin.json's extensions block; a
+   * raw file editor shows a writer half of it at best, so the form talks to
+   * this pair instead. PUT commits both files together and refuses the states
+   * that would strand a half (see McpServerEditService).
+   */
+  router.get('/tools/:slug/server', async (req, res) => {
+    if (!serverEdit) return void res.status(404).json({ error: 'Not available' });
+    const email = req.userEmail;
+    if (!email) return void res.status(401).json({ error: 'Not authenticated' });
+    try {
+      const view = await serverEdit.service.getServer(email, String(req.params.slug));
+      if (!view) return void res.status(404).json({ error: 'Not found' });
+      res.json(view);
+    } catch (err) {
+      console.error('[tool-manuals] server read failed:', err instanceof Error ? err.message : err);
+      res.status(500).json({ error: 'Failed to read the server' });
+    }
+  });
+
+  router.put('/tools/:slug/server', async (req, res) => {
+    if (!serverEdit) return void res.status(404).json({ error: 'Not available' });
+    if (!req.userId) return void res.status(401).json({ error: 'Not authenticated' });
+    try {
+      const user = await serverEdit.getUser(req.userId);
+      if (!user) return void res.status(401).json({ error: 'Not authenticated' });
+      const result = await serverEdit.service.putServer(
+        user,
+        String(req.params.slug),
+        (req.body ?? {}) as McpServerWrite,
+      );
+      res.json(result);
+    } catch (err) {
+      if (err instanceof McpServerEditError) {
+        return void res.status(err.status).json({ error: err.message });
+      }
+      console.error('[tool-manuals] server write failed:', err instanceof Error ? err.message : err);
+      res.status(500).json({ error: 'Failed to save the server' });
+    }
+  });
 
   router.get('/tools', async (req, res) => {
     const email = req.userEmail;

--- a/packages/core-frontend/src/modules/library/__tests__/McpServerSection.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/McpServerSection.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { McpServerView } from '../services/tools.api';
+
+/**
+ * The server-scoped editor. What is worth pinning: the section renders nothing
+ * for a `.tool`-backed manual (GET 404 → null), non-writers get facts and no
+ * button, and a RENAME with configured secrets is interrupted by a dialog that
+ * names the count — the save must not fire until "Rename anyway".
+ */
+
+const apiMock = vi.hoisted(() => ({
+  getMcpServer: vi.fn<() => Promise<McpServerView | null>>(),
+  putMcpServer: vi.fn(),
+}));
+vi.mock('../services/tools.api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/tools.api')>()),
+  getMcpServer: apiMock.getMcpServer,
+  putMcpServer: apiMock.putMcpServer,
+}));
+
+import { McpServerSection } from '../components/tool-page/McpServerSection';
+
+const VIEW: McpServerView = {
+  name: 'vendor',
+  transport: 'streamable-http',
+  url: 'https://v.example/mcp',
+  literalHeaders: { 'X-V': '2' },
+  authHeaders: { Authorization: 'Bearer ${VENDOR_KEY}' },
+  variables: [{ name: 'VENDOR_KEY', scope: 'user' }],
+  local: false,
+  canWrite: true,
+};
+
+function renderSection(configuredCount = 2) {
+  const onSaved = vi.fn();
+  const onError = vi.fn();
+  render(
+    <MemoryRouter>
+      <McpServerSection slug="vendor" configuredCount={configuredCount} onSaved={onSaved} onError={onError} />
+    </MemoryRouter>,
+  );
+  return { onSaved, onError };
+}
+
+beforeEach(() => {
+  apiMock.getMcpServer.mockReset();
+  apiMock.putMcpServer.mockReset();
+  apiMock.putMcpServer.mockResolvedValue({ name: 'vendor' });
+});
+
+describe('McpServerSection', () => {
+  it('renders nothing for a .tool-backed manual', async () => {
+    apiMock.getMcpServer.mockResolvedValue(null);
+    renderSection();
+    await waitFor(() => expect(apiMock.getMcpServer).toHaveBeenCalled());
+    expect(screen.queryByText('Server')).not.toBeInTheDocument();
+  });
+
+  it('shows the facts, and the edit button only to writers', async () => {
+    apiMock.getMcpServer.mockResolvedValue({ ...VIEW, canWrite: false });
+    renderSection();
+    expect(await screen.findByText('https://v.example/mcp')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit server' })).not.toBeInTheDocument();
+  });
+
+  it('saves without ceremony when the name is unchanged', async () => {
+    apiMock.getMcpServer.mockResolvedValue(VIEW);
+    const { onSaved } = renderSection();
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit server' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(apiMock.putMcpServer).toHaveBeenCalledTimes(1));
+    // No newName in the payload — an unchanged name is not a rename.
+    expect(apiMock.putMcpServer.mock.calls[0]![1]).not.toHaveProperty('newName');
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+  });
+
+  it('interrupts a rename with the disconnect count, and saves only on "Rename anyway"', async () => {
+    apiMock.getMcpServer.mockResolvedValue(VIEW);
+    renderSection(2);
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit server' }));
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), {
+      target: { value: 'vendor_eu' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // The save did NOT fire — the dialog is the gate, and it says the cost.
+    expect(apiMock.putMcpServer).not.toHaveBeenCalled();
+    expect(await screen.findByText(/2 configured secrets and sign-ins/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename anyway' }));
+    await waitFor(() => expect(apiMock.putMcpServer).toHaveBeenCalledTimes(1));
+    expect(apiMock.putMcpServer.mock.calls[0]![1]).toMatchObject({ newName: 'vendor_eu' });
+  });
+});

--- a/packages/core-frontend/src/modules/library/__tests__/ToolPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/ToolPage.test.tsx
@@ -29,7 +29,12 @@ const secretsMock = vi.hoisted(() => ({
 vi.mock('../../secrets-vault/services/tool-secrets.api', () => secretsMock);
 
 const toolsMock = vi.hoisted(() => ({ getToolDetail: vi.fn() }));
-vi.mock('../services/tools.api', () => ({ getToolDetail: toolsMock.getToolDetail }));
+vi.mock('../services/tools.api', () => ({
+  getToolDetail: toolsMock.getToolDetail,
+  // The server section self-hides on null — these frame tests are not about it.
+  getMcpServer: vi.fn(async () => null),
+  putMcpServer: vi.fn(),
+}));
 
 const libraryMock = vi.hoisted(() => ({ listSkills: vi.fn(), getSkill: vi.fn() }));
 vi.mock('../services/library.api', () => ({

--- a/packages/core-frontend/src/modules/library/components/LibraryCard.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryCard.tsx
@@ -6,6 +6,12 @@ import type { AttentionStatus, GemState } from '../utils/status';
 
 export interface LibraryCardProps {
   kind: 'skill' | 'integration';
+  /**
+   * How an integration is declared: an `mcp.json` server or a `.tool` UTCP
+   * manual. Two different files to edit and two different capability sets, so
+   * the card says which one this is — skills carry nothing here.
+   */
+  flavor?: 'mcp' | 'utcp';
   id: string;
   name: string;
   description: string;
@@ -58,6 +64,7 @@ export function LibraryCard({
   version,
   pending,
   onOpen,
+  flavor,
 }: LibraryCardProps) {
   /**
    * What the bottom-left says, and when it says anything at all.
@@ -103,6 +110,11 @@ export function LibraryCard({
             column of coloured squares that distinguish nothing. */}
         {kind === 'integration' && <ToolLogo slug={id} name={name} />}
         <span className="truncate text-lede font-semibold text-ink">{name}</span>
+        {kind === 'integration' && flavor && (
+          <Badge tone="outline" size="xs" className="shrink-0 uppercase">
+            {flavor === 'mcp' ? 'MCP server' : 'UTCP manual'}
+          </Badge>
+        )}
         {pending && (
           <Badge tone="wait" size="xs" className="shrink-0 uppercase">
             In review

--- a/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { DEFAULT_BRANCH, type FileTreeEntry } from '@bevel-software/platform-shared';
+import { Button } from '../../../shared/components';
+import { listFiles } from '../../workspace/services/workspace.api';
+import { kbFileUrl } from '../../workspace/routing/kb-routes';
+
+/**
+ * The plugin page's two smallest sections, both pure REUSE of the Knowledge
+ * surface: every link is a `kbFileUrl` + `rawFile` navigation into the same
+ * raw editor the tool page's "Edit the tool file" uses — no new viewer, no new
+ * backend.
+ *
+ * MANIFEST: writers get a button to `plugin.json`. It is a button to the FILE,
+ * not a form, deliberately: the fields worth hand-editing (`version`,
+ * `description`, `license`) are plain JSON, and the `extensions` block is
+ * machine-written by the server editor — a bespoke form would either duplicate
+ * that editor or invite hand-edits it then overwrites.
+ *
+ * EXTENSIONS: the spec reserves reverse-DNS directories for client-specific
+ * data any other client must ignore — which cuts both ways: a plugin authored
+ * for ANOTHER client can carry `com.example.client/`, and this section is how
+ * a person inspects one instead of wondering what it is. Our own namespace's
+ * `tools/` contents already appear in the Tools band above, so entries here
+ * are typically foreign — exactly when looking inside matters.
+ */
+
+/** A reverse-DNS namespace directory: at least one dot, per the spec's shape. */
+const isNamespaceDir = (name: string): boolean => name.includes('.');
+
+export function ManifestButton({
+  kbDirName,
+  folder,
+  canWrite,
+}: {
+  kbDirName: string | null;
+  folder: string;
+  canWrite: boolean;
+}) {
+  const navigate = useNavigate();
+  if (!canWrite || !kbDirName) return null;
+  return (
+    <Button
+      variant="quiet"
+      size="sm"
+      onClick={() =>
+        navigate(kbFileUrl(DEFAULT_BRANCH, `${kbDirName}/Plugins/${folder}/plugin.json`), {
+          state: { rawFile: true },
+        })
+      }
+    >
+      Manifest
+    </Button>
+  );
+}
+
+interface NamespaceListing {
+  namespace: string;
+  files: string[]; // plugin-relative, e.g. `com.example.client/hooks/on-save.js`
+}
+
+export function ClientExtensionsSection({
+  workspaceId,
+  kbDirName,
+  folder,
+}: {
+  workspaceId: string | null;
+  kbDirName: string | null;
+  folder: string;
+}) {
+  const navigate = useNavigate();
+  const [listings, setListings] = useState<NamespaceListing[]>([]);
+
+  useEffect(() => {
+    if (!workspaceId || !kbDirName) return;
+    let live = true;
+    listFiles(workspaceId)
+      .then((tree) => {
+        if (live) setListings(namespaceListings(tree, kbDirName, folder));
+      })
+      .catch(() => {
+        /* the section renders nothing — a tree fetch failure is not this page's story */
+      });
+    return () => {
+      live = false;
+    };
+  }, [workspaceId, kbDirName, folder]);
+
+  if (listings.length === 0) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="mb-2.5 text-label font-semibold uppercase text-ink-faint">
+        Client-specific extensions
+      </h2>
+      <p className="mb-2 max-w-[62ch] text-detail text-ink-muted">
+        Reverse-DNS directories carry data for a specific client; other clients ignore them. Files
+        open in the Knowledge editor.
+      </p>
+      {listings.map((l) => (
+        <div key={l.namespace} className="mb-2 rounded-md border border-line px-3.5 py-2.5">
+          <p className="font-mono text-detail font-semibold text-ink">{l.namespace}/</p>
+          <ul className="mt-1">
+            {l.files.map((f) => (
+              <li key={f}>
+                <button
+                  type="button"
+                  className="cursor-pointer font-mono text-detail text-ink-muted hover:text-ink hover:underline"
+                  onClick={() =>
+                    navigate(kbFileUrl(DEFAULT_BRANCH, `${kbDirName}/Plugins/${folder}/${f}`), {
+                      state: { rawFile: true },
+                    })
+                  }
+                >
+                  {f.slice(l.namespace.length + 1)}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+/** Walk the (already-loaded, ACL-filtered) tree down to this plugin's namespace dirs. */
+function namespaceListings(tree: FileTreeEntry, kbDirName: string, folder: string): NamespaceListing[] {
+  const pluginDir = descend(tree, [kbDirName, 'Plugins', folder]);
+  if (!pluginDir?.children) return [];
+  const out: NamespaceListing[] = [];
+  for (const child of pluginDir.children) {
+    if (child.type !== 'directory' || !isNamespaceDir(child.name)) continue;
+    const files: string[] = [];
+    collectFiles(child, child.name, files);
+    if (files.length > 0) out.push({ namespace: child.name, files: files.sort() });
+  }
+  return out.sort((a, b) => a.namespace.localeCompare(b.namespace));
+}
+
+function descend(tree: FileTreeEntry, segments: string[]): FileTreeEntry | null {
+  let node: FileTreeEntry | undefined = tree;
+  for (const segment of segments) {
+    node = node?.children?.find((c) => c.name === segment);
+    if (!node) return null;
+  }
+  return node ?? null;
+}
+
+function collectFiles(node: FileTreeEntry, prefix: string, out: string[]): void {
+  for (const child of node.children ?? []) {
+    const rel = `${prefix}/${child.name}`;
+    if (child.type === 'directory') collectFiles(child, rel, out);
+    else out.push(rel);
+  }
+}

--- a/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
@@ -72,6 +72,9 @@ export function ClientExtensionsSection({
   const [listings, setListings] = useState<NamespaceListing[]>([]);
 
   useEffect(() => {
+    // Reset FIRST: on a folder change or a failed refetch, stale state would
+    // keep rendering the previous plugin's files under the new plugin's name.
+    setListings([]);
     if (!workspaceId || !kbDirName) return;
     let live = true;
     listFiles(workspaceId)

--- a/packages/core-frontend/src/modules/library/components/PluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginPage.tsx
@@ -193,8 +193,7 @@ export function PluginPage() {
           }}
           onManage={setManageFolder}
         />
-        <ClientExtensionsSection workspaceId={workspaceId} kbDirName={kbDirName} folder={plugin} />
-        {manageDialog}
+{manageDialog}
       </>
     );
   }
@@ -366,6 +365,7 @@ export function PluginPage() {
         />
       )}
 
+      <ClientExtensionsSection workspaceId={workspaceId} kbDirName={kbDirName} folder={plugin} />
       {manageDialog}
     </div>
   );

--- a/packages/core-frontend/src/modules/library/components/PluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginPage.tsx
@@ -11,6 +11,7 @@ import {
 import { primaryFolderOf } from '../utils/plugin-summary';
 import { PluginJoinRequests } from './PluginJoinRequests';
 import { useWorkspace } from '../../workspace/state/workspace.context';
+import { ManifestButton, ClientExtensionsSection } from './PluginExtras';
 import { ManageAccessDialog } from '../../access/components/ManageAccessDialog';
 import { AddToPluginDialog } from './AddToPluginDialog';
 import { BandControls, PluginBreadcrumb, PluginItemSections, PageNote, RemoveLibraryItemDialog,
@@ -44,7 +45,7 @@ export function PluginPage() {
   const data = useLibrary();
   const toast = useLibraryToast();
   const navigate = useNavigate();
-  const { kbDirName } = useWorkspace();
+  const { kbDirName, workspaceId } = useWorkspace();
   const [addOpen, setAddOpen] = useState(false);
   // The Skills band's two controls. `filterOn` narrows the band to what is
   // waiting on the reader; `refresh` re-reads the catalog and then says when it
@@ -192,6 +193,7 @@ export function PluginPage() {
           }}
           onManage={setManageFolder}
         />
+        <ClientExtensionsSection workspaceId={workspaceId} kbDirName={kbDirName} folder={plugin} />
         {manageDialog}
       </>
     );
@@ -230,7 +232,8 @@ export function PluginPage() {
           which is exactly what "who is this shared with?" should answer. */}
       <div className="flex items-start justify-between gap-4">
         <h1 className="mt-1.5 text-display font-semibold">{plugin}</h1>
-        <div className="mt-1.5">
+        <div className="mt-1.5 flex items-center gap-1">
+          <ManifestButton kbDirName={kbDirName} folder={plugin} canWrite={summary?.canWrite === true} />
           <PageActions
             onShare={primaryFolder ? () => setManageFolder(primaryFolder) : undefined}
             onAdd={() => setAddOpen(true)}

--- a/packages/core-frontend/src/modules/library/components/plugin-page-parts.tsx
+++ b/packages/core-frontend/src/modules/library/components/plugin-page-parts.tsx
@@ -138,6 +138,13 @@ export function CardGrid({
           <LibraryCard
             key={key}
             kind={item.kind}
+            flavor={
+              item.kind === 'integration'
+                ? item.path.endsWith('/mcp.json')
+                  ? 'mcp'
+                  : 'utcp'
+                : undefined
+            }
             id={item.id}
             name={item.name}
             description={item.description}

--- a/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
@@ -49,6 +49,7 @@ export function McpServerSection({
   const [literalHeaders, setLiteralHeaders] = useState('');
   const [authHeaders, setAuthHeaders] = useState('');
   const [local, setLocal] = useState(false);
+  const [variables, setVariables] = useState<McpServerView['variables']>([]);
 
   useEffect(() => {
     let live = true;
@@ -75,6 +76,7 @@ export function McpServerSection({
     setLiteralHeaders(headersToLines(server.literalHeaders));
     setAuthHeaders(headersToLines(server.authHeaders));
     setLocal(server.local);
+    setVariables(server.variables);
     setEditing(true);
   };
 
@@ -95,7 +97,7 @@ export function McpServerSection({
           : { url: url.trim() }),
         literalHeaders: linesToHeaders(literalHeaders),
         authHeaders: linesToHeaders(authHeaders),
-        variables: server.variables,
+        variables: variables.filter((v) => v.name.trim().length > 0),
         ...(server.description ? { description: server.description } : {}),
         local,
       });
@@ -189,6 +191,7 @@ export function McpServerSection({
             hint="One `Header: value` per line. Visible package data — no secrets here." />
           <LabeledTextarea label="Auth headers" value={authHeaders} onChange={setAuthHeaders}
             hint="One per line; values may use ${VAR} vault references, e.g. `Authorization: Bearer ${API_KEY}`." />
+          <VariablesEditor variables={variables} onChange={setVariables} />
           {transport !== 'stdio' && (
             <label className="flex items-center gap-2 text-detail text-ink-muted">
               <input type="checkbox" checked={local} onChange={(e) => setLocal(e.target.checked)} />
@@ -274,6 +277,69 @@ function LabeledTextarea({
       />
       {hint && <span className="text-ink-faint">{hint}</span>}
     </label>
+  );
+}
+
+/**
+ * Declared `${VAR}`s and who provisions each: `admin` (one shared value, set
+ * by a tool writer) or `user` (each member their own, on the Connect page).
+ * The names must match the `${VAR}` references in the auth headers — the vault
+ * key is `<server>_<VAR>`, derived from exactly these names.
+ */
+function VariablesEditor({
+  variables,
+  onChange,
+}: {
+  variables: McpServerView['variables'];
+  onChange(next: McpServerView['variables']): void;
+}) {
+  const update = (i: number, patch: Partial<McpServerView['variables'][number]>) =>
+    onChange(variables.map((v, j) => (j === i ? { ...v, ...patch } : v)));
+  return (
+    <div className="flex flex-col gap-1 text-detail">
+      <span className="font-semibold text-ink">Variables</span>
+      {variables.map((v, i) => (
+        // Index keys are correct here: rows are edited in place and have no
+        // identity beyond their position until saved.
+        // eslint-disable-next-line react/no-array-index-key
+        <div key={i} className="flex items-center gap-2">
+          <input
+            aria-label={`Variable ${i + 1} name`}
+            className="w-40 rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+            value={v.name}
+            onChange={(e) => update(i, { name: e.target.value })}
+          />
+          <select
+            aria-label={`Variable ${i + 1} scope`}
+            className="rounded-md border border-line bg-white px-2 py-1 text-ui"
+            value={v.scope}
+            onChange={(e) => update(i, { scope: e.target.value as 'admin' | 'user' })}
+          >
+            <option value="admin">admin — one shared value</option>
+            <option value="user">user — each member their own</option>
+          </select>
+          <input
+            aria-label={`Variable ${i + 1} label`}
+            className="min-w-0 flex-1 rounded-md border border-line bg-white px-2 py-1 text-ui"
+            placeholder="Label shown in the secrets UI"
+            value={v.label ?? ''}
+            onChange={(e) => update(i, { label: e.target.value || undefined })}
+          />
+          <Button variant="quiet" size="sm" onClick={() => onChange(variables.filter((_, j) => j !== i))}>
+            Remove
+          </Button>
+        </div>
+      ))}
+      <div>
+        <Button variant="outline" size="sm" onClick={() => onChange([...variables, { name: '', scope: 'admin' }])}>
+          Add variable
+        </Button>
+      </div>
+      <span className="text-ink-faint">
+        Names must match the {'`${VAR}`'} references in the auth headers; secrets are stored under{' '}
+        <code>&lt;server&gt;_&lt;VAR&gt;</code>.
+      </span>
+    </div>
   );
 }
 

--- a/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
@@ -57,8 +57,11 @@ export function McpServerSection({
       .then((view) => {
         if (live) setServer(view);
       })
-      .catch(() => {
-        /* the section simply does not render — the page stays a tool page */
+      .catch((err: unknown) => {
+        // A 404 already came back as null (a .tool-backed manual). Anything
+        // ELSE is a real failure, and vanishing silently would make it
+        // indistinguishable from that expected case.
+        if (live) onError(err instanceof Error ? err.message : 'Could not load the server configuration.');
       });
     return () => {
       live = false;

--- a/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Badge, Banner, Button, Dialog } from '../../../../shared/components';
+import {
+  getMcpServer,
+  putMcpServer,
+  type McpServerView,
+  type McpTransport,
+} from '../../services/tools.api';
+import { pathForTool } from '../../routes/library-paths';
+
+/**
+ * The server-scoped editor for an mcp.json-backed tool — the form that
+ * replaces dropping a writer into raw JSON. It shows nothing for `.tool`
+ * manuals (the GET 404s: those edit as files) and renders read-only facts for
+ * non-writers, whose editing surface this page has never been.
+ *
+ * RENAME CONFIRMS, WITH THE COST NAMED. The server's name is the namespace
+ * its vault secrets bind to (`<name>_<VAR>`), so renaming disconnects every
+ * configured value and completed sign-in under the old name. The page already
+ * knows how many that is; the dialog says the number instead of "are you
+ * sure".
+ */
+export function McpServerSection({
+  slug,
+  configuredCount,
+  onSaved,
+  onError,
+}: {
+  slug: string;
+  /** Configured secrets + sign-ins under this server's name — what a rename disconnects. */
+  configuredCount: number;
+  /** Called after a save lands; the new slug when the server was renamed. */
+  onSaved(newSlug?: string): void;
+  onError(message: string): void;
+}) {
+  const navigate = useNavigate();
+  const [server, setServer] = useState<McpServerView | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [confirmingRename, setConfirmingRename] = useState(false);
+
+  // Draft fields, seeded from the loaded view when editing opens.
+  const [name, setName] = useState('');
+  const [transport, setTransport] = useState<McpTransport>('streamable-http');
+  const [url, setUrl] = useState('');
+  const [command, setCommand] = useState('');
+  const [args, setArgs] = useState('');
+  const [literalHeaders, setLiteralHeaders] = useState('');
+  const [authHeaders, setAuthHeaders] = useState('');
+  const [local, setLocal] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    getMcpServer(slug)
+      .then((view) => {
+        if (live) setServer(view);
+      })
+      .catch(() => {
+        /* the section simply does not render — the page stays a tool page */
+      });
+    return () => {
+      live = false;
+    };
+  }, [slug]);
+
+  if (!server) return null;
+
+  const openEditor = () => {
+    setName(server.name);
+    setTransport(server.transport);
+    setUrl(server.url ?? '');
+    setCommand(server.command ?? '');
+    setArgs((server.args ?? []).join(' '));
+    setLiteralHeaders(headersToLines(server.literalHeaders));
+    setAuthHeaders(headersToLines(server.authHeaders));
+    setLocal(server.local);
+    setEditing(true);
+  };
+
+  const save = async () => {
+    const renaming = name.trim() !== server.name;
+    if (renaming && !confirmingRename && configuredCount > 0) {
+      setConfirmingRename(true);
+      return;
+    }
+    setSaving(true);
+    setConfirmingRename(false);
+    try {
+      const result = await putMcpServer(slug, {
+        ...(renaming ? { newName: name.trim() } : {}),
+        transport,
+        ...(transport === 'stdio'
+          ? { command: command.trim(), args: args.trim() ? args.trim().split(/\s+/) : [] }
+          : { url: url.trim() }),
+        literalHeaders: linesToHeaders(literalHeaders),
+        authHeaders: linesToHeaders(authHeaders),
+        variables: server.variables,
+        ...(server.description ? { description: server.description } : {}),
+        local,
+      });
+      setEditing(false);
+      if (result.name !== server.name) {
+        // The slug IS the name — the old page no longer exists.
+        navigate(pathForTool(result.name), { replace: true });
+        onSaved(result.name);
+      } else {
+        setServer(null); // refetch on next render via onSaved's reload
+        onSaved();
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="mt-8">
+      <h2 className="mb-2.5 flex items-center gap-2 text-label font-semibold uppercase text-ink-faint">
+        Server
+        <Badge tone="outline" size="xs" className="uppercase">
+          MCP server
+        </Badge>
+      </h2>
+
+      {!editing && (
+        <div className="flex items-start justify-between gap-4 rounded-md border border-line px-3.5 py-2.5">
+          <dl className="min-w-0 text-detail text-ink-muted">
+            <div className="flex gap-2">
+              <dt className="shrink-0 font-semibold">Transport</dt>
+              <dd>{server.transport}</dd>
+            </div>
+            {server.url && (
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-semibold">URL</dt>
+                <dd className="truncate">{server.url}</dd>
+              </div>
+            )}
+            {server.command && (
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-semibold">Command</dt>
+                <dd className="truncate">
+                  {server.command} {(server.args ?? []).join(' ')}
+                </dd>
+              </div>
+            )}
+            {server.local && (
+              <div className="mt-1 text-ink-faint">
+                Runs locally — served by hexis-mcp on each member's machine, never by the workspace.
+              </div>
+            )}
+          </dl>
+          {server.canWrite && (
+            <Button variant="outline" size="sm" onClick={openEditor}>
+              Edit server
+            </Button>
+          )}
+        </div>
+      )}
+
+      {editing && (
+        <div className="flex flex-col gap-3 rounded-md border border-line px-3.5 py-3">
+          <LabeledInput label="Name" value={name} onChange={setName} mono
+            hint="The name is this server's secret namespace — renaming disconnects configured secrets." />
+          <label className="flex flex-col gap-1 text-detail">
+            <span className="font-semibold text-ink">Transport</span>
+            <select
+              className="rounded-md border border-line bg-white px-2.5 py-1.5 text-ui"
+              value={transport}
+              onChange={(e) => setTransport(e.target.value as McpTransport)}
+            >
+              <option value="streamable-http">streamable-http</option>
+              <option value="sse">sse (legacy)</option>
+              <option value="stdio">stdio — runs on each member's machine</option>
+            </select>
+          </label>
+          {transport === 'stdio' ? (
+            <>
+              <LabeledInput label="Command" value={command} onChange={setCommand} mono
+                hint="A bare executable name, or a ./ path inside the plugin." />
+              <LabeledInput label="Arguments" value={args} onChange={setArgs} mono
+                hint="Space-separated. ${PLUGIN_ROOT} and ${PLUGIN_DATA} expand at launch." />
+            </>
+          ) : (
+            <LabeledInput label="URL" value={url} onChange={setUrl} mono />
+          )}
+          <LabeledTextarea label="Headers (portable)" value={literalHeaders} onChange={setLiteralHeaders}
+            hint="One `Header: value` per line. Visible package data — no secrets here." />
+          <LabeledTextarea label="Auth headers" value={authHeaders} onChange={setAuthHeaders}
+            hint="One per line; values may use ${VAR} vault references, e.g. `Authorization: Bearer ${API_KEY}`." />
+          {transport !== 'stdio' && (
+            <label className="flex items-center gap-2 text-detail text-ink-muted">
+              <input type="checkbox" checked={local} onChange={(e) => setLocal(e.target.checked)} />
+              Local-only — reachable only from a member's own machine (e.g. localhost)
+            </label>
+          )}
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => void save()} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+            <Button variant="quiet" size="sm" onClick={() => setEditing(false)} disabled={saving}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {confirmingRename && (
+        <Dialog open onClose={() => setConfirmingRename(false)} title="Rename this server?">
+          <Banner tone="danger" role="alert" className="mb-3">
+            Renaming <b>{server.name}</b> to <b>{name.trim()}</b> disconnects{' '}
+            {configuredCount === 1 ? '1 configured secret or sign-in' : `${configuredCount} configured secrets and sign-ins`}{' '}
+            — they are stored under the old name and every one must be set up again.
+          </Banner>
+          <div className="flex justify-end gap-2">
+            <Button variant="quiet" size="sm" onClick={() => setConfirmingRename(false)}>
+              Keep the name
+            </Button>
+            <Button size="sm" onClick={() => void save()}>
+              Rename anyway
+            </Button>
+          </div>
+        </Dialog>
+      )}
+    </section>
+  );
+}
+
+function LabeledInput({
+  label,
+  value,
+  onChange,
+  hint,
+  mono,
+}: {
+  label: string;
+  value: string;
+  onChange(v: string): void;
+  hint?: string;
+  mono?: boolean;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-detail">
+      <span className="font-semibold text-ink">{label}</span>
+      <input
+        className={`rounded-md border border-line bg-white px-2.5 py-1.5 text-ui ${mono ? 'font-mono' : ''}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint && <span className="text-ink-faint">{hint}</span>}
+    </label>
+  );
+}
+
+function LabeledTextarea({
+  label,
+  value,
+  onChange,
+  hint,
+}: {
+  label: string;
+  value: string;
+  onChange(v: string): void;
+  hint?: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-detail">
+      <span className="font-semibold text-ink">{label}</span>
+      <textarea
+        className="min-h-16 rounded-md border border-line bg-white px-2.5 py-1.5 font-mono text-ui"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint && <span className="text-ink-faint">{hint}</span>}
+    </label>
+  );
+}
+
+function headersToLines(headers: Record<string, string>): string {
+  return Object.entries(headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+}
+
+function linesToHeaders(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}

--- a/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
@@ -145,7 +145,7 @@ export function ToolPage({
 
       <McpServerSection
         slug={tool.slug}
-        configuredCount={tool.variables.filter((v) => v.adminConfigured || v.userConfigured).length}
+        configuredCount={tool.variables.filter((v) => v.adminConfigured || v.userConfigured || v.authorized === true).length}
         onSaved={() => {
           setActionError(null);
           page.reload();

--- a/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Banner, Button, buttonClasses } from '../../../../shared/components';
 import { useToolPage } from '../../hooks/useToolPage';
+import { McpServerSection } from './McpServerSection';
 import { libraryHomeForItemPath, LIBRARY_ROOT } from '../../routes/library-paths';
 import { readOAuthFragment } from '../../utils/oauth-fragment';
 import type { ToolCapability } from '../../services/tools.api';
@@ -136,6 +137,16 @@ export function ToolPage({
       <ToolConnectionSection
         tool={tool}
         onChanged={() => {
+          setActionError(null);
+          page.reload();
+        }}
+        onError={setActionError}
+      />
+
+      <McpServerSection
+        slug={tool.slug}
+        configuredCount={tool.variables.filter((v) => v.adminConfigured || v.userConfigured).length}
+        onSaved={() => {
           setActionError(null);
           page.reload();
         }}

--- a/packages/core-frontend/src/modules/library/services/tools.api.ts
+++ b/packages/core-frontend/src/modules/library/services/tools.api.ts
@@ -58,3 +58,49 @@ export async function getToolDetail(slug: string): Promise<ToolManualDetail> {
   if (!res.ok) await unwrap(res, "Couldn't load this tool.");
   return ((await res.json()) as { tool: ToolManualDetail }).tool;
 }
+
+/**
+ * The server-scoped view/edit surface for an mcp.json-backed tool. One
+ * server's truth spans two files (mcp.json + plugin.json's extensions block);
+ * these endpoints are the pair kept in step, so the form never shows a writer
+ * half of it. Absent (404) for `.tool`-backed manuals — those edit as files.
+ */
+export type McpTransport = 'streamable-http' | 'sse' | 'stdio';
+
+export interface McpServerView {
+  name: string;
+  transport: McpTransport;
+  url?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  literalHeaders: Record<string, string>;
+  authHeaders: Record<string, string>;
+  variables: { name: string; scope: 'admin' | 'user'; label?: string }[];
+  description?: string;
+  local: boolean;
+  canWrite: boolean;
+}
+
+export type McpServerWrite = Omit<Partial<McpServerView>, 'name' | 'canWrite'> & {
+  transport: McpTransport;
+  newName?: string;
+};
+
+export async function getMcpServer(slug: string): Promise<McpServerView | null> {
+  const res = await authFetch(`/api/tools/${encodeURIComponent(slug)}/server`);
+  if (res.status === 404) return null; // a .tool-backed manual — no server pair
+  if (!res.ok) await unwrap(res, "Couldn't load the server configuration.");
+  return (await res.json()) as McpServerView;
+}
+
+export async function putMcpServer(slug: string, write: McpServerWrite): Promise<{ name: string }> {
+  const res = await authFetch(`/api/tools/${encodeURIComponent(slug)}/server`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(write),
+  });
+  if (!res.ok) await unwrap(res, "Couldn't save the server configuration.");
+  return (await res.json()) as { name: string };
+}


### PR DESCRIPTION
Stacked on #73. The editing layer for the restructured plugin page, built by reuse: every file-open is the existing `kbFileUrl` + `rawFile` navigation into the Knowledge raw editor, and the extensions browser reads the already-loaded, ACL-filtered workspace file tree — no new viewers, one new endpoint pair.

## The server editor

One MCP server's truth spans two files (`mcp.json` + `plugin.json`'s extensions block), so a raw file editor shows a writer half of it at best. `GET`/`PUT /api/tools/:slug/server` serve the merged view and rewrite both entries in one folder-scoped commit. The service reroutes any `${VAR}` arriving in the portable headers into the extensions block — `mcp.json` never carries a credential reference regardless of what a client sends — and gates writes on the plugin's own `canWrite`. `.tool`-backed manuals 404 here and keep editing as files.

**Renaming confirms with the cost named.** The server's name is the vault namespace (`<name>_<VAR>`); the dialog states how many configured secrets and sign-ins disconnect, counted from status the page already holds, and the save cannot fire until "Rename anyway". Renames onto a taken key are 409.

The form covers transport (streamable-http / sse / stdio with command+args), portable vs auth headers, the local flag, and editable variable declarations (name, admin/user scope, label).

## The plugin page

- Tools band badges each integration **MCP server** or **UTCP manual**.
- Writers get a **Manifest** button — deliberately the file, not a form: the hand-editable fields are plain JSON, and the extensions block is machine-written by the server editor, which a form would duplicate or fight.
- A **client-specific extensions** section lists reverse-DNS namespace directories with their files. The spec's reservation cuts both ways: a plugin authored for another client carries directories this platform cannot interpret either, and this is how someone inspects one.

## Verification

7 service tests (merge, rename across both files, `${VAR}` rerouting, access gate, stdio), 4 component tests (self-hiding on 404, writer gating, rename interception with the count asserted), suites green — backend, frontend 1173 — typecheck across all 7 projects.

Not covered: no component test for `PluginExtras` (manifest button + extensions browser — both thin composition over existing pieces), and the server editor has not been exercised against a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Edit MCP tools as servers, not raw JSON, to keep one truth across mcp.json and the plugin’s extensions block. Writers use GET/PUT `/api/tools/:slug/server` to read and save both files in one commit; `${VAR}` credentials never land in mcp.json.

- Adds `/api/tools/:slug/server` (GET/PUT). `.tool` manuals return 404 and continue to edit as files; writes gate on the plugin’s `canWrite`. Returns 403 (no access), 404 (no server), 409 (rename collision), 422 (bad input: unknown transport, malformed `extensions`, invalid name/URL, or SSRF unless marked local‑only).
- Saves rewrite both files and commit the plugin folder once; invalidates the catalog. Reroutes any `${VAR}` seen in “portable” headers to the extensions auth headers — mcp.json never stores credential references.
- Supports `streamable-http`, `sse`, and `stdio` (with `command`/`args`, no URL). Exposes `local` and editable variable declarations (name, admin/user scope, label).
- Renaming changes the server key used by vault secrets; names must be unique and match the namespace pattern. The UI confirms with the number of disconnected secrets and completed sign-ins; save waits for “Rename anyway”.

- Tool page adds a Server section: shows facts for everyone; writers get a form (transport, URL or command/args, portable headers, auth headers, variables, local).
- Plugin page adds a Manifest button that opens `plugin.json` in the Knowledge raw editor, and a client‑specific extensions section listing reverse‑DNS namespaces with links. Fixes placement to render in the main view only; listings reset on plugin change or failed refetch.
- Library cards badge integrations as “MCP server” or “UTCP manual”.

<sup>Written for commit 73dc137c856a3e803526084ca0b4ca6a024e7b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

