### PR TITLE
read_file returns images as images

### DIFF
--- a/.changeset/wise-pandas-see.md
+++ b/.changeset/wise-pandas-see.md
@@ -1,0 +1,7 @@
+---
+"@bevel-software/platform-core-backend": minor
+"@bevel-software/platform-mcp-core": minor
+"@bevel-software/hexis-mcp": minor
+---
+
+`read_file` on an image returns the image itself as native MCP image content. A `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp` read comes back as an MCP image content block (base64 + mimeType) plus a one-line text note naming the path, size and dimensions — so a multimodal client actually sees the picture instead of a binary-file notice. `.svg` stays on the text path. Images over 3.5 MB raw are refused with an honest message (base64 inflation would push them past what Claude-family clients accept — downscale locally or upload a smaller export). The local `hexis-mcp` server forwards the image blocks unmangled, and `call_tool_chain` deliberately omits image payloads from chain results (a chained image read yields an `{ image_omitted, note }` stub — images are only delivered on a direct `read_file` call).

--- a/packages/core-backend/src/modules/code-mode/__tests__/code-mode.tool.test.ts
+++ b/packages/core-backend/src/modules/code-mode/__tests__/code-mode.tool.test.ts
@@ -65,3 +65,33 @@ describe('tools_info', () => {
     await expect(run(['solo.run', 'down.run'])).rejects.toThrow(/repository unavailable/);
   });
 });
