### PR TITLE
Version 0.12.0

### DIFF
--- a/.changeset/document-viewers-frontend.md
+++ b/.changeset/document-viewers-frontend.md
@@ -1,5 +1,0 @@
----
-"@bevel-software/platform-core-frontend": minor
----
-
-The file viewer displays PDF, Word, Excel and PowerPoint files. PDFs render page by page (pdf.js) with a Prev/Next pager and fit-to-width scaling; `.xlsx` workbooks render as a per-sheet grid capped at 1,000 rows / 100 columns with an honest truncation note; `.docx` continues to render through mammoth (sanitized); `.pptx` shows a text outline — slides as sections with speaker notes, matching what agents read through `read_file` — with the original deck one download away. Legacy `.doc`/`.ppt`/`.xls` get a convert-to-modern-format note instead of the raw-bytes text fallback, and every document viewer carries a Download affordance. All document parsers stay out of the eager bundle (code-split per viewer).

--- a/.changeset/email-files-readable.md
+++ b/.changeset/email-files-readable.md
@@ -1,6 +1,0 @@
----
-"@bevel-software/platform-core-backend": minor
-"@bevel-software/platform-core-frontend": minor
----
-
-Email files — `.eml` (MIME) and `.msg` (Outlook) — join the document family. `read_file` returns the message as extracted text under the honest `[extracted text of …]` header: a `[from]`/`[to]`/`[cc]`/`[subject]`/`[date]` header block (absent fields omitted), the body preferring the plain-text part (an HTML-only body is stripped to text; a `.msg` whose body exists only as RTF says so instead of pretending to decode it), and an `[attachments]` list of names with type and size — attachments are listed, never extracted. `grep` searches inside emails via the same cached extraction, and the text-editing tools refuse them with an email-honest message (a message snapshot cannot be text-edited — replace the file). The file viewer renders both formats with labelled header fields, the body as plain text (never HTML, even for HTML emails), the attachment names, and the Download affordance; parsing is client-side (postal-mime for `.eml`; the `.msg` CFB container is read through the SheetJS CFB parser already in the bundle) and stays out of the eager chunk.

--- a/.changeset/ninety-books-read.md
+++ b/.changeset/ninety-books-read.md
@@ -1,5 +1,0 @@
----
-"@bevel-software/platform-core-backend": minor
----
-
-Agents read office documents and PDFs as extracted text. `read_file` on a `.docx`/`.pptx`/`.xlsx`/`.pdf` now returns the document's text under an honest `[extracted text of …]` header (with `[slide N]`/`[sheet: Name]`/`[page N]` markers) instead of megabytes of undecodable bytes, and `grep` searches inside those documents via the same cached extraction. Extractions are cached by content hash beside the workspaces root. The agent text-editing tools (`write_file`/`write_files`/`edit_file`) refuse document extensions — extracted reads cannot round-trip, so documents are changed by uploading a new version. Other binary files answer `read_file` with a one-line description (legacy `.doc`/`.ppt`/`.xls` get a convert-to-modern-format hint, `.zip` points at the unzip tool).

--- a/.changeset/odd-doors-open.md
+++ b/.changeset/odd-doors-open.md
@@ -1,5 +1,0 @@
----
-"@bevel-software/platform-core-backend": minor
----
-
-OpenDocument files — `.odt`, `.odp`, `.ods` — read as extracted text. `read_file` returns their text under the same honest `[extracted text of …]` header the office formats get (`.odt` paragraphs and headings as lines with real tabs/line-breaks/spaces, `.odp` slides in document order under `[slide N]` markers with notes, `.ods` sheets as tab-separated rows under `[sheet: Name]` with the same 200-column/10k-row bounds — trailing empty grid padding trimmed before repeat expansion), `grep` searches inside them via the same cached extraction, and the agent text-editing tools refuse them like the other extracted formats.

--- a/.changeset/parser-for-document-scanning.md
+++ b/.changeset/parser-for-document-scanning.md
@@ -1,5 +1,0 @@
----
-"@bevel-software/platform-core-backend": patch
----
-
-Document extraction parses XML and HTML with htmlparser2 instead of hand-rolled scanners. Real documents extract byte-for-byte identically; malformed ones are now recovered the way a parser recovers them, rather than by rules the scanner had to be taught one crafted file at a time.

--- a/.changeset/parser-for-viewer-scanning.md
+++ b/.changeset/parser-for-viewer-scanning.md
@@ -1,5 +1,0 @@
----
-"@bevel-software/platform-core-frontend": patch
----
-
-The pptx outline and the email viewer read XML and HTML with htmlparser2 instead of hand-rolled scanners, matching the backend extractors so the viewer and `read_file` cannot drift apart. `renderers/xmlEntities.ts` is now `renderers/xmlReading.ts`.

