### PR TITLE
OpenDocument files read as extracted text

### DIFF
--- a/.changeset/odd-doors-open.md
+++ b/.changeset/odd-doors-open.md
@@ -1,0 +1,5 @@
+---
+"@bevel-software/platform-core-backend": minor
+---
+
+OpenDocument files — `.odt`, `.odp`, `.ods` — read as extracted text. `read_file` returns their text under the same honest `[extracted text of …]` header the office formats get (`.odt` paragraphs and headings as lines with real tabs/line-breaks/spaces, `.odp` slides in document order under `[slide N]` markers with notes, `.ods` sheets as tab-separated rows under `[sheet: Name]` with the same 200-column/10k-row bounds — trailing empty grid padding trimmed before repeat expansion), `grep` searches inside them via the same cached extraction, and the agent text-editing tools refuse them like the other extracted formats.

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -484,6 +484,45 @@ describe('office documents and PDFs', () => {
     return Buffer.from(out, 'latin1');
   };
 
+  /** Minimal ODF package: a zip with a `content.xml` carrying `body` under `<office:body>`. */
+  const odf = (body: string): Buffer => {
+    const zip = new AdmZip();
+    zip.addFile(
+      'content.xml',
+      Buffer.from(
+        '<?xml version="1.0"?><office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ' +
+          'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" ' +
+          'xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0">' +
+          `<office:body>${body}</office:body></office:document-content>`,
+      ),
+    );
+    return zip.toBuffer();
+  };
+
+  const odt = (...paragraphs: string[]): Buffer =>
+    odf(`<office:text>${paragraphs.map((p) => `<text:p>${p}</text:p>`).join('')}</office:text>`);
+
+  const odp = (slides: string[][]): Buffer =>
+    odf(
+      '<office:presentation>' +
+        slides
+          .map(
+            (paragraphs) =>
+              `<draw:page><draw:frame><draw:text-box>${paragraphs.map((p) => `<text:p>${p}</text:p>`).join('')}</draw:text-box></draw:frame></draw:page>`,
+          )
+          .join('') +
+        '</office:presentation>',
+    );
+
+  const ods = (name: string, rows: string[][]): Buffer =>
+    odf(
+      `<office:spreadsheet><table:table table:name="${name}">` +
+        rows
+          .map((cells) => `<table:table-row>${cells.map((c) => `<table:table-cell><text:p>${c}</text:p></table:table-cell>`).join('')}</table:table-row>`)
+          .join('') +
+        '</table:table></office:spreadsheet>',
+    );
+
   const readContent = async (base: string, path: string, extra: Record<string, unknown> = {}): Promise<string> => {
     const res = (await (await post(`${base}/api/agent/tools/read_file`, { path, ...extra })).json()) as { content: string };
     return res.content;
@@ -554,6 +593,49 @@ describe('office documents and PDFs', () => {
     expect(second.note).toBeUndefined();
   });
 
+  it('read_file returns marker + extracted text for the three OpenDocument formats', async () => {
+    const base = await start();
+    await fs.writeFile('memo.odt', odt('Hello from Writer', 'Second paragraph'));
+    const odtContent = await readContent(base, 'memo.odt');
+    expect(odtContent.split('\n')).toEqual([
+      '[extracted text of memo.odt — 2 paragraphs; layout, images and formatting omitted]',
+      'Hello from Writer',
+      'Second paragraph',
+    ]);
+
+    await fs.writeFile('deck.odp', odp([['Impress intro'], ['Second page']]));
+    const odpContent = await readContent(base, 'deck.odp');
+    expect(odpContent).toMatch(/^\[extracted text of deck\.odp — 2 slides;/);
+    expect(odpContent).toContain('[slide 1]\nImpress intro\n[slide 2]\nSecond page');
+
+    await fs.writeFile('numbers.ods', ods('Inventory', [['Name', 'Qty'], ['Widget', '3']]));
+    const odsContent = await readContent(base, 'numbers.ods');
+    expect(odsContent).toMatch(/^\[extracted text of numbers\.ods — 1 sheet, rows as tab-separated values;/);
+    expect(odsContent).toContain('[sheet: Inventory]\nName\tQty\nWidget\t3');
+  });
+
+  it('grep finds a term inside an odp, with the [slide N] marker line locating it', async () => {
+    const base = await start();
+    await fs.writeFile('deck.odp', odp([['Intro'], ['Roadmap 2027', 'Ship OpenDocument']]));
+    const res = (await (await post(`${base}/api/agent/tools/grep`, { pattern: 'Roadmap' })).json()) as {
+      matches: { path: string; line: number; text: string }[];
+    };
+    // Extraction: marker line 1, [slide 1] 2, Intro 3, [slide 2] 4, Roadmap 5.
+    expect(res.matches).toContainEqual(expect.objectContaining({ path: 'deck.odp', text: 'Roadmap 2027', line: 5 }));
+    const markers = (await (await post(`${base}/api/agent/tools/grep`, { pattern: '\\[slide 2\\]' })).json()) as { matches: { path: string }[] };
+    expect(markers.matches).toContainEqual(expect.objectContaining({ path: 'deck.odp' }));
+  });
+
+  it('read_file answers a corrupt odt zip with an honest could-not-parse message (no 500)', async () => {
+    const base = await start();
+    await fs.writeFile('broken.odt', Buffer.from('not really a zip'));
+    const res = await post(`${base}/api/agent/tools/read_file`, { path: 'broken.odt' });
+    expect(res.status).toBe(200);
+    const { content } = (await res.json()) as { content: string };
+    expect(content).toContain('could not be parsed as a .odt');
+    expect(content).toContain('uploading a new version');
+  });
+
   it('read_file answers a corrupt docx with an honest could-not-parse message (no 500)', async () => {
     const base = await start();
     await fs.writeFile('broken.docx', Buffer.from('not really a zip'));
@@ -589,8 +671,12 @@ describe('office documents and PDFs', () => {
     await fs.writeFile('deck.pptx', pptx([['Original']]));
     for (const [tool, body] of [
       ['write_file', { path: 'new.docx', content: 'plain text' }],
+      ['write_file', { path: 'new.odt', content: 'plain text' }],
+      ['write_file', { path: 'slides.odp', content: 'plain text' }],
       ['edit_file', { path: 'deck.pptx', old_string: 'Original', new_string: 'Changed' }],
+      ['edit_file', { path: 'numbers.ods', old_string: 'a', new_string: 'b' }],
       ['write_files', { files: [{ path: 'ok.md', content: 'fine' }, { path: 'sheet.xlsx', content: 'nope' }] }],
+      ['write_files', { files: [{ path: 'ok.md', content: 'fine' }, { path: 'sheet.ods', content: 'nope' }] }],
     ] as const) {
       const res = await post(`${base}/api/agent/tools/${tool}`, body);
       expect(res.status, tool).toBe(400);

--- a/packages/core-backend/src/modules/workspace/doc-extract/__tests__/doc-extract.test.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/__tests__/doc-extract.test.ts
@@ -8,6 +8,9 @@ import { extractDocx } from '../extract-docx.js';
 import { extractPptx } from '../extract-pptx.js';
 import { extractXlsx } from '../extract-xlsx.js';
 import { extractPdf } from '../extract-pdf.js';
+import { extractOdt } from '../extract-odt.js';
+import { extractOdp } from '../extract-odp.js';
+import { extractOds } from '../extract-ods.js';
 import { DocExtractService } from '../doc-extract.service.js';
 import { gitBlobSha } from '../extraction-cache.js';
 import { fileExtension, isLegacyDocument, isSupportedDocument } from '../doc-extract.types.js';
@@ -89,11 +92,51 @@ export function pdfBytes(text: string): Buffer {
   return Buffer.from(pdf, 'latin1');
 }
 
+// ── ODF fixture builders ───────────────────────────────────────────────────
+
+const ODF_NS =
+  'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ' +
+  'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" ' +
+  'xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" ' +
+  'xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" ' +
+  'xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0"';
+
+function odfBytes(mimetype: string, bodyXml: string): Buffer {
+  const zip = new AdmZip();
+  zip.addFile('mimetype', Buffer.from(mimetype));
+  zip.addFile(
+    'content.xml',
+    Buffer.from(`<?xml version="1.0"?><office:document-content ${ODF_NS}><office:body>${bodyXml}</office:body></office:document-content>`),
+  );
+  return zip.toBuffer();
+}
+
+const odtBytes = (textXml: string): Buffer =>
+  odfBytes('application/vnd.oasis.opendocument.text', `<office:text>${textXml}</office:text>`);
+
+/** One odp slide: frame paragraphs + optional notes paragraphs. */
+const odpPage = (paragraphs: string[], notes: string[] = []): string =>
+  '<draw:page draw:name="page">' +
+  `<draw:frame><draw:text-box>${paragraphs.map((p) => `<text:p>${p}</text:p>`).join('')}</draw:text-box></draw:frame>` +
+  (notes.length > 0
+    ? `<presentation:notes><draw:frame><draw:text-box>${notes.map((p) => `<text:p>${p}</text:p>`).join('')}</draw:text-box></draw:frame></presentation:notes>`
+    : '') +
+  '</draw:page>';
+
+const odpBytes = (...pages: string[]): Buffer =>
+  odfBytes('application/vnd.oasis.opendocument.presentation', `<office:presentation>${pages.join('')}</office:presentation>`);
+
+const odsBytes = (...tables: string[]): Buffer =>
+  odfBytes('application/vnd.oasis.opendocument.spreadsheet', `<office:spreadsheet>${tables.join('')}</office:spreadsheet>`);
+
+const odsCell = (text: string, repeat?: number): string =>
+  `<table:table-cell${repeat ? ` table:number-columns-repeated="${repeat}"` : ''}>${text === '' ? '' : `<text:p>${text}</text:p>`}</table:table-cell>`;
+
 // ── extension classification ───────────────────────────────────────────────
 
 describe('document type classification', () => {
-  it('recognises the four supported types, case-insensitively', () => {
-    for (const p of ['a.docx', 'Plugins/GTM/Deck.PPTX', 'x/y.xlsx', 'r.pdf']) {
+  it('recognises the seven supported types, case-insensitively', () => {
+    for (const p of ['a.docx', 'Plugins/GTM/Deck.PPTX', 'x/y.xlsx', 'r.pdf', 'n.odt', 'd.ODP', 'b/s.ods']) {
       expect(isSupportedDocument(p), p).toBe(true);
     }
   });
@@ -254,6 +297,195 @@ describe('extractPdf', () => {
     expect(res.ok).toBe(false);
     if (res.ok) return;
     expect(res.message).toContain('could not be parsed as a PDF');
+  });
+});
+
+// ── odt ────────────────────────────────────────────────────────────────────
+
+describe('extractOdt', () => {
+  it('joins spans with NO separator; headings and paragraphs are lines in document order', () => {
+    const res = extractOdt(
+      odtBytes(
+        '<text:h text:outline-level="1">Ti<text:span text:style-name="T1">tle</text:span></text:h>' +
+          '<text:p>Hel<text:span text:style-name="T2">lo world</text:span></text:p>',
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text.split('\n')).toEqual(['Title', 'Hello world']);
+    expect(res.summary).toBe('2 paragraphs; layout, images and formatting omitted');
+  });
+
+  it('renders <text:tab/>, <text:line-break/> and <text:s text:c="N"/> as real characters', () => {
+    const res = extractOdt(odtBytes('<text:p>a<text:tab/>b<text:line-break/>c<text:s text:c="3"/>d<text:s/>e</text:p>'));
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text).toBe('a\tb\nc   d e');
+  });
+
+  it('decodes named and numeric XML entities', () => {
+    const res = extractOdt(odtBytes('<text:p>&amp; &lt;tag&gt; &quot;q&quot; &apos;a&apos; &#65;&#x42;</text:p>'));
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text).toBe('& <tag> "q" \'a\' AB');
+  });
+
+  it('returns a typed failure for bytes that are not a zip', () => {
+    const res = extractOdt(Buffer.from('this is not an odt at all'));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('could not be parsed as a .odt');
+  });
+
+  it('returns a typed failure for a zip without content.xml', () => {
+    const zip = new AdmZip();
+    zip.addFile('hello.txt', Buffer.from('hi'));
+    const res = extractOdt(zip.toBuffer());
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('no content.xml');
+  });
+});
+
+// ── odp ────────────────────────────────────────────────────────────────────
+
+describe('extractOdp', () => {
+  it('numbers slides by DOCUMENT order of <draw:page>, with notes under [slide N notes]', () => {
+    const res = extractOdp(
+      odpBytes(
+        odpPage(['Road', 'map 2026'], ['Remember the demo']),
+        odpPage(['Second slide']),
+        odpPage(['Third slide']),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text.split('\n')).toEqual([
+      '[slide 1]',
+      'Road',
+      'map 2026',
+      '[slide 1 notes]',
+      'Remember the demo',
+      '[slide 2]',
+      'Second slide',
+      '[slide 3]',
+      'Third slide',
+    ]);
+    expect(res.summary).toBe('3 slides + notes; layout, images and formatting omitted');
+  });
+
+  it('omits the notes marker (and "+ notes") when no slide has note text', () => {
+    const res = extractOdp(odpBytes(odpPage(['Only slide'])));
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text).toBe('[slide 1]\nOnly slide');
+    expect(res.summary).toContain('1 slide;');
+  });
+
+  it('returns a typed failure for a zip whose content.xml has no draw:page', () => {
+    const res = extractOdp(odtBytes('<text:p>not a presentation</text:p>'));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('could not be parsed as a .odp');
+  });
+
+  it('returns a typed failure for bytes that are not a zip', () => {
+    const res = extractOdp(Buffer.from('junk'));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('could not be parsed as a .odp');
+  });
+});
+
+// ── ods ────────────────────────────────────────────────────────────────────
+
+describe('extractOds', () => {
+  const row = (...cells: string[]): string => `<table:table-row>${cells.join('')}</table:table-row>`;
+  const table = (name: string, ...rows: string[]): string =>
+    `<table:table table:name="${name}">${rows.join('')}</table:table>`;
+
+  it('emits [sheet: Name] markers and rows as tab-separated cell text', () => {
+    const res = extractOds(
+      odsBytes(
+        table('Inventory', row(odsCell('Name'), odsCell('Qty')), row(odsCell('Widget'), odsCell('3'))),
+        table('Empty'),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    const lines = res.text.split('\n');
+    expect(lines[0]).toBe('[sheet: Inventory]');
+    expect(lines[1]).toBe('Name\tQty');
+    expect(lines[2]).toBe('Widget\t3');
+    expect(lines).toContain('[sheet: Empty]');
+    expect(res.summary).toContain('2 sheets');
+  });
+
+  it('expands column/row repeats for real data', () => {
+    const res = extractOds(
+      odsBytes(
+        table(
+          'S',
+          row(odsCell('x', 3), odsCell('end')),
+          `<table:table-row table:number-rows-repeated="2">${odsCell('dup')}</table:table-row>`,
+        ),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text.split('\n')).toEqual(['[sheet: S]', 'x\tx\tx\tend', 'dup', 'dup']);
+  });
+
+  it('TRIMS trailing empty cells/rows before applying their repeats — million-wide grid padding costs nothing', () => {
+    const res = extractOds(
+      odsBytes(
+        table(
+          'Padded',
+          row(odsCell('a'), odsCell('', 1_000_000)),
+          `<table:table-row table:number-rows-repeated="1048576">${odsCell('', 1_000_000)}</table:table-row>`,
+        ),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    // No truncation note: the padding was trimmed, not truncated.
+    expect(res.text.split('\n')).toEqual(['[sheet: Padded]', 'a']);
+  });
+
+  it('caps NON-empty repeats at 200 columns / 10k rows and says so under the sheet marker', () => {
+    const res = extractOds(
+      odsBytes(
+        table(
+          'Big',
+          row(odsCell('w', 300)),
+          `<table:table-row table:number-rows-repeated="20000">${odsCell('r')}</table:table-row>`,
+        ),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    const lines = res.text.split('\n');
+    expect(lines[1]).toBe('[sheet truncated to the first 10000 rows and first 200 columns]');
+    expect(lines[2]).toBe(Array(200).fill('w').join('\t'));
+    expect(lines).toHaveLength(2 + 10_000);
+  });
+
+  it('decodes entities in cell text and the sheet name; covered cells render empty', () => {
+    const res = extractOds(
+      odsBytes(
+        table(
+          'P&amp;L',
+          row(odsCell('A&amp;B'), '<table:covered-table-cell/>', odsCell('C')),
+        ),
+      ),
+    );
+    if (!res.ok) throw new Error(res.message);
+    expect(res.text.split('\n')).toEqual(['[sheet: P&L]', 'A&B\t\tC']);
+  });
+
+  it('returns a typed failure for bytes that are not a zip', () => {
+    const res = extractOds(Buffer.from('nope'));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('could not be parsed as a .ods');
+  });
+
+  it('returns a typed failure for a content.xml without table:table', () => {
+    const res = extractOds(odtBytes('<text:p>a text document</text:p>'));
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.message).toContain('no table:table');
   });
 });
 

--- a/packages/core-backend/src/modules/workspace/doc-extract/doc-extract.service.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/doc-extract.service.ts
@@ -3,6 +3,9 @@ import { extractDocx } from './extract-docx.js';
 import { extractPptx } from './extract-pptx.js';
 import { extractXlsx } from './extract-xlsx.js';
 import { extractPdf } from './extract-pdf.js';
+import { extractOdt } from './extract-odt.js';
+import { extractOdp } from './extract-odp.js';
+import { extractOds } from './extract-ods.js';
 import { DocExtractionCache, gitBlobSha } from './extraction-cache.js';
 
 /** An extraction ready for a consumer: the honest marker header + the text. */
@@ -68,6 +71,12 @@ async function extractByType(path: string, bytes: Buffer): Promise<ExtractResult
       return extractXlsx(bytes);
     case '.pdf':
       return extractPdf(bytes);
+    case '.odt':
+      return extractOdt(bytes);
+    case '.odp':
+      return extractOdp(bytes);
+    case '.ods':
+      return extractOds(bytes);
     default:
       // Callers gate on `isSupportedDocument` first; this is the honest
       // answer if one ever doesn't.

--- a/packages/core-backend/src/modules/workspace/doc-extract/doc-extract.types.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/doc-extract.types.ts
@@ -1,8 +1,9 @@
 /**
  * Server-side document text extraction — shared types.
  *
- * The extractors turn an office document (`.docx` / `.pptx` / `.xlsx`) or a
- * PDF into plain text an agent can read and grep. They are HONEST about being
+ * The extractors turn an office document (`.docx` / `.pptx` / `.xlsx`), an
+ * OpenDocument file (`.odt` / `.odp` / `.ods`) or a PDF into plain text an
+ * agent can read and grep. They are HONEST about being
  * lossy: every successful extraction carries a one-line `summary` the consumer
  * turns into a marker header (`[extracted text of <path> — <summary>]`) so the
  * reader knows it is looking at extracted text, not the file's bytes.
@@ -38,7 +39,7 @@ export function extractionMarker(path: string, summary: string): string {
   return `[extracted text of ${path} — ${summary}]`;
 }
 
-const SUPPORTED_EXTENSIONS = new Set(['.docx', '.pptx', '.xlsx', '.pdf']);
+const SUPPORTED_EXTENSIONS = new Set(['.docx', '.pptx', '.xlsx', '.pdf', '.odt', '.odp', '.ods']);
 const LEGACY_EXTENSIONS = new Set(['.doc', '.ppt', '.xls']);
 
 /** Lowercased extension of `path` including the dot, or '' when there is none. */
@@ -48,7 +49,7 @@ export function fileExtension(path: string): string {
   return dot > 0 ? name.slice(dot).toLowerCase() : '';
 }
 
-/** Is this a document type the extractor supports (.docx/.pptx/.xlsx/.pdf)? */
+/** Is this a document type the extractor supports (.docx/.pptx/.xlsx/.pdf and .odt/.odp/.ods)? */
 export function isSupportedDocument(path: string): boolean {
   return SUPPORTED_EXTENSIONS.has(fileExtension(path));
 }

--- a/packages/core-backend/src/modules/workspace/doc-extract/extract-odp.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/extract-odp.ts
@@ -1,0 +1,53 @@
+import type { ExtractResult } from './doc-extract.types.js';
+import { odfParagraphLines, readOdfContentXml } from './odf-text.js';
+
+/**
+ * Extract the text of a `.odp` (OpenDocument Presentation) deck.
+ *
+ * Slides are the `<draw:page>` elements of `content.xml`, in DOCUMENT order —
+ * ODF orders slides in the file itself, so unlike pptx there is no numeric
+ * filename sort. Each slide is emitted under a `[slide N]` marker (N = 1-based
+ * position); speaker notes (`<presentation:notes>` inside the page) follow
+ * under `[slide N notes]` when non-empty. Within a slide, each `<text:p>` in
+ * its frames is a line; spans concatenate with no separator.
+ */
+export function extractOdp(bytes: Buffer): ExtractResult {
+  const content = readOdfContentXml(bytes, '.odp');
+  if (!content.ok) return content;
+
+  const pages = drawPageBlocks(content.xml);
+  if (pages.length === 0) {
+    return { ok: false, message: 'could not be parsed as a .odp (no draw:page elements in content.xml)' };
+  }
+
+  const lines: string[] = [];
+  let anyNotes = false;
+  pages.forEach((page, i) => {
+    // Split the notes part out FIRST so its paragraphs don't render as slide text.
+    const notesRe = /<presentation:notes(?:\s[^>]*)?>([\s\S]*?)<\/presentation:notes>/;
+    const notesXml = notesRe.exec(page)?.[1] ?? '';
+    const slideXml = page.replace(notesRe, '');
+    lines.push(`[slide ${i + 1}]`);
+    lines.push(...odfParagraphLines(slideXml));
+    const noteLines = odfParagraphLines(notesXml);
+    if (noteLines.length > 0) {
+      anyNotes = true;
+      lines.push(`[slide ${i + 1} notes]`);
+      lines.push(...noteLines);
+    }
+  });
+  return {
+    ok: true,
+    summary: `${pages.length} slide${pages.length === 1 ? '' : 's'}${anyNotes ? ' + notes' : ''}; layout, images and formatting omitted`,
+    text: lines.join('\n'),
+  };
+}
+
+/** The `<draw:page>…</draw:page>` bodies in document order (pages never nest). */
+function drawPageBlocks(xml: string): string[] {
+  const re = /<draw:page(?=[\s>])(?:\s[^>]*)?>([\s\S]*?)<\/draw:page>/g;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) out.push(m[1]);
+  return out;
+}

--- a/packages/core-backend/src/modules/workspace/doc-extract/extract-ods.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/extract-ods.ts
@@ -1,0 +1,147 @@
+import type { ExtractResult } from './doc-extract.types.js';
+import { decodeXmlEntities } from './ooxml-text.js';
+import { odfParagraphBlocks, odfParagraphText, readOdfContentXml } from './odf-text.js';
+
+/**
+ * Per-sheet extraction caps — the SAME bounds as the xlsx extractor. ODF is
+ * fond of `table:number-columns-repeated="16384"` (or a million empty trailing
+ * rows) to pad a sheet to the grid, so repeats are expanded BOUNDED and the
+ * extraction says when it truncated (a `[sheet truncated …]` line right under
+ * the sheet marker). Trailing EMPTY cells/rows are trimmed before their
+ * repeats are applied at all, so grid padding never counts as truncation.
+ */
+const MAX_ROWS_PER_SHEET = 10_000;
+const MAX_COLS_PER_SHEET = 200;
+
+/**
+ * Extract a `.ods` (OpenDocument Spreadsheet) workbook: per `<table:table>`
+ * (sheet) a `[sheet: Name]` marker (the `table:name` attribute), then the rows
+ * as tab-separated cell text. A cell's text is its `<text:p>` content
+ * (multiple paragraphs join with a space — a newline would break the row
+ * line); covered cells (under a merge) render empty.
+ */
+export function extractOds(bytes: Buffer): ExtractResult {
+  const content = readOdfContentXml(bytes, '.ods');
+  if (!content.ok) return content;
+
+  const tables = tableBlocks(content.xml);
+  if (tables.length === 0) {
+    return { ok: false, message: 'could not be parsed as a .ods (no table:table elements in content.xml)' };
+  }
+
+  const lines: string[] = [];
+  for (const table of tables) {
+    lines.push(`[sheet: ${table.name}]`);
+    const { rows, truncated } = expandRows(table.xml);
+    if (truncated.length > 0) lines.push(`[sheet truncated to the ${truncated.join(' and ')}]`);
+    lines.push(...rows.map((cells) => cells.join('\t')));
+  }
+  return {
+    ok: true,
+    summary: `${tables.length} sheet${tables.length === 1 ? '' : 's'}, rows as tab-separated values; formulas, formatting and charts omitted`,
+    text: lines.join('\n'),
+  };
+}
+
+/**
+ * The `<table:table>` blocks with their decoded `table:name`, in document
+ * order. Non-greedy close — a nested table (legal in ODF text documents, not
+ * produced by spreadsheets) would end the outer block early, degrading
+ * grouping but never crashing.
+ */
+function tableBlocks(xml: string): Array<{ name: string; xml: string }> {
+  const re = /<table:table(?=[\s>])((?:\s[^>]*)?)>([\s\S]*?)<\/table:table>/g;
+  const out: Array<{ name: string; xml: string }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) {
+    const name = /table:name="([^"]*)"/.exec(m[1])?.[1];
+    out.push({ name: name ? decodeXmlEntities(name) : `Sheet${out.length + 1}`, xml: m[2] });
+  }
+  return out;
+}
+
+/** One parsed (not yet repeat-expanded) unit: the content + its repeat count. */
+interface Repeated<T> {
+  value: T;
+  repeat: number;
+}
+
+/**
+ * Expand a sheet's rows with BOUNDED repeat handling:
+ *
+ *  1. parse every row into its trailing-trimmed cell texts (columns already
+ *     capped, per row),
+ *  2. TRIM trailing all-empty rows — before their `table:number-rows-repeated`
+ *     is ever applied, so a million-row empty tail simply disappears,
+ *  3. expand the remaining row repeats up to the row cap.
+ *
+ * `truncated` lists what the caps cut (mirrors the xlsx extractor's note).
+ */
+function expandRows(tableXml: string): { rows: string[][]; truncated: string[] } {
+  const rowRe = /<table:table-row(?=[\s/>])((?:\s[^>]*)?)(?:\/>|>([\s\S]*?)<\/table:table-row>)/g;
+  const parsed: Repeated<string[]>[] = [];
+  let colsTruncated = false;
+  let m: RegExpExecArray | null;
+  while ((m = rowRe.exec(tableXml)) !== null) {
+    const cells = expandCells(m[2] ?? '');
+    if (cells.truncated) colsTruncated = true;
+    parsed.push({ value: cells.cells, repeat: repeatCount(m[1], 'table:number-rows-repeated') });
+  }
+  // Trailing empty rows: dropped with their repeats (grid padding, not data).
+  while (parsed.length > 0 && parsed[parsed.length - 1].value.length === 0) parsed.pop();
+
+  const rows: string[][] = [];
+  let rowsTruncated = false;
+  for (const { value, repeat } of parsed) {
+    for (let i = 0; i < repeat; i++) {
+      if (rows.length >= MAX_ROWS_PER_SHEET) {
+        rowsTruncated = true;
+        break;
+      }
+      rows.push(value);
+    }
+    if (rowsTruncated) break;
+  }
+  const truncated: string[] = [];
+  if (rowsTruncated) truncated.push(`first ${MAX_ROWS_PER_SHEET} rows`);
+  if (colsTruncated) truncated.push(`first ${MAX_COLS_PER_SHEET} columns`);
+  return { rows, truncated };
+}
+
+/**
+ * One row's cell texts: `<table:table-cell>` / `<table:covered-table-cell>`
+ * in order, trailing EMPTY cells trimmed before `table:number-columns-repeated`
+ * is applied, then repeats expanded up to the column cap.
+ */
+function expandCells(rowXml: string): { cells: string[]; truncated: boolean } {
+  const cellRe = /<table:(table-cell|covered-table-cell)(?=[\s/>])((?:\s[^>]*)?)(?:\/>|>([\s\S]*?)<\/table:\1>)/g;
+  const parsed: Repeated<string>[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = cellRe.exec(rowXml)) !== null) {
+    // Covered cells (m[1] === 'covered-table-cell') carry no own text anyway.
+    const text = odfParagraphBlocks(m[3] ?? '').map(odfParagraphText).join(' ');
+    parsed.push({ value: text, repeat: repeatCount(m[2], 'table:number-columns-repeated') });
+  }
+  while (parsed.length > 0 && parsed[parsed.length - 1].value === '') parsed.pop();
+
+  const cells: string[] = [];
+  let truncated = false;
+  for (const { value, repeat } of parsed) {
+    for (let i = 0; i < repeat; i++) {
+      if (cells.length >= MAX_COLS_PER_SHEET) {
+        truncated = true;
+        break;
+      }
+      cells.push(value);
+    }
+    if (truncated) break;
+  }
+  return { cells, truncated };
+}
+
+/** A `…-repeated="N"` attribute value, clamped to a sane positive integer. */
+function repeatCount(attrs: string, name: string): number {
+  const raw = new RegExp(`${name}="(\\d+)"`).exec(attrs)?.[1];
+  const n = raw ? parseInt(raw, 10) : 1;
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}

--- a/packages/core-backend/src/modules/workspace/doc-extract/extract-odt.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/extract-odt.ts
@@ -1,0 +1,36 @@
+import type { ExtractResult } from './doc-extract.types.js';
+import { odfParagraphBlocks, odfParagraphText, readOdfContentXml } from './odf-text.js';
+
+/**
+ * Extract the BODY text of a `.odt` (OpenDocument Text) document.
+ *
+ * An odt is a zip whose main part is `content.xml`; the body lives under
+ * `<office:text>`. Headers/footers are skipped like docx — in ODF they live in
+ * `styles.xml`, which is never opened, so reading `content.xml` alone IS the
+ * body-only extraction.
+ *
+ * Paragraphs (`<text:p>`) and headings (`<text:h>`, heading text as its own
+ * line) become lines in document order; `<text:span>` runs inside concatenate
+ * with NO separator, and the ODF whitespace elements (`<text:tab/>`,
+ * `<text:line-break/>`, `<text:s text:c="N"/>`) render as real characters —
+ * see `odfParagraphText`.
+ */
+export function extractOdt(bytes: Buffer): ExtractResult {
+  const content = readOdfContentXml(bytes, '.odt');
+  if (!content.ok) return content;
+
+  // Table cells contain their own <text:p>, so the flat paragraph scan renders
+  // table text too (one line per cell paragraph, like the raw document order).
+  const bodyMatch = /<office:text(?:\s[^>]*)?>([\s\S]*?)<\/office:text>/.exec(content.xml);
+  const body = bodyMatch ? bodyMatch[1] : content.xml;
+
+  const lines = odfParagraphBlocks(body).map(odfParagraphText);
+  const paragraphs = lines.length;
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop();
+
+  return {
+    ok: true,
+    summary: `${paragraphs} paragraph${paragraphs === 1 ? '' : 's'}; layout, images and formatting omitted`,
+    text: lines.join('\n'),
+  };
+}

--- a/packages/core-backend/src/modules/workspace/doc-extract/odf-text.ts
+++ b/packages/core-backend/src/modules/workspace/doc-extract/odf-text.ts
@@ -1,0 +1,88 @@
+import AdmZip from 'adm-zip';
+import { decodeXmlEntities } from './ooxml-text.js';
+
+/**
+ * Minimal ODF (OpenDocument) text helpers shared by the odt/odp/ods
+ * extractors. Same DELIBERATELY hand-rolled approach as `ooxml-text.ts`: an
+ * ODF package's `content.xml` is well-formed XML (LibreOffice/OpenOffice wrote
+ * it), and the extractors only need paragraph character content plus three
+ * whitespace elements — a linear regex scan does that correctly without a new
+ * XML-parser dependency.
+ */
+
+/**
+ * The text of one ODF paragraph (`<text:p>` / `<text:h>` content). Character
+ * data between tags is entity-decoded and concatenated with NO separator —
+ * formatting runs (`<text:span>`) split words exactly like OOXML runs do, so
+ * ignoring the span tags joins them back. Three ODF whitespace elements are
+ * REAL characters and are rendered as such:
+ *
+ *  - `<text:tab/>`        → a tab
+ *  - `<text:line-break/>` → a newline
+ *  - `<text:s text:c="N"/>` → N spaces (no `text:c` attribute = 1)
+ */
+export function odfParagraphText(paragraphXml: string): string {
+  let out = '';
+  let last = 0;
+  const tagRe = /<[^>]*>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(paragraphXml)) !== null) {
+    out += decodeXmlEntities(paragraphXml.slice(last, m.index));
+    last = tagRe.lastIndex;
+    const name = /^<\/?([^\s/>]+)/.exec(m[0])?.[1];
+    if (name === 'text:tab') out += '\t';
+    else if (name === 'text:line-break') out += '\n';
+    else if (name === 'text:s') {
+      const c = /text:c="(\d+)"/.exec(m[0]);
+      const count = c ? parseInt(c[1], 10) : 1;
+      // A count is bounded defensively — a corrupt attribute must not balloon the extraction.
+      out += ' '.repeat(Math.min(Math.max(count, 0), 1000));
+    }
+  }
+  return out + decodeXmlEntities(paragraphXml.slice(last));
+}
+
+/**
+ * The `<text:p>` / `<text:h>` paragraph bodies of an XML fragment, in DOCUMENT
+ * order (headings interleaved with paragraphs, as written). Self-closing
+ * elements (`<text:p/>`, an empty paragraph) yield ''. The lookahead keeps
+ * `<text:page-number>` and friends from counting as paragraphs; non-greedy
+ * close is correct because ODF paragraphs cannot nest.
+ */
+export function odfParagraphBlocks(xml: string): string[] {
+  const re = /<text:(p|h)(?=[\s/>])(?:\s[^>]*)?(?:\/>|>([\s\S]*?)<\/text:\1>)/g;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) out.push(m[2] ?? '');
+  return out;
+}
+
+/** Non-empty paragraph texts of an ODF fragment — what odp slides/notes render. */
+export function odfParagraphLines(xml: string): string[] {
+  const out: string[] = [];
+  for (const p of odfParagraphBlocks(xml)) {
+    const text = odfParagraphText(p);
+    if (text.trim() !== '') out.push(text);
+  }
+  return out;
+}
+
+/**
+ * `content.xml` of an ODF package, or a typed could-not-parse failure message
+ * (`kind` names the extension for the message, e.g. '.odt').
+ */
+export function readOdfContentXml(
+  bytes: Buffer,
+  kind: '.odt' | '.odp' | '.ods',
+): { ok: true; xml: string } | { ok: false; message: string } {
+  try {
+    const zip = new AdmZip(bytes);
+    const entry = zip.getEntry('content.xml');
+    if (!entry) {
+      return { ok: false, message: `could not be parsed as a ${kind} (no content.xml inside the archive)` };
+    }
+    return { ok: true, xml: entry.getData().toString('utf8') };
+  } catch (err) {
+    return { ok: false, message: `could not be parsed as a ${kind} (${(err as Error).message})` };
+  }
+}

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -403,7 +403,7 @@ export function registerWorkspaceTools(
   mount({
     name: 'read_file',
     description:
-      'Read a workspace file as text. Returns `{ path, content }`. Images (.png/.jpg/.jpeg/.gif/.webp) return the IMAGE ITSELF as native MCP image content (plus a one-line text note naming the file), so you can look at the picture — up to 3.5 MB of raw image data; a larger image gets an honest refusal asking for a locally downscaled copy or a smaller export (`.svg` is text and reads as text). Images come back only on a DIRECT call: inside `call_tool_chain` an image read yields an `{ image_omitted, note }` stub instead. Office documents (.docx/.pptx/.xlsx) and PDFs return their EXTRACTED text under an honest `[extracted text of …]` header, with `[slide N]`/`[sheet: Name]`/`[page N]` markers — the extraction is READ-ONLY (layout/images omitted; such files cannot be edited as text, only replaced by uploading a new version). Other binary files return a one-line description instead of raw bytes. Optional `offset`/`limit` slice the content (characters for a file, bytes for a `__tool_chain_spill__/…` ref; ignored for an image) — use them to page through large files or a `call_tool_chain` spill rather than reading multi-MB in full. A spill ref is workspace-independent: `branch` is ignored for it.' +
+      'Read a workspace file as text. Returns `{ path, content }`. Images (.png/.jpg/.jpeg/.gif/.webp) return the IMAGE ITSELF as native MCP image content (plus a one-line text note naming the file), so you can look at the picture — up to 3.5 MB of raw image data; a larger image gets an honest refusal asking for a locally downscaled copy or a smaller export (`.svg` is text and reads as text). Images come back only on a DIRECT call: inside `call_tool_chain` an image read yields an `{ image_omitted, note }` stub instead. Office and OpenDocument files (.docx/.pptx/.xlsx, .odt/.odp/.ods) and PDFs return their EXTRACTED text under an honest `[extracted text of …]` header, with `[slide N]`/`[sheet: Name]`/`[page N]` markers — the extraction is READ-ONLY (layout/images omitted; such files cannot be edited as text, only replaced by uploading a new version). Other binary files return a one-line description instead of raw bytes. Optional `offset`/`limit` slice the content (characters for a file, bytes for a `__tool_chain_spill__/…` ref; ignored for an image) — use them to page through large files or a `call_tool_chain` spill rather than reading multi-MB in full. A spill ref is workspace-independent: `branch` is ignored for it.' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
@@ -548,7 +548,7 @@ export function registerWorkspaceTools(
   mount({
     name: 'grep',
     description:
-      'Regex content search across the workspace. Returns `{ matches: [{ path, line, text }] }` (capped). Use to find where something is defined/referenced. Searches INSIDE office documents (.docx/.pptx/.xlsx) and PDFs via their extracted text — matches there carry the extraction\'s line numbers, and the `[slide N]`/`[sheet: Name]`/`[page N]` marker lines locate them; a bounded number of not-yet-extracted documents is extracted per call, and the result notes how many were skipped (re-run to cover them).' +
+      'Regex content search across the workspace. Returns `{ matches: [{ path, line, text }] }` (capped). Use to find where something is defined/referenced. Searches INSIDE Office and OpenDocument files (.docx/.pptx/.xlsx, .odt/.odp/.ods) and PDFs via their extracted text — matches there carry the extraction\'s line numbers, and the `[slide N]`/`[sheet: Name]`/`[page N]` marker lines locate them; a bounded number of not-yet-extracted documents is extracted per call, and the result notes how many were skipped (re-run to cover them).' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
@@ -627,7 +627,7 @@ export function registerWorkspaceTools(
   mount({
     name: 'write_file',
     description:
-      'Write (create or overwrite) a workspace file. The change is committed + pushed as you. Returns `{ path, bytes }`. Refuses office documents/PDFs (.docx/.pptx/.xlsx/.pdf) — their reads are text EXTRACTIONS that cannot round-trip; replace such a file by uploading a new version instead.' +
+      'Write (create or overwrite) a workspace file. The change is committed + pushed as you. Returns `{ path, bytes }`. Refuses Office/OpenDocument files and PDFs (.docx/.pptx/.xlsx/.odt/.odp/.ods/.pdf) — their reads are text EXTRACTIONS that cannot round-trip; replace such a file by uploading a new version instead.' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
@@ -666,8 +666,8 @@ export function registerWorkspaceTools(
       'Batch-write many files in ONE commit — far faster than calling write_file once per file when ' +
       'creating many files at once (e.g. seeding a knowledge base). Each entry is `{ path, content }`; all ' +
       'are created/overwritten and committed + pushed together as you. Prefer this over many write_file ' +
-      'calls. All files must be in the SAME ontology (the boundary below applies to the batch). Refuses office ' +
-      'documents/PDFs (.docx/.pptx/.xlsx/.pdf) — their reads are text EXTRACTIONS that cannot round-trip. Returns `{ count }`.' +
+      'calls. All files must be in the SAME ontology (the boundary below applies to the batch). Refuses Office/OpenDocument ' +
+      'files and PDFs (.docx/.pptx/.xlsx/.odt/.odp/.ods/.pdf) — their reads are text EXTRACTIONS that cannot round-trip. Returns `{ count }`.' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
@@ -718,7 +718,7 @@ export function registerWorkspaceTools(
   mount({
     name: 'edit_file',
     description:
-      'Replace an exact string in a workspace file. `old_string` must appear exactly once unless `replace_all`. Committed + pushed as you. Refuses office documents/PDFs (.docx/.pptx/.xlsx/.pdf) — their reads are text EXTRACTIONS that cannot round-trip; replace such a file by uploading a new version instead.' +
+      'Replace an exact string in a workspace file. `old_string` must appear exactly once unless `replace_all`. Committed + pushed as you. Refuses Office/OpenDocument files and PDFs (.docx/.pptx/.xlsx/.odt/.odp/.ods/.pdf) — their reads are text EXTRACTIONS that cannot round-trip; replace such a file by uploading a new version instead.' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',


### PR DESCRIPTION
Stacked on #84 (retarget to dev once that merges). Extends the document extractor with the OpenDocument family:

- **.odt** — paragraphs and headings from `office:text`, runs rejoined with no separator, `text:tab`/`line-break`/`text:s` elements honored (space runs clamped); body-only for free since ODF headers/footers live in styles.xml, which is never opened.
- **.odp** — slides in document order with the same `[slide N]` / `[slide N notes]` markers as pptx; notes are split out of the page XML *before* rendering so they can never leak into slide text.
- **.ods** — `[sheet: Name]` + tab-separated rows mirroring xlsx, same caps — with ODF's repeated-cells quirk handled properly: trailing empty repeats (the classic million-empty-column padding) are trimmed as grid padding *before* expansion, so they neither explode nor count as truncation.

Everything else was already list-driven through one place (`SUPPORTED_EXTENSIONS`), so read_file routing, grep's document set, and the write-refusal all picked the three formats up together; tool descriptions updated. +19 tests (1705 passing), typecheck clean, changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenDocument files (.odt/.odp/.ods) now read as extracted text. Previously they were opaque binaries; now read_file returns a marked extraction, grep searches inside via the cache, and write/edit tools refuse them like other extracted formats.

- ODT: outputs headings and paragraphs as lines in document order; spans join with no separator; renders text:tab/line-break/s with real characters; body-only (headers/footers live in styles.xml).
- ODP: emits slides in document order under “[slide N]”; non-empty notes appear under “[slide N notes]”; notes are removed from slide XML before rendering so they cannot leak.
- ODS: emits “[sheet: Name]” then tab-separated rows; trims trailing empty repeats before expansion; expands bounded to 200 columns and 10k rows and adds a “[sheet truncated …]” line when capped; covered cells render empty; entities decoded in names and cells.
- Errors: invalid archives or missing content.xml return typed “could not be parsed as .odt/.odp/.ods” messages (read_file greets with a 200 + honest message; no 500s).
- Routing and tools: added to `SUPPORTED_EXTENSIONS`; `doc-extract.service` dispatches to new extractors; `grep` and extraction cache pick them up automatically; tool descriptions updated; write/edit/write_files refusals now include .odt/.odp/.ods. No API shape changes.

<sup>Written for commit d31fb9d635c2a59a8d5ad6f8143fa99ce744d618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