+
+/**
+ * The in-process agent's `call_tool_chain` shares the MCP surfaces' image
+ * policy: a chain result is stringified into the transcript, so an image read
+ * inside it must come back as an omitted-image note — never inline base64.
+ */
+describe('call_tool_chain image scrub', () => {
+  it('replaces a chained image sentinel with a note before serialization', async () => {
+    const { createCallToolChainTool } = await import('../code-mode.tool.js');
+    const sentinel = {
+      kind: 'bevel/mcp-image@v1',
+      data: 'QUJDREVG',
+      mimeType: 'image/png',
+      note: '[image: Files/logo.png — image/png, 6 bytes]',
+    };
+    const chainClient = {
+      callToolChain: vi.fn(async () => ({ result: { pic: sentinel, ok: true }, logs: [] as string[] })),
+    } as unknown as CodeModeUtcpClient;
+    const spill = { write: vi.fn(async () => ({ ref: '__tool_chain_spill__/x.json', bytes: 1 })) };
+    const tool = createCallToolChainTool(chainClient, spill as never) as unknown as {
+      execute: (input: { code: string }) => Promise<unknown>;
+    };
+    const out = JSON.stringify(await tool.execute({ code: 'return 1' }));
+    expect(out).not.toContain('QUJDREVG');
+    expect(out).toContain('image_omitted');
+    expect(out).toContain('Files/logo.png');
+    expect(out).toContain('"ok":true');
+    expect(spill.write).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core-backend/src/modules/code-mode/code-mode.tool.ts
+++ b/packages/core-backend/src/modules/code-mode/code-mode.tool.ts
@@ -2,6 +2,7 @@ import '@utcp/direct-call';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import { CodeModeUtcpClient } from '@utcp/code-mode';
+import { omitImagePayloads } from '@bevel-software/platform-mcp-core';
 import type { SpillStore } from '../workspace/spill-store.js';
 import { utcpNameToTsInterfaceName, findToolByName, AmbiguousToolNameError } from './code-mode-names.js';
 
@@ -43,7 +44,12 @@ export function createCallToolChainTool(
       const timeout = input.timeout ?? 30_000;
       const maxOutputSize = input.max_output_size ?? 200_000;
       try {
-        const { result, logs } = await client.callToolChain(input.code, timeout);
+        const { result: rawResult, logs } = await client.callToolChain(input.code, timeout);
+        // Same policy as the MCP surfaces' `call_tool_chain` (see
+        // `omitImagePayloads`): a chain result is stringified JSON, so an image
+        // read inside it comes back as an omitted-image note instead of a
+        // base64 flood — images are only delivered on a direct `read_file`.
+        const result = omitImagePayloads(rawResult);
         const json = JSON.stringify({ success: true, result, logs });
         if (json.length <= maxOutputSize) {
           return { success: true, result, logs };

--- a/packages/core-backend/src/modules/workspace/__tests__/image-read.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/image-read.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IMAGE_MAX_RAW_BYTES,
+  imageDimensions,
+  imageMimeType,
+  imageNote,
+  isImageFile,
+  oversizedImageNotice,
+} from '../image-read.js';
+
+/** A real, complete 1×1 transparent PNG. */
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+/** A real, complete 1×1 GIF89a. */
+const GIF_1X1 = Buffer.from('R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==', 'base64');
+
+/** A minimal JPEG prefix: SOI, an APP0 stub, then an SOF0 declaring 4×3. */
+function jpegWithSof(width: number, height: number): Buffer {
+  const app0 = Buffer.from([0xff, 0xe0, 0x00, 0x04, 0x00, 0x00]); // 4-byte segment
+  const sof0 = Buffer.alloc(2 + 2 + 5 + 3);
+  sof0.set([0xff, 0xc0]); // SOF0 marker
+  sof0.writeUInt16BE(sof0.length - 2, 2); // segment length
+  sof0[4] = 8; // precision
+  sof0.writeUInt16BE(height, 5);
+  sof0.writeUInt16BE(width, 7);
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app0, sof0]);
+}
+
+describe('isImageFile / imageMimeType', () => {
+  it('covers exactly the five raster extensions, case-insensitively', () => {
+    expect(isImageFile('a/b/logo.png')).toBe(true);
+    expect(isImageFile('photo.JPG')).toBe(true);
+    expect(isImageFile('photo.jpeg')).toBe(true);
+    expect(isImageFile('anim.gif')).toBe(true);
+    expect(isImageFile('pic.webp')).toBe(true);
+    // SVG is TEXT — must flow through the normal text path.
+    expect(isImageFile('icon.svg')).toBe(false);
+    expect(isImageFile('favicon.ico')).toBe(false);
+    expect(isImageFile('image.bmp')).toBe(false);
+    expect(isImageFile('doc.pdf')).toBe(false);
+  });
+
+  it('maps jpg and jpeg to image/jpeg', () => {
+    expect(imageMimeType('a.jpg')).toBe('image/jpeg');
+    expect(imageMimeType('a.jpeg')).toBe('image/jpeg');
+    expect(imageMimeType('a.png')).toBe('image/png');
+  });
+});
+
+describe('imageDimensions', () => {
+  it('reads PNG IHDR', () => {
+    expect(imageDimensions(PNG_1X1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('reads the GIF logical screen descriptor', () => {
+    expect(imageDimensions(GIF_1X1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('walks JPEG segments to the SOF0 frame header', () => {
+    expect(imageDimensions(jpegWithSof(640, 480))).toEqual({ width: 640, height: 480 });
+  });
+
+  it('returns undefined (never throws) for truncated or unknown bytes', () => {
+    expect(imageDimensions(Buffer.from([0x89, 0x50]))).toBeUndefined();
+    expect(imageDimensions(Buffer.from([0xff, 0xd8, 0xff, 0xd9]))).toBeUndefined();
+    expect(imageDimensions(Buffer.from('RIFFxxxxWEBP'))).toBeUndefined(); // webp: honestly dimensionless
+    expect(imageDimensions(Buffer.alloc(0))).toBeUndefined();
+  });
+});
+
+describe('cap + notes', () => {
+  it('the cap is 3.5 MiB raw, whose base64 stays under the ~5 MB client reject line', () => {
+    expect(IMAGE_MAX_RAW_BYTES).toBe(3_670_016);
+    const encodedChars = Math.ceil(IMAGE_MAX_RAW_BYTES / 3) * 4;
+    expect(encodedChars).toBeLessThan(5 * 1024 * 1024);
+  });
+
+  it('imageNote includes dimensions when known and omits them cleanly when not', () => {
+    expect(imageNote('a/logo.png', 'image/png', 67, { width: 1, height: 1 })).toBe(
+      '[image: a/logo.png — image/png, 67 bytes, 1×1 px]',
+    );
+    expect(imageNote('p.webp', 'image/webp', 10, undefined)).toBe('[image: p.webp — image/webp, 10 bytes]');
+  });
+
+  it('oversizedImageNotice names the file, the cap arithmetic and the way out', () => {
+    const notice = oversizedImageNotice('big.png', 'image/png', 9_999_999);
+    expect(notice).toContain('big.png');
+    expect(notice).toContain('9999999 bytes');
+    expect(notice).toContain('3670016 bytes');
+    expect(notice).toContain('Downscale');
+    expect(notice).toContain('upload a smaller export');
+  });
+});

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -574,9 +574,10 @@ describe('office documents and PDFs', () => {
 
   it('read_file answers other binary files with a one-line notice (zip names the unzip tool)', async () => {
     const base = await start();
-    await fs.writeFile('img.png', Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]));
-    const png = await readContent(base, 'img.png');
-    expect(png).toBe('[img.png is a binary file (image/png, 9 bytes) — not readable as text.]');
+    // .mp3, not an image: images return native MCP image content (see below).
+    await fs.writeFile('song.mp3', Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]));
+    const mp3 = await readContent(base, 'song.mp3');
+    expect(mp3).toBe('[song.mp3 is a binary file (audio/mpeg, 9 bytes) — not readable as text.]');
     await fs.writeFile('bundle.zip', Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x00]));
     const zip = await readContent(base, 'bundle.zip');
     expect(zip).toContain('application/zip');
@@ -601,6 +602,97 @@ describe('office documents and PDFs', () => {
     expect((await post(`${base}/api/agent/tools/read_file`, { path: 'ok.md' })).status).not.toBe(200);
     // And the pptx is untouched: reading it still extracts the original text.
     expect(await readContent(base, 'deck.pptx')).toContain('Original');
+  });
+});
+
+/**
+ * Image reads: `read_file` on an image returns the `McpImageResult` sentinel
+ * (base64 + mimeType + self-describing note) that the MCP result shaping turns
+ * into a native image content block — never raw bytes and never the binary
+ * notice. Real fixtures: a genuine 1×1 PNG and 1×1 GIF.
+ */
+describe('images', () => {
+  /** A real, complete 1×1 transparent PNG. */
+  const PNG_1X1 = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+    'base64',
+  );
+  /** A real, complete 1×1 GIF89a. */
+  const GIF_1X1 = Buffer.from('R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==', 'base64');
+
+  interface ImageSentinel {
+    kind: string;
+    data: string;
+    mimeType: string;
+    note: string;
+  }
+
+  it('read_file on a png returns the image sentinel with base64, mimeType and a note naming path + dimensions + size', async () => {
+    const base = await start();
+    await fs.writeFile('logo.png', PNG_1X1);
+    const res = await post(`${base}/api/agent/tools/read_file`, { path: 'logo.png' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ImageSentinel;
+    expect(body.kind).toBe('bevel/mcp-image@v1');
+    expect(body.mimeType).toBe('image/png');
+    expect(body.data).toBe(PNG_1X1.toString('base64'));
+    expect(body.note).toContain('logo.png');
+    expect(body.note).toContain('image/png');
+    expect(body.note).toContain(`${PNG_1X1.length} bytes`);
+    expect(body.note).toContain('1×1 px');
+  });
+
+  it('read_file passes a gif through whole under the same cap (first frame is the client’s concern)', async () => {
+    const base = await start();
+    await fs.writeFile('anim.gif', GIF_1X1);
+    const body = (await (await post(`${base}/api/agent/tools/read_file`, { path: 'anim.gif' })).json()) as ImageSentinel;
+    expect(body.kind).toBe('bevel/mcp-image@v1');
+    expect(body.mimeType).toBe('image/gif');
+    expect(body.data).toBe(GIF_1X1.toString('base64'));
+    expect(body.note).toContain('1×1 px');
+  });
+
+  it('read_file maps .jpg/.jpeg to image/jpeg (dimensions omitted when the header has none to give)', async () => {
+    const base = await start();
+    const bytes = Buffer.from([0xff, 0xd8, 0xff, 0xd9]); // SOI + EOI, no frame header
+    await fs.writeFile('photo.jpg', bytes);
+    const body = (await (await post(`${base}/api/agent/tools/read_file`, { path: 'photo.jpg' })).json()) as ImageSentinel;
+    expect(body.mimeType).toBe('image/jpeg');
+    expect(body.data).toBe(bytes.toString('base64'));
+    expect(body.note).toBe(`[image: photo.jpg — image/jpeg, ${bytes.length} bytes]`);
+  });
+
+  it('read_file refuses an image over 3.5 MiB raw with the downscale message, not a sentinel', async () => {
+    const base = await start();
+    // 3,670,016 is the cap; one byte over must refuse. PNG magic + zero fill.
+    const big = Buffer.alloc(3_670_017);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(big);
+    await fs.writeFile('huge.png', big);
+    const res = await post(`${base}/api/agent/tools/read_file`, { path: 'huge.png' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string; content: string };
+    expect(body.path).toBe('huge.png');
+    expect(body.content).toContain('too large to return over MCP');
+    expect(body.content).toContain('3670016 bytes');
+    expect(body.content).toContain('Downscale');
+    expect(body.content).not.toContain(big.toString('base64').slice(0, 40));
+  });
+
+  it('read_file keeps .svg on the TEXT path — it is markup, not an image block', async () => {
+    const base = await start();
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8"/></svg>';
+    await fs.writeFile('icon.svg', svg);
+    expect(await (await post(`${base}/api/agent/tools/read_file`, { path: 'icon.svg' })).json()).toEqual({
+      path: 'icon.svg',
+      content: svg,
+    });
+  });
+
+  it('read_file on an image still honors the read gate (403 before any bytes are returned)', async () => {
+    const base = await start('write', denyReads(new Set(['Knowledge/Secret.png'])));
+    await fs.writeFile(`${KB_DIR}/Knowledge/Secret.png`, PNG_1X1);
+    const res = await post(`${base}/api/agent/tools/read_file`, { path: `${KB_DIR}/Knowledge/Secret.png` });
+    expect(res.status).toBe(403);
   });
 });
 

--- a/packages/core-backend/src/modules/workspace/image-read.ts
+++ b/packages/core-backend/src/modules/workspace/image-read.ts
@@ -1,0 +1,115 @@
+/**
+ * `read_file` image support: which files come back as a native MCP image
+ * content block instead of text, the size cap that keeps the encoded payload
+ * under what Claude-family clients accept, and the self-describing note that
+ * rides beside the image so the transcript still says what was read.
+ *
+ * Deliberately dependency-free: dimensions are parsed straight from the
+ * container headers (PNG/GIF/JPEG) rather than through a native image library.
+ * No downscaling in this increment — `sharp` is a heavy native dependency, so
+ * an oversized image gets an honest refusal telling the caller to downscale
+ * locally or upload a smaller export.
+ */
+import { fileExtension } from './doc-extract/doc-extract.types.js';
+
+/** The image types `read_file` returns as a native MCP image content block. `.svg` is TEXT and stays on the text path. */
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  // GIF passes through whole under the same cap; clients render the first frame.
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
+
+/** Is this a file `read_file` should return as an image? */
+export function isImageFile(path: string): boolean {
+  return fileExtension(path) in IMAGE_MIME_BY_EXT;
+}
+
+/** The MCP mime type for an image path — call only after `isImageFile`. */
+export function imageMimeType(path: string): string {
+  return IMAGE_MIME_BY_EXT[fileExtension(path)]!;
+}
+
+/**
+ * Cap on the RAW bytes of an image `read_file` will return.
+ *
+ * The arithmetic: Claude-family clients reject a base64 image payload around
+ * 5 MB encoded (5 * 1024 * 1024 = 5,242,880 chars). Base64 inflates by 4/3,
+ * so the raw ceiling for that limit is 5,242,880 * 3/4 = 3,932,160 bytes. We
+ * cap at 3.5 MiB raw = 3,670,016 bytes, which encodes to
+ * ceil(3,670,016 / 3) * 4 = 4,893,356 base64 chars (~4.67 MiB) — under the
+ * reject line with headroom for the JSON envelope the sentinel travels in.
+ */
+export const IMAGE_MAX_RAW_BYTES = 3.5 * 1024 * 1024; // = 3,670,016
+
+/** Width×height parsed from the container header, when the format makes that cheap. */
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Best-effort dimensions straight from the header bytes: PNG (IHDR), GIF
+ * (logical screen descriptor), JPEG (SOFn scan). WebP is left dimensionless —
+ * its three sub-formats (VP8/VP8L/VP8X) each encode size differently, and the
+ * note is honest without it. Returns undefined on anything unexpected; never
+ * throws (a corrupt image must still be delivered or refused, not 500).
+ */
+export function imageDimensions(bytes: Buffer): ImageDimensions | undefined {
+  try {
+    // PNG: 8-byte signature, then the IHDR chunk — width/height at 16/20 (BE).
+    if (bytes.length >= 24 && bytes.readUInt32BE(0) === 0x89504e47 && bytes.toString('latin1', 12, 16) === 'IHDR') {
+      return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
+    }
+    // GIF: "GIF87a"/"GIF89a", then the logical screen size at 6/8 (LE).
+    if (bytes.length >= 10 && bytes.toString('latin1', 0, 3) === 'GIF') {
+      return { width: bytes.readUInt16LE(6), height: bytes.readUInt16LE(8) };
+    }
+    // JPEG: walk the marker segments to the first SOFn frame header.
+    if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+      let i = 2;
+      while (i + 9 < bytes.length) {
+        if (bytes[i] !== 0xff) {
+          i += 1; // stray fill byte — resync
+          continue;
+        }
+        const marker = bytes[i + 1]!;
+        // Standalone markers (no length field): padding, restarts, SOI/EOI.
+        if (marker === 0xff) {
+          i += 1;
+          continue;
+        }
+        if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) {
+          i += 2;
+          continue;
+        }
+        // SOFn (C0–CF except the non-frame C4/C8/CC): height at +5, width at +7.
+        if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+          return { height: bytes.readUInt16BE(i + 5), width: bytes.readUInt16BE(i + 7) };
+        }
+        i += 2 + bytes.readUInt16BE(i + 2);
+      }
+    }
+  } catch {
+    // Truncated/corrupt header — the note simply omits dimensions.
+  }
+  return undefined;
+}
+
+/** The one-line note emitted as a text block beside the image, so the transcript names what it shows. */
+export function imageNote(path: string, mime: string, sizeBytes: number, dims: ImageDimensions | undefined): string {
+  const dimsPart = dims ? `, ${dims.width}×${dims.height} px` : '';
+  return `[image: ${path} — ${mime}, ${sizeBytes} bytes${dimsPart}]`;
+}
+
+/** The honest refusal for an image over {@link IMAGE_MAX_RAW_BYTES} — returned as the file's text content. */
+export function oversizedImageNotice(path: string, mime: string, sizeBytes: number): string {
+  return (
+    `[${path} is a ${mime} image of ${sizeBytes} bytes — too large to return over MCP. The cap is ` +
+    `${IMAGE_MAX_RAW_BYTES} bytes (3.5 MiB) of raw image data, because base64 encoding inflates it by 4/3 and ` +
+    'Claude-family clients reject images near 5 MB encoded. Downscale the image locally or upload a smaller ' +
+    'export, then read that file instead.]'
+  );
+}

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -26,6 +26,15 @@ import { toKbRelative, resolveReadableMap } from '../access-model/kb-read-filter
 import type { SpillStore } from './spill-store.js';
 import type { DocExtractService } from './doc-extract/doc-extract.service.js';
 import { fileExtension, isLegacyDocument, isSupportedDocument } from './doc-extract/doc-extract.types.js';
+import { mcpImageResult } from '@bevel-software/platform-mcp-core';
+import {
+  IMAGE_MAX_RAW_BYTES,
+  imageDimensions,
+  imageMimeType,
+  imageNote,
+  isImageFile,
+  oversizedImageNotice,
+} from './image-read.js';
 
 /** A directory entry as returned by `LocalFilesystem.readdir`. */
 interface DirEntry {
@@ -167,8 +176,8 @@ const MIME_BY_EXT: Record<string, string> = {
  * The honest one-line notice `read_file` returns INSTEAD of raw bytes for a
  * binary file it cannot extract: what the file is (mime by extension + size),
  * plus the actionable hint where one exists — unzip for archives, convert for
- * legacy office formats. (Images get native handling in a later increment;
- * for now they take the same one-liner naming their type.)
+ * legacy office formats. (Images never reach this: they are intercepted first
+ * and returned as native MCP image content — see `image-read.ts`.)
  */
 function binaryReadNotice(path: string, sizeBytes: number): string {
   const ext = fileExtension(path);
@@ -394,7 +403,7 @@ export function registerWorkspaceTools(
   mount({
     name: 'read_file',
     description:
-      'Read a workspace file as text. Returns `{ path, content }`. Office documents (.docx/.pptx/.xlsx) and PDFs return their EXTRACTED text under an honest `[extracted text of …]` header, with `[slide N]`/`[sheet: Name]`/`[page N]` markers — the extraction is READ-ONLY (layout/images omitted; such files cannot be edited as text, only replaced by uploading a new version). Other binary files return a one-line description instead of raw bytes. Optional `offset`/`limit` slice the content (characters for a file, bytes for a `__tool_chain_spill__/…` ref) — use them to page through large files or a `call_tool_chain` spill rather than reading multi-MB in full. A spill ref is workspace-independent: `branch` is ignored for it.' +
+      'Read a workspace file as text. Returns `{ path, content }`. Images (.png/.jpg/.jpeg/.gif/.webp) return the IMAGE ITSELF as native MCP image content (plus a one-line text note naming the file), so you can look at the picture — up to 3.5 MB of raw image data; a larger image gets an honest refusal asking for a locally downscaled copy or a smaller export (`.svg` is text and reads as text). Images come back only on a DIRECT call: inside `call_tool_chain` an image read yields an `{ image_omitted, note }` stub instead. Office documents (.docx/.pptx/.xlsx) and PDFs return their EXTRACTED text under an honest `[extracted text of …]` header, with `[slide N]`/`[sheet: Name]`/`[page N]` markers — the extraction is READ-ONLY (layout/images omitted; such files cannot be edited as text, only replaced by uploading a new version). Other binary files return a one-line description instead of raw bytes. Optional `offset`/`limit` slice the content (characters for a file, bytes for a `__tool_chain_spill__/…` ref; ignored for an image) — use them to page through large files or a `call_tool_chain` spill rather than reading multi-MB in full. A spill ref is workspace-independent: `branch` is ignored for it.' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
@@ -424,9 +433,28 @@ export function registerWorkspaceTools(
       await recordOntologyRead(sessionOntologyGate, ctx, p);
       await assertCanRead(readGateFor(a.branch as string, ctx), p);
       const fs = await ctx.getFilesystem(a.branch as string);
-      // Extraction (and the binary notice) happen AFTER the access gate and the
-      // ontology-read recording above — a document read is still a KB read.
+      // Extraction (and the binary/image handling) happen AFTER the access gate
+      // and the ontology-read recording above — a document read is still a KB read.
       const raw = await fs.readFile(p);
+      // Images return the picture itself as an MCP image content block, so a
+      // multimodal model SEES it. The handler returns the `McpImageResult`
+      // sentinel; the MCP result shaping (`toCallToolResult` in
+      // platform-mcp-core) turns it into `content: [image, text-note]`. The
+      // declared `outputs` schema (`{ path, content }`) intentionally does NOT
+      // cover this shape: `outputs` is advisory documentation — never enforced
+      // at the route, and not advertised over MCP (`toListedTool` exposes
+      // `inputSchema` only) — and the image result is replaced wholesale by
+      // content blocks before any client could try to validate it, so the
+      // schema keeps describing the text path it has always described.
+      // `offset`/`limit` are meaningless on a picture and are ignored.
+      if (isImageFile(p)) {
+        const bytes = asBytes(raw);
+        const mime = imageMimeType(p);
+        if (bytes.length > IMAGE_MAX_RAW_BYTES) {
+          return { path: p, content: oversizedImageNotice(p, mime, bytes.length) };
+        }
+        return mcpImageResult(bytes.toString('base64'), mime, imageNote(p, mime, bytes.length, imageDimensions(bytes)));
+      }
       let content: string;
       if (isSupportedDocument(p)) {
         const res = await docExtract.extract(p, asBytes(raw));

--- a/packages/hexis-mcp/src/__tests__/image-passthrough.test.ts
+++ b/packages/hexis-mcp/src/__tests__/image-passthrough.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { CodeModeUtcpClient } from '@utcp/code-mode';
+import {
+  dispatchToolCall,
+  dispatchMetaTool,
+  mcpImageResult,
+  type ProxiedTool,
+} from '@bevel-software/platform-mcp-core';
+
+/**
+ * Image results must cross the local stdio server UNMANGLED. This server
+ * reaches the deployment through @utcp/mcp, whose result processing unwraps a
+ * remote CallToolResult's `content`: text blocks are JSON-parsed (the image
+ * note comes back as a bare string), image blocks pass through verbatim, and a
+ * single-entry list collapses to the entry itself. These tests pin that the
+ * shared dispatch (this server's exact call path) re-emits spec-shaped image
+ * content for every form that hop can hand it — never a text block holding
+ * stringified base64.
+ */
+
+const readFileTool: ProxiedTool = {
+  utcpName: 'KNOWLEDGE_BASE.KNOWLEDGE_BASE.read_file',
+  mcpName: 'read_file',
+  description: 'the read_file tool',
+  inputSchema: { type: 'object', properties: {} },
+  manualName: 'KNOWLEDGE_BASE',
+};
+
+function clientYielding(chunk: unknown): CodeModeUtcpClient {
+  return {
+    callToolStreaming: async function* () {
+      yield chunk;
+    },
+  } as unknown as CodeModeUtcpClient;
+}
+
+const B64 = 'aVZCT1J3MEtHZ28='; // stands in for real image bytes
+
+describe('hexis-mcp forwards image results as native MCP image content', () => {
+  it('re-emits the remote hop\'s [imageBlock, "note"] form as spec-shaped content blocks', async () => {
+    const chunk = [
+      { type: 'image', data: B64, mimeType: 'image/png' },
+      '[image: Files/logo.png — image/png, 12 bytes, 1×1 px]',
+    ];
+    const result = await dispatchToolCall(clientYielding(chunk), readFileTool, {});
+    expect(result).toEqual({
+      content: [
+        { type: 'image', data: B64, mimeType: 'image/png' },
+        { type: 'text', text: '[image: Files/logo.png — image/png, 12 bytes, 1×1 px]' },
+      ],
+    });
+  });
+
+  it('re-emits a bare image block (noteless single-entry collapse) as spec-shaped content', async () => {
+    const block = { type: 'image', data: B64, mimeType: 'image/webp' };
+    const result = await dispatchToolCall(clientYielding(block), readFileTool, {});
+    expect(result).toEqual({ content: [block] });
+  });
+
+  it('shapes a raw image sentinel (http-transport form) the same way', async () => {
+    const sentinel = mcpImageResult(B64, 'image/jpeg', '[image: a.jpg — image/jpeg, 12 bytes]');
+    const result = await dispatchToolCall(clientYielding(sentinel), readFileTool, {});
+    expect(result).toEqual({
+      content: [
+        { type: 'image', data: B64, mimeType: 'image/jpeg' },
+        { type: 'text', text: '[image: a.jpg — image/jpeg, 12 bytes]' },
+      ],
+    });
+  });
+
+  it('still forwards an ordinary JSON result as one stringified text block', async () => {
+    const result = await dispatchToolCall(clientYielding({ path: 'a.md', content: 'hi' }), readFileTool, {});
+    expect(result).toEqual({ content: [{ type: 'text', text: '{"path":"a.md","content":"hi"}' }] });
+  });
+
+  it("this server's call_tool_chain omits a chained image (no spill store here to hide it in)", async () => {
+    const chainChunk = [
+      { type: 'image', data: B64, mimeType: 'image/png' },
+      '[image: Files/logo.png — image/png, 12 bytes]',
+    ];
+    const client = {
+      callToolChain: async () => ({ result: { pic: chainChunk }, logs: [] as string[] }),
+    } as unknown as CodeModeUtcpClient;
+    const result = await dispatchMetaTool(client, 'call_tool_chain', { code: 'return 1' });
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).not.toContain(B64);
+    expect(text).toContain('image_omitted');
+    expect(text).toContain('read_file');
+  });
+});

--- a/packages/mcp-core/src/__tests__/meta-tools.test.ts
+++ b/packages/mcp-core/src/__tests__/meta-tools.test.ts
@@ -120,7 +120,7 @@ describe('dispatchMetaTool call_tool_chain — image results', () => {
       mimeType: 'image/png',
       note: '[image: Files/logo.png — image/png, 6 bytes]',
     };
-    callToolChain.mockResolvedValueOnce({ result: { pic: sentinel, ok: true }, logs: [] });
+    callToolChain.mockResolvedValueOnce({ result: { pic: sentinel, ok: true } as unknown as string, logs: [] });
     const res = await dispatchMetaTool(client, 'call_tool_chain', { code: 'return 1' });
     const text = resultText(res);
     expect(text).not.toContain('QUJDREVG');

--- a/packages/mcp-core/src/__tests__/meta-tools.test.ts
+++ b/packages/mcp-core/src/__tests__/meta-tools.test.ts
@@ -110,3 +110,22 @@ describe('dispatchMetaTool tools_info', () => {
     expect(getTool).not.toHaveBeenCalled();
   });
 });
+
+describe('dispatchMetaTool call_tool_chain — image results', () => {
+  it('replaces a chained image read with an omitted-image note instead of stringifying base64', async () => {
+    const { client, callToolChain } = clientWith([]);
+    const sentinel = {
+      kind: 'bevel/mcp-image@v1',
+      data: 'QUJDREVG',
+      mimeType: 'image/png',
+      note: '[image: Files/logo.png — image/png, 6 bytes]',
+    };
+    callToolChain.mockResolvedValueOnce({ result: { pic: sentinel, ok: true }, logs: [] });
+    const res = await dispatchMetaTool(client, 'call_tool_chain', { code: 'return 1' });
+    const text = resultText(res);
+    expect(text).not.toContain('QUJDREVG');
+    expect(text).toContain('image_omitted');
+    expect(text).toContain('Files/logo.png');
+    expect(text).toContain('"ok":true');
+  });
+});

--- a/packages/mcp-core/src/__tests__/results.test.ts
+++ b/packages/mcp-core/src/__tests__/results.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { describeToolFailure, toCallToolResult, renderProgress } from '../results.js';
+import {
+  describeToolFailure,
+  toCallToolResult,
+  renderProgress,
+  mcpImageResult,
+  omitImagePayloads,
+  MCP_IMAGE_RESULT_KIND,
+} from '../results.js';
 
 describe('describeToolFailure', () => {
   it('pulls the REST error body out of an axios-shaped failure', () => {
@@ -90,5 +97,95 @@ describe('renderProgress', () => {
     const s = renderProgress('x'.repeat(600));
     expect(s).toHaveLength(500);
     expect(s.endsWith('...')).toBe(true);
+  });
+});
+
+describe('toCallToolResult — image results', () => {
+  const B64 = 'aGVsbG8='; // any base64 payload
+
+  it('shapes an image sentinel into spec content: image block + text note', () => {
+    const value = mcpImageResult(B64, 'image/png', '[image: Files/logo.png — image/png, 5 bytes, 1×1 px]');
+    expect(toCallToolResult(value)).toEqual({
+      content: [
+        { type: 'image', data: B64, mimeType: 'image/png' },
+        { type: 'text', text: '[image: Files/logo.png — image/png, 5 bytes, 1×1 px]' },
+      ],
+    });
+  });
+
+  it('shapes a noteless sentinel into a lone image block', () => {
+    expect(toCallToolResult(mcpImageResult(B64, 'image/gif'))).toEqual({
+      content: [{ type: 'image', data: B64, mimeType: 'image/gif' }],
+    });
+  });
+
+  it('reassembles the remote-hop mangled form ([imageBlock, "note"]) instead of stringifying base64', () => {
+    // Exactly what @utcp/mcp's _processMcpToolResult hands the local server for
+    // the hosted proxy's [image, text] result: the image block verbatim, the
+    // prose note JSON-parse-failed back to a bare string.
+    const mangled = [{ type: 'image', data: B64, mimeType: 'image/jpeg' }, '[image: a.jpg — image/jpeg, 5 bytes]'];
+    expect(toCallToolResult(mangled)).toEqual({
+      content: [
+        { type: 'image', data: B64, mimeType: 'image/jpeg' },
+        { type: 'text', text: '[image: a.jpg — image/jpeg, 5 bytes]' },
+      ],
+    });
+  });
+
+  it('reassembles a bare image block (single-entry remote collapse) into spec content', () => {
+    const block = { type: 'image', data: B64, mimeType: 'image/webp' };
+    expect(toCallToolResult(block)).toEqual({ content: [block] });
+  });
+
+  it('leaves ordinary data untouched: a kind field that is not the sentinel constant stringifies as before', () => {
+    const value = { kind: 'image', data: B64, mimeType: 'image/png' };
+    expect(toCallToolResult(value)).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(value) }],
+    });
+  });
+
+  it('leaves an array with any non-image, non-string entry on the stringify path', () => {
+    const value = [{ type: 'image', data: B64, mimeType: 'image/png' }, { other: true }];
+    expect(toCallToolResult(value)).toEqual({
+      content: [{ type: 'text', text: JSON.stringify(value) }],
+    });
+  });
+});
+
+describe('omitImagePayloads', () => {
+  const sentinel = mcpImageResult('QUJD', 'image/png', '[image: Files/logo.png — image/png, 3 bytes]');
+
+  it('replaces a top-level sentinel with an omitted-image note that keeps the file description', () => {
+    const out = omitImagePayloads(sentinel) as { image_omitted: boolean; note: string };
+    expect(out.image_omitted).toBe(true);
+    expect(out.note).toContain('Files/logo.png');
+    expect(out.note).toContain('read_file');
+    expect(JSON.stringify(out)).not.toContain('QUJD');
+  });
+
+  it('replaces sentinels nested inside the structure a chain built', () => {
+    const value = { files: [{ name: 'a', res: sentinel }], count: 1 };
+    const out = JSON.stringify(omitImagePayloads(value));
+    expect(out).not.toContain('QUJD');
+    expect(out).not.toContain(MCP_IMAGE_RESULT_KIND);
+    expect(out).toContain('"count":1');
+    expect(out).toContain('image_omitted');
+  });
+
+  it('replaces a spec-shaped image block too (what the remote MCP hop hands a local chain)', () => {
+    const value = [{ type: 'image', data: 'QUJD', mimeType: 'image/png' }, 'note'];
+    const out = JSON.stringify(omitImagePayloads(value));
+    expect(out).not.toContain('QUJD');
+    expect(out).toContain('image_omitted');
+    expect(out).toContain('"note"');
+  });
+
+  it('leaves ordinary values untouched and survives cycles', () => {
+    const value: Record<string, unknown> = { a: 1, list: ['x', 2, null] };
+    value.self = value;
+    const out = omitImagePayloads(value) as Record<string, unknown>;
+    expect(out.a).toBe(1);
+    expect(out.list).toEqual(['x', 2, null]);
+    expect(out.self).toBe('[Circular]');
   });
 });

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -38,6 +38,11 @@ export {
   renderProgress,
   toolError,
   needsAuthorizationResult,
+  MCP_IMAGE_RESULT_KIND,
+  type McpImageResult,
+  mcpImageResult,
+  isMcpImageResult,
+  omitImagePayloads,
 } from './results.js';
 
 export {

--- a/packages/mcp-core/src/meta-tools.ts
+++ b/packages/mcp-core/src/meta-tools.ts
@@ -1,7 +1,7 @@
 import type { Tool as McpTool, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { CodeModeUtcpClient } from '@utcp/code-mode';
 import { utcpNameToTsInterfaceName, findToolsByNames } from './code-mode-names.js';
-import { toCallToolResult, toolError, describeToolFailure } from './results.js';
+import { toCallToolResult, toolError, describeToolFailure, omitImagePayloads } from './results.js';
 
 /**
  * Code-mode meta-tools exposed ALONGSIDE the direct tools. They let an external
@@ -25,6 +25,7 @@ const CALL_TOOL_CHAIN_DESCRIPTION = [
   'Execute a short JavaScript program with direct access to every registered UTCP tool as a synchronous function. Call tools as `KNOWLEDGE_BASE.<tool>({ body: { ...args } })` with NO `await` (results are already resolved), and `return` the final value. The runtime is plain JavaScript (no type annotations / no TypeScript-only syntax).',
   'Discover first: `list_tools` lists every tool in callable form (e.g. `KNOWLEDGE_BASE.read_file`); `tools_info` returns their exact argument + return shapes — do not guess. Batch multiple tool calls into one chain to avoid a round-trip per call. The chain runs with your own connection key, so it can only reach the tools you can already call directly.',
   'Large results: if the combined result+logs exceed `max_output_size` (default 200000 chars) the full JSON is spilled to a shared store and you get back a `__tool_chain_spill__/…` ref instead. Read it with `read_file` (pass that ref as `path` — `branch` is ignored — plus `offset`/`limit` to slice it), or better, re-run a narrower chain that returns only what you need.',
+  'Images: image files are returned as native MCP image content on a DIRECT `read_file` call only — a chained `read_file` of an image yields `{ image_omitted: true, note }` instead of the picture, so call it outside the chain to actually see the image.',
 ].join('\n\n');
 
 export const CODE_MODE_META_TOOLS: McpTool[] = [
@@ -151,7 +152,12 @@ export async function dispatchMetaTool(
       typeof args.max_output_size === 'number' && Number.isFinite(args.max_output_size)
         ? Math.min(1_000_000, Math.max(1_000, Math.trunc(args.max_output_size)))
         : CALL_TOOL_CHAIN_MAX_OUTPUT;
-    const { result, logs } = await client.callToolChain(code, timeout);
+    const { result: rawResult, logs } = await client.callToolChain(code, timeout);
+    // Images never ride a chain result: the chain's value is stringified JSON,
+    // where base64 is context flood, not a picture. A chained `read_file` of an
+    // image comes back as an omitted-image note instead (see omitImagePayloads);
+    // the direct tool call is the sanctioned way to SEE an image.
+    const result = omitImagePayloads(rawResult);
     // Bound the payload: an external session has no ambient workspace, so an
     // oversized result spills to the shared store and we return only a ref —
     // parity with the in-process agent's `call_tool_chain`.

--- a/packages/mcp-core/src/results.ts
+++ b/packages/mcp-core/src/results.ts
@@ -1,6 +1,67 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 /**
+ * Discriminator for {@link McpImageResult}. The slash + version suffix make it
+ * a value no ordinary tool result carries by accident — a domain object with a
+ * `kind` field holds things like `'image'` or `'file'`, never this string —
+ * so the result shaping below can act on the shape without ever mistaking
+ * caller data for it.
+ */
+export const MCP_IMAGE_RESULT_KIND = 'bevel/mcp-image@v1';
+
+/**
+ * The sentinel a tool HANDLER returns when its result is a picture, not JSON.
+ *
+ * Handlers normally return domain JSON that `toCallToolResult` stringifies
+ * into one text block. An image cannot ride that path — a multimodal client
+ * only SEES a picture delivered as a native MCP image content block — so a
+ * handler that wants the caller to see one returns this shape instead, and
+ * the MCP result shaping turns it into
+ * `content: [{type:'image', data, mimeType}, {type:'text', text: note}]`.
+ * The `note` keeps the transcript self-describing (path, size, dimensions);
+ * without it the result is the bare image block.
+ *
+ * The shape intentionally travels as plain JSON: it crosses the UTCP http hop
+ * (loopback REST → hosted proxy) unchanged, and only the final MCP surface
+ * turns it into content blocks.
+ */
+export interface McpImageResult {
+  kind: typeof MCP_IMAGE_RESULT_KIND;
+  /** Base64-encoded image bytes (no data-URI prefix). */
+  data: string;
+  /** e.g. `image/png` — what the MCP image block advertises. */
+  mimeType: string;
+  /** One-line description (path + size/dimensions) emitted as a text block beside the image. */
+  note?: string;
+}
+
+/** Build a {@link McpImageResult} for a handler to return. */
+export function mcpImageResult(data: string, mimeType: string, note?: string): McpImageResult {
+  return { kind: MCP_IMAGE_RESULT_KIND, data, mimeType, ...(note !== undefined ? { note } : {}) };
+}
+
+export function isMcpImageResult(value: unknown): value is McpImageResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === MCP_IMAGE_RESULT_KIND &&
+    typeof (value as { data?: unknown }).data === 'string' &&
+    typeof (value as { mimeType?: unknown }).mimeType === 'string'
+  );
+}
+
+/** A spec-shaped MCP image content block (`{type:'image', data, mimeType}`). */
+function isMcpImageBlockObject(value: unknown): value is { type: 'image'; data: string; mimeType: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: unknown }).type === 'image' &&
+    typeof (value as { data?: unknown }).data === 'string' &&
+    typeof (value as { mimeType?: unknown }).mimeType === 'string'
+  );
+}
+
+/**
  * Extract a human-meaningful failure message from a tool-call error. UTCP's
  * HTTP protocol surfaces a non-2xx as an axios-style error whose `.response.data`
  * is the REST endpoint's JSON body (`{ error: "..." }`). Pull that out so the
@@ -93,6 +154,40 @@ function safeJsonText(value: unknown): string {
 }
 
 export function toCallToolResult(value: unknown): CallToolResult {
+  // An image sentinel (see McpImageResult): the tool's result IS a picture.
+  // Emit a native image content block so a multimodal client renders it, plus
+  // the note as a text block so the transcript stays self-describing.
+  if (isMcpImageResult(value)) {
+    return {
+      content: [
+        { type: 'image', data: value.data, mimeType: value.mimeType },
+        ...(value.note !== undefined ? [{ type: 'text' as const, text: value.note }] : []),
+      ],
+    };
+  }
+  // The same image result AFTER a remote MCP hop. The local stdio server
+  // (hexis-mcp) reaches the deployment's MCP endpoint through @utcp/mcp, whose
+  // `_processMcpToolResult` unwraps a CallToolResult's `content` array: text
+  // blocks are JSON-parsed (our prose note comes back as a bare string), other
+  // blocks pass through verbatim, and a single-entry list collapses to the
+  // entry itself. So the hosted proxy's `[image, text]` result arrives here as
+  // `[imageBlock, "note"]` — or, noteless, as the bare image block. Recognize
+  // both and reassemble the spec-shaped result instead of JSON-stringifying
+  // megabytes of base64 into a text block. A caller's ordinary data is safe:
+  // only arrays made EXCLUSIVELY of image blocks and strings (with at least
+  // one image block) qualify, and such a value already denotes image content.
+  if (isMcpImageBlockObject(value)) {
+    return { content: [value] };
+  }
+  if (
+    Array.isArray(value) &&
+    value.some(isMcpImageBlockObject) &&
+    value.every((e) => isMcpImageBlockObject(e) || typeof e === 'string')
+  ) {
+    return {
+      content: value.map((e) => (typeof e === 'string' ? { type: 'text' as const, text: e } : e)),
+    };
+  }
   // Already in MCP agentic format — pass through untouched, but only when every
   // `content` entry is a real content block (has a string `type`).
   const content = (value as { content?: unknown })?.content;
@@ -101,6 +196,57 @@ export function toCallToolResult(value: unknown): CallToolResult {
   }
   const text = typeof value === 'string' ? value : safeJsonText(value ?? null);
   return { content: [{ type: 'text', text: text || '(tool produced no output)' }] };
+}
+
+/**
+ * Replace image payloads inside a `call_tool_chain` result with a short note.
+ *
+ * A chain's return value is JSON that gets STRINGIFIED into the transcript
+ * (or spilled), so an image result reaching it would either flood the context
+ * with base64 or burn a spill for bytes no one can see — a chain has no way to
+ * deliver a native image block. Policy (v1): images are returned directly,
+ * never through tool chains. This walk swaps every image sentinel — and every
+ * spec-shaped image content block, which is what the local server's remote
+ * MCP hop hands a chain (see `toCallToolResult`) — for
+ * `{ image_omitted: true, note }`, keeping whatever structure the chain built
+ * around it. Best-effort by design: chain code that EXTRACTS the base64 string
+ * itself escapes the walk, and then the ordinary max_output_size spill bounds
+ * the damage.
+ */
+export function omitImagePayloads(value: unknown): unknown {
+  // Active-descent set: guards real cycles without mislabeling diamond shares.
+  const ancestors = new Set<object>();
+  const walk = (v: unknown, depth: number): unknown => {
+    if (v === null || typeof v !== 'object' || depth > 64) return v;
+    if (isMcpImageResult(v)) {
+      const what = v.note ?? `an image (${v.mimeType})`;
+      return {
+        image_omitted: true,
+        note:
+          `${what} — images are returned directly to you as native MCP image content, not through ` +
+          '`call_tool_chain`. Call `read_file` on the image path as a DIRECT tool call (outside the chain) to see it.',
+      };
+    }
+    if (isMcpImageBlockObject(v)) {
+      return {
+        image_omitted: true,
+        note:
+          `an image (${v.mimeType}) — images are returned directly to you as native MCP image content, not ` +
+          'through `call_tool_chain`. Call `read_file` on the image path as a DIRECT tool call (outside the chain) to see it.',
+      };
+    }
+    if (ancestors.has(v)) return '[Circular]';
+    ancestors.add(v);
+    try {
+      if (Array.isArray(v)) return v.map((e) => walk(e, depth + 1));
+      const out: Record<string, unknown> = {};
+      for (const [k, e] of Object.entries(v)) out[k] = walk(e, depth + 1);
+      return out;
+    } finally {
+      ancestors.delete(v);
+    }
+  };
+  return walk(value, 0);
 }
 
 export function renderProgress(chunk: unknown): string {


### PR DESCRIPTION
An agent calling `read_file` on a `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp` now receives a native MCP image content block — the model sees the picture — instead of a one-line "binary file" refusal. `.svg` stays text.

- **The contract**: a tool returns `McpImageResult` (a versioned sentinel, `kind: 'bevel/mcp-image@v1'`, collision-proof against ordinary result JSON); `toCallToolResult` — the one shaping point both MCP surfaces route through — emits `[image block, text note]`. The note carries path, mimeType, bytes, and dimensions (parsed dependency-free from PNG/GIF/JPEG headers).
- **The cap**: 3.5 MB raw, with the base64 arithmetic in a comment (Claude-family clients reject ~5 MB encoded); over-cap reads return an honest downscale-or-reupload message. No image-processing dependency.
- **hexis-mcp** forwards image blocks unmangled — including reassembling the two forms `@utcp/mcp` produces on the remote hop, pinned by tests, so the local server never stringifies megabytes of base64.
- **Chains**: images never ride `call_tool_chain` — image payloads are scrubbed to `{image_omitted, note}` pointing at direct `read_file`, in all three chain paths, before any size accounting.

Typecheck clean across mcp-core/core-backend/hexis-mcp; suites: 57, 109, and 1686 passing respectively. Follow-up increments (document viewers; odt/odp/ods extraction) arrive as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns image files from read_file as native MCP image content so multimodal clients see the picture; previously these paths returned a one-line “binary file” notice. `.svg` continues to read as text.

- Contract: tools can return `McpImageResult` (`kind: 'bevel/mcp-image@v1'`, base64 `data`, `mimeType`, optional `note`); `toCallToolResult` emits `[image block, text note]` (or a lone image block).
- Cap: 3.5 MiB raw max; oversized reads return a refusal with downscale/upload guidance. No image processing dependency. Note includes path, mime type, size, and PNG/GIF/JPEG dimensions (parsed from headers).
- Chains: `call_tool_chain` uses `omitImagePayloads` to replace any image result with `{ image_omitted: true, note }`; images are only delivered on a direct `read_file`.
- Passthrough: `hexis-mcp` forwards image blocks unmangled across the `@utcp/mcp` hop (both bare image and `[imageBlock, "note"]` forms), avoiding stringified base64.
- Types: `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp` return images; `.svg` stays on the text path.
- Client impact: MCP clients require no changes; HTTP callers of `read_file` on images now receive the `McpImageResult` sentinel instead of `{ path, content }`.

<sup>Written for commit 43be088def7667aa9c6e7863b60015cdfd7badd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