--- a/.changeset/wise-pandas-see.md
+++ b/.changeset/wise-pandas-see.md
@@ -1,7 +1,0 @@
----
-"@bevel-software/platform-core-backend": minor
-"@bevel-software/platform-mcp-core": minor
-"@bevel-software/hexis-mcp": minor
----
-
-`read_file` on an image returns the image itself as native MCP image content. A `.png`/`.jpg`/`.jpeg`/`.gif`/`.webp` read comes back as an MCP image content block (base64 + mimeType) plus a one-line text note naming the path, size and dimensions — so a multimodal client actually sees the picture instead of a binary-file notice. `.svg` stays on the text path. Images over 3.5 MB raw are refused with an honest message (base64 inflation would push them past what Claude-family clients accept — downscale locally or upload a smaller export). The local `hexis-mcp` server forwards the image blocks unmangled, and `call_tool_chain` deliberately omits image payloads from chain results (a chained image read yields an `{ image_omitted, note }` stub — images are only delivered on a direct `read_file` call).

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-backend",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Open-source core backend of the Bevel platform: git-backed knowledge workspace, workflow (branches/change requests/locks/SSE), skills, tools, secrets vault, access control and the remote MCP surface.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core-frontend/package.json
+++ b/packages/core-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-core-frontend",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Open-source core UI of the Bevel platform (raw TS/TSX source): workspace explorer/viewer, branches & change requests, Library, secrets, tools, access control.",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/hexis-mcp/package.json
+++ b/packages/hexis-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/hexis-mcp",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Run a Hexis workspace as a local MCP server: every tool the hosted endpoint serves, plus the local-only tools it cannot reach.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-mcp-core",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "The transport-agnostic half of Bevel's MCP surface: UTCP manual registration, tool discovery, MCP listing/dispatch and the code-mode meta-tools. Shared by the hosted proxy and the local stdio server.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bevel-software/platform-shared",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Shared types and pure domain utilities of the Bevel core platform (auth, workspace, git/workflow contracts, branch registry).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Consumes the seven pending changesets and bumps the fixed group to **0.12.0** (from 0.11.2). Mechanical: five `package.json` version fields and the changeset files they came from. No changelogs — `changelog: false` is the repo's setting.

Merge this into `dev` before #89 goes to `main`, so the release carries its own version numbers.

## What 0.12.0 ships

- **Documents are readable.** docx, pptx, xlsx, pdf, odt, odp and ods extract to text for `read_file` and for `grep`, cached by blob sha; the frontend renders each of them; edits refuse, because extraction cannot round-trip.
- **Email files join them** — `.eml` and `.msg` extract to one shared shape, with a viewer that renders the body as text and never as HTML.
- **Images reach the model as MCP image blocks** rather than mojibake, bounded at 3.5 MB and scrubbed out of chain transcripts.
- **Downloads are offered only where the download verb allows them.**
- The XML and HTML reading behind all of it is **htmlparser2** rather than hand-rolled scanning, on both the server and the viewers.

## Remaining release steps

1. Merge this into `dev`
2. Merge #89 (`dev` → `main`)
3. Tag `v0.12.0` on `main` so the container build runs
4. `pnpm release` to publish

Then the enterprise repin, which needs the in-app chat agent's image-sentinel mirror — that agent calls `read_file` directly rather than through MCP, so it would otherwise receive sentinel JSON where an image belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships 0.12.0 by consuming seven changesets and bumping the fixed group to 0.12.0. Documents and emails become readable, images return as MCP image blocks, and parsing standardizes — replacing binary reads, refusing edits on extracted formats, and tightening download affordances.

- Bumps `@bevel-software/platform-core-backend`, `@bevel-software/platform-core-frontend`, `@bevel-software/platform-mcp-core`, `@bevel-software/hexis-mcp`, and `@bevel-software/platform-shared` to 0.12.0; removes consumed `.changeset` files.

**Behavior changes**
- `read_file`/`grep`: `.docx`/`.pptx`/`.xlsx`/`.pdf`/`.odt`/`.odp`/`.ods` extract to text (cached by blob hash). Old: undecodable bytes. New: structured text markers; edits on these extensions are refused.
- Emails: `.eml`/`.msg` extract to a shared text shape; viewer renders headers and body as text only; attachments listed, not extracted. Edits are refused.
- Images: `read_file` returns MCP image content blocks with a one-line note. Old: mojibake/binary notice. New: 3.5 MB raw size limit; `call_tool_chain` omits image payloads.
- Downloads: shown only where the download verb allows.
- Parsing: XML/HTML reading uses `htmlparser2` across backend and viewers, replacing hand-rolled scanners.

**Rollout**
- Merge into `dev` before #89 goes to `main`; then tag `v0.12.0` and run `pnpm release`.
- API consumers must handle MCP image blocks from `read_file` and the 3.5 MB limit; images are not included in `call_tool_chain` results.
- Enterprise: repin after release; update the in‑app chat agent’s image‑sentinel mirror since it calls `read_file` directly.

<sup>Written for commit fe593ed3c7a3b738c6594b053a309b03fc9ebb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

