### PR TITLE
Show the message, without letting the message act

### DIFF
--- a/.changeset/email-html-rendering.md
+++ b/.changeset/email-html-rendering.md
@@ -1,0 +1,5 @@
+---
+"@bevel-software/platform-core-frontend": minor
+---
+
+The email viewer renders a message's HTML the way a mail client does, inside a frame that cannot run scripts or fetch anything: remote images (tracking pixels included) never load, images the sender embedded do, and links are inert and listed with their full address so nothing opens without a deliberate click.

--- a/packages/core-frontend/src/lib/clipboard.ts
+++ b/packages/core-frontend/src/lib/clipboard.ts
@@ -11,7 +11,10 @@
  * buttons and the email viewer's link list.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
-  const clipboard = navigator.clipboard;
+  // `navigator` itself is undefined off the browser (SSR, a test runner with
+  // no DOM): reading through it would THROW rather than answer false, which is
+  // the one thing this function promises not to do.
+  const clipboard = typeof navigator === 'undefined' ? undefined : navigator.clipboard;
   if (!clipboard?.writeText) return false;
   try {
     await clipboard.writeText(text);

--- a/packages/core-frontend/src/lib/clipboard.ts
+++ b/packages/core-frontend/src/lib/clipboard.ts
@@ -1,0 +1,22 @@
+/**
+ * Copy text, and say whether it landed.
+ *
+ * `navigator.clipboard` is undefined outside a secure context (plain-HTTP
+ * staging, some embedded webviews), and `writeText` rejects when the document
+ * isn't focused. Both are ordinary conditions, not exceptions — a copy button
+ * hands over something the user can also select by hand, so a failure has a
+ * real answer and must never surface as success.
+ *
+ * Lives in `lib/` because more than one module needs it: the Library's copy
+ * buttons and the email viewer's link list.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  const clipboard = navigator.clipboard;
+  if (!clipboard?.writeText) return false;
+  try {
+    await clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core-frontend/src/modules/library/utils/clipboard.ts
+++ b/packages/core-frontend/src/modules/library/utils/clipboard.ts
@@ -1,23 +1,7 @@
-/**
- * Copy text, and say whether it landed.
- *
- * `navigator.clipboard` is undefined outside a secure context (plain-HTTP
- * staging, some embedded webviews), and `writeText` rejects when the document
- * isn't focused. Both are ordinary conditions here, not exceptions — the
- * Library's copy buttons hand over an agent prompt the user can also just
- * select, so a failure has a real answer ("select the text instead") and must
- * never surface as a success toast.
- */
-export async function copyToClipboard(text: string): Promise<boolean> {
-  const clipboard = navigator.clipboard;
-  if (!clipboard?.writeText) return false;
-  try {
-    await clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
+// The implementation moved to `lib/clipboard.ts` when the email viewer needed
+// it too; re-exported here so the Library keeps importing its copy helper and
+// its toast strings from one place.
+export { copyToClipboard } from '../../../lib/clipboard';
 
 /** What a copy button tells the user, either way. */
 export const COPIED_TOAST = 'Prompt copied.';

--- a/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, Copy, ExternalLink, Mail, Paperclip } from 'lucide-react';
 import { useWorkspace } from '../../state/workspace.context';
 import { authFetch } from '../../../../lib/api';
@@ -230,6 +230,12 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
  */
 function CopyLinkButton({ url }: { url: string }): React.ReactElement {
   const [state, setState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  // One timer, cancelled before another is scheduled: two clicks inside the
+  // reset window let the FIRST timer clear the second click's answer, so the
+  // button stopped reporting the copy the reader had just made. Cleared on
+  // unmount too, so a late reset cannot land on a gone component.
+  const resetAt = useRef<number | undefined>(undefined);
+  useEffect(() => () => window.clearTimeout(resetAt.current), []);
   return (
     <button
       type="button"
@@ -238,7 +244,8 @@ function CopyLinkButton({ url }: { url: string }): React.ReactElement {
       onClick={() => {
         void copyToClipboard(url).then((ok) => {
           setState(ok ? 'copied' : 'failed');
-          window.setTimeout(() => setState('idle'), 2000);
+          window.clearTimeout(resetAt.current);
+          resetAt.current = window.setTimeout(() => setState('idle'), 2000);
         });
       }}
     >

--- a/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
-import { Mail, Paperclip } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Copy, ExternalLink, Mail, Paperclip } from 'lucide-react';
 import { useWorkspace } from '../../state/workspace.context';
 import { authFetch } from '../../../../lib/api';
 import { DownloadFileButton } from './DownloadFileButton';
 import { MAX_EMAIL_BYTES, attachmentLine, type EmailMessageView } from './emailMessage';
+import { buildEmailBody, type EmailLink } from './emailBody';
 import { readBodyCapped } from './readBodyCapped';
 import type { FileRendererProps } from './types';
 
@@ -13,11 +14,19 @@ import type { FileRendererProps } from './types';
  * backend's extractors tell agents through `read_file`, so human and agent
  * conversations about one message point at the same thing.
  *
- * Nothing from the message is ever interpreted as HTML: an HTML-only body is
- * stripped to text by the parser and rendered as React text nodes, and the
- * up-front note says formatting is omitted. Attachments are names, not
- * downloads — v1 does not unpack them; the original file (with everything in
- * it) is one Download away.
+ * A message that carries HTML is RENDERED, the way a mail client renders it —
+ * inside a frame mounted `sandbox=""` (no scripts, ever) whose policy permits
+ * `img-src data:` and nothing else. Two consequences are the point of the
+ * design: no script in a stranger's mail can run, and no remote fetch can
+ * happen, so a tracking pixel cannot report that this message was opened.
+ * Images the sender EMBEDDED still appear — they travel inside the file, and
+ * are inlined as data: URIs. Links are made inert and listed below the body
+ * with their full address, because a click inside a script-free frame cannot
+ * be intercepted and a live anchor would open its destination unseen.
+ *
+ * A message with no HTML part falls back to the plain text, as before.
+ * Attachments are names, not downloads — v1 does not unpack them; the original
+ * file (with everything in it) is one Download away.
  *
  * Parsing is client-side, per format, behind its own dynamic import so the
  * `.eml` path never pays for the CFB machinery: postal-mime for `.eml`
@@ -30,6 +39,12 @@ import type { FileRendererProps } from './types';
 export function EmailRenderer({ filePath }: FileRendererProps) {
   const { workspaceId } = useWorkspace();
   const [view, setView] = useState<EmailMessageView | null>(null);
+  // The sender's own markup, made safe to show. Rebuilt only when the message
+  // changes — the sanitize + inline pass walks the whole body.
+  const rendered = useMemo(
+    () => (view?.bodyHtml !== undefined ? buildEmailBody(view.bodyHtml, view.attachments) : null),
+    [view],
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -139,6 +154,28 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
           The message body is stored as RTF only — there is no plain-text part to show. Download
           the file to read it in a mail client.
         </p>
+      ) : rendered !== null ? (
+        <>
+          <iframe
+            // `sandbox=""` — NOT allow-scripts. Nothing in a stranger's message
+            // executes, and the document's CSP allows `img-src data:` only, so no
+            // remote fetch can happen: a tracking pixel cannot report that this
+            // message was opened. Images the sender EMBEDDED are inlined as data:
+            // URIs and do render.
+            sandbox=""
+            srcDoc={rendered.srcDoc}
+            title="Message body"
+            className="h-[32rem] w-full rounded-xs border border-line bg-white"
+          />
+          {rendered.blockedRemoteImages > 0 && (
+            <p className="mt-2 text-detail text-ink-faint">
+              {rendered.blockedRemoteImages} remote image
+              {rendered.blockedRemoteImages === 1 ? '' : 's'} not loaded — fetching one would tell
+              the sender you opened this message.
+            </p>
+          )}
+          {rendered.links.length > 0 && <EmailLinks links={rendered.links} />}
+        </>
       ) : view.body === '' ? (
         <p className="text-detail italic text-ink-faint">No message body.</p>
       ) : (
@@ -163,6 +200,65 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+
+/**
+ * The message's links, in TRUSTED UI outside the sandbox.
+ *
+ * A click inside a script-free frame cannot be intercepted, so an anchor left
+ * live would open its destination with no chance to show the reader where it
+ * goes. The body renders them inert and numbered instead, and they are listed
+ * here with the whole address visible: copy it, or open it deliberately. A
+ * phishing link is never one stray click away, and nothing in the frame can
+ * reach `window.opener` or leak a referrer, because nothing in the frame
+ * navigates at all.
+ */
+function EmailLinks({ links }: { links: readonly EmailLink[] }): React.ReactElement {
+  return (
+    <div className="mt-4 border-t border-line pt-3">
+      <div className="mb-1 flex items-center gap-1.5 text-meta font-medium uppercase tracking-wide text-ink-faint">
+        <ExternalLink size={12} aria-hidden />
+        Links
+      </div>
+      <ul className="space-y-1">
+        {links.map((link) => (
+          <li key={link.index} className="flex items-start gap-2 text-detail">
+            <span className="shrink-0 text-ink-faint">[{link.index}]</span>
+            <span className="min-w-0 flex-1">
+              {link.text !== '' && <span className="text-ink">{link.text} — </span>}
+              <span className="break-all text-ink-faint">{link.url}</span>
+            </span>
+            <button
+              type="button"
+              className="shrink-0 text-ink-faint hover:text-ink"
+              title="Copy this address"
+              onClick={() => void navigator.clipboard?.writeText(link.url)}
+            >
+              <Copy size={12} aria-hidden />
+            </button>
+            <button
+              type="button"
+              className="shrink-0 text-ink-faint hover:text-ink"
+              title="Open in a new tab"
+              onClick={() => {
+                // Asked before anything opens, with the address in the prompt:
+                // the reader decides against the REAL destination, not against
+                // whatever text the sender chose to show.
+                if (window.confirm(`Open this link?
+
+${link.url}`)) {
+                  window.open(link.url, '_blank', 'noopener,noreferrer');
+                }
+              }}
+            >
+              <ExternalLink size={12} aria-hidden />
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/EmailRenderer.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Copy, ExternalLink, Mail, Paperclip } from 'lucide-react';
+import { Check, Copy, ExternalLink, Mail, Paperclip } from 'lucide-react';
 import { useWorkspace } from '../../state/workspace.context';
 import { authFetch } from '../../../../lib/api';
+import { copyToClipboard } from '../../../../lib/clipboard';
 import { DownloadFileButton } from './DownloadFileButton';
 import { MAX_EMAIL_BYTES, attachmentLine, type EmailMessageView } from './emailMessage';
 import { buildEmailBody, type EmailLink } from './emailBody';
@@ -130,8 +131,10 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
       <div className="mb-4 flex items-center gap-3 rounded-sm bg-sunken px-3 py-2">
         <Mail size={15} className="shrink-0 text-ink-faint" aria-hidden />
         <p className="min-w-0 flex-1 text-detail text-ink-muted">
-          Text view of the email — formatting, inline images and attachment contents are not
-          shown. Download the file to open it in a mail client.
+          {rendered !== null
+            ? 'The sender’s formatting, shown without remote content: images hosted elsewhere are not loaded, and links open only after you confirm the address. Attachment contents are not shown.'
+            : 'Text view of the email — formatting, inline images and attachment contents are not shown.'}{' '}
+          Download the file to open it in a mail client.
         </p>
         <DownloadFileButton filePath={filePath} size="sm" />
       </div>
@@ -167,11 +170,23 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
             title="Message body"
             className="h-[32rem] w-full rounded-xs border border-line bg-white"
           />
-          {rendered.blockedRemoteImages > 0 && (
+          {(rendered.blockedRemoteImages > 0 || rendered.unavailableInlineImages > 0) && (
             <p className="mt-2 text-detail text-ink-faint">
-              {rendered.blockedRemoteImages} remote image
-              {rendered.blockedRemoteImages === 1 ? '' : 's'} not loaded — fetching one would tell
-              the sender you opened this message.
+              {rendered.blockedRemoteImages > 0 && (
+                <>
+                  {rendered.blockedRemoteImages} remote image
+                  {rendered.blockedRemoteImages === 1 ? '' : 's'} not loaded — fetching one would
+                  tell the sender you opened this message.
+                </>
+              )}
+              {rendered.blockedRemoteImages > 0 && rendered.unavailableInlineImages > 0 && ' '}
+              {rendered.unavailableInlineImages > 0 && (
+                <>
+                  {rendered.unavailableInlineImages} embedded image
+                  {rendered.unavailableInlineImages === 1 ? '' : 's'} could not be shown — the part
+                  is missing from the file or too large to inline.
+                </>
+              )}
             </p>
           )}
           {rendered.links.length > 0 && <EmailLinks links={rendered.links} />}
@@ -206,6 +221,36 @@ export function EmailRenderer({ filePath }: FileRendererProps) {
 
 
 /**
+ * A copy button that says whether the copy LANDED.
+ *
+ * `navigator.clipboard` is absent outside a secure context and rejects when
+ * the document is not focused — ordinary conditions, not exceptions. A button
+ * that silently did nothing (or left an unhandled rejection) would leave the
+ * reader believing they hold an address they do not.
+ */
+function CopyLinkButton({ url }: { url: string }): React.ReactElement {
+  const [state, setState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  return (
+    <button
+      type="button"
+      className="flex shrink-0 items-center gap-1 text-ink-faint hover:text-ink"
+      title={state === 'failed' ? 'Could not copy — select the address instead' : 'Copy this address'}
+      onClick={() => {
+        void copyToClipboard(url).then((ok) => {
+          setState(ok ? 'copied' : 'failed');
+          window.setTimeout(() => setState('idle'), 2000);
+        });
+      }}
+    >
+      {state === 'copied' ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+      {state !== 'idle' && (
+        <span className="text-meta">{state === 'copied' ? 'Copied' : 'Copy failed'}</span>
+      )}
+    </button>
+  );
+}
+
+/**
  * The message's links, in TRUSTED UI outside the sandbox.
  *
  * A click inside a script-free frame cannot be intercepted, so an anchor left
@@ -231,14 +276,7 @@ function EmailLinks({ links }: { links: readonly EmailLink[] }): React.ReactElem
               {link.text !== '' && <span className="text-ink">{link.text} — </span>}
               <span className="break-all text-ink-faint">{link.url}</span>
             </span>
-            <button
-              type="button"
-              className="shrink-0 text-ink-faint hover:text-ink"
-              title="Copy this address"
-              onClick={() => void navigator.clipboard?.writeText(link.url)}
-            >
-              <Copy size={12} aria-hidden />
-            </button>
+            <CopyLinkButton url={link.url} />
             <button
               type="button"
               className="shrink-0 text-ink-faint hover:text-ink"

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/EmailRenderer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/EmailRenderer.test.tsx
@@ -109,7 +109,7 @@ describe('EmailRenderer', () => {
     expect(screen.getByText('report.pdf (application/pdf, 8 bytes)')).toBeInTheDocument();
     expect(screen.getByText(/listed by name only/)).toBeInTheDocument();
     // The honest strip + the way to the real thing.
-    expect(screen.getByText(/Text view of the email/)).toBeInTheDocument();
+    expect(screen.getByText(/shown without remote content/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Download/ })).toBeInTheDocument();
   });
 

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/EmailRenderer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/EmailRenderer.test.tsx
@@ -96,8 +96,13 @@ describe('EmailRenderer', () => {
     expect(screen.getByText('Subject')).toBeInTheDocument();
     expect(screen.getByText('Quarterly numbers')).toBeInTheDocument();
     expect(screen.getByText('2026-01-05T10:00:00.000Z')).toBeInTheDocument();
-    // The HTML body arrives as STRIPPED TEXT — tags gone, nothing injected.
-    expect(screen.getByText('Please see attached.')).toBeInTheDocument();
+    // CHANGED: a message carrying an HTML alternative now RENDERS it, the way a
+    // mail client does — in a frame that cannot run scripts or fetch anything.
+    const frame = screen.getByTitle('Message body') as HTMLIFrameElement;
+    expect(frame.getAttribute('sandbox')).toBe('');
+    expect(frame.srcdoc).toContain('Please see');
+    expect(frame.srcdoc).toContain("default-src 'none'");
+    expect(frame.srcdoc).toContain('img-src data:');
     expect(document.querySelector('b')).toBeNull();
     expect(document.querySelector('script')).toBeNull();
     // Attachments: named, and honestly not downloadable one by one.

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailBody.test.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailBody.test.ts
@@ -35,9 +35,15 @@ describe('a rendered email body', () => {
   });
 
   it('drops a cid: image whose bytes were not retained, rather than fetching anything', () => {
-    const { srcDoc, blockedRemoteImages } = buildEmailBody('<img src="cid:missing@x">', []);
+    const { srcDoc, blockedRemoteImages, unavailableInlineImages } = buildEmailBody(
+      '<img src="cid:missing@x">',
+      [],
+    );
     expect(srcDoc).not.toContain('cid:');
-    expect(blockedRemoteImages).toBe(1);
+    // Not "blocked": nothing was withheld to protect the reader — the part is
+    // simply not in the file, and the notice says so in different words.
+    expect(blockedRemoteImages).toBe(0);
+    expect(unavailableInlineImages).toBe(1);
   });
 
   it('carries no script, however the sender spelled it', () => {
@@ -86,5 +92,26 @@ describe('a rendered email body', () => {
     );
     expect(srcDoc).not.toContain('evil.example');
     expect(srcDoc).not.toContain('<input');
+  });
+});
+
+describe('what the rendering keeps and what it admits to dropping', () => {
+  it('keeps CSS the sender put in <head>, where mail routinely puts it', () => {
+    const { srcDoc } = buildEmailBody(
+      '<html><head><style>.brand{color:#0a7}</style></head><body><p class="brand">Hi</p></body></html>',
+      [],
+    );
+    expect(srcDoc).toContain('.brand');
+  });
+
+  it('counts an embedded image it could not draw APART from a remote one', () => {
+    const { blockedRemoteImages, unavailableInlineImages } = buildEmailBody(
+      '<img src="cid:missing@x"><img src="https://tracker.example/p.gif">',
+      [],
+    );
+    // Different sentences: one was withheld to protect the reader, the other
+    // simply is not in the file.
+    expect(unavailableInlineImages).toBe(1);
+    expect(blockedRemoteImages).toBe(1);
   });
 });

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailBody.test.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailBody.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { buildEmailBody } from '../emailBody';
+import type { EmailAttachmentView } from '../emailMessage';
+
+/**
+ * What a rendered message may and may not do. These are the security
+ * properties of the viewer, so they are asserted on the DOCUMENT that goes
+ * into the frame — the thing a browser would actually execute.
+ */
+describe('a rendered email body', () => {
+  const inlineLogo: EmailAttachmentView = {
+    name: 'logo.png',
+    mimeType: 'image/png',
+    sizeBytes: 3,
+    contentId: 'logo@sender',
+    bytes: new Uint8Array([1, 2, 3]),
+  };
+
+  it('renders an image the sender EMBEDDED, without any network', () => {
+    const { srcDoc, blockedRemoteImages } = buildEmailBody(
+      '<p>Hi</p><img src="cid:logo@sender">',
+      [inlineLogo],
+    );
+    expect(srcDoc).toContain('data:image/png;base64,');
+    expect(blockedRemoteImages).toBe(0);
+  });
+
+  it('drops a REMOTE image — a tracking pixel cannot report that the mail was opened', () => {
+    const { srcDoc, blockedRemoteImages } = buildEmailBody(
+      '<p>Hi</p><img src="https://tracker.example/pixel.gif?id=42" width="1" height="1">',
+      [],
+    );
+    expect(srcDoc).not.toContain('tracker.example');
+    expect(blockedRemoteImages).toBe(1);
+  });
+
+  it('drops a cid: image whose bytes were not retained, rather than fetching anything', () => {
+    const { srcDoc, blockedRemoteImages } = buildEmailBody('<img src="cid:missing@x">', []);
+    expect(srcDoc).not.toContain('cid:');
+    expect(blockedRemoteImages).toBe(1);
+  });
+
+  it('carries no script, however the sender spelled it', () => {
+    const { srcDoc } = buildEmailBody(
+      `<p onclick="steal()">Hi</p><script>steal()</script><img src=x onerror="steal()">`,
+      [],
+    );
+    expect(srcDoc).not.toContain('steal()');
+    expect(srcDoc).not.toContain('onerror');
+    expect(srcDoc).not.toContain('onclick');
+  });
+
+  it('states a policy that forbids every outbound request', () => {
+    const { srcDoc } = buildEmailBody('<p>Hi</p>', []);
+    expect(srcDoc).toContain("default-src 'none'");
+    expect(srcDoc).toContain('img-src data:');
+    expect(srcDoc).toContain("connect-src 'none'");
+    expect(srcDoc).toContain("form-action 'none'");
+  });
+
+  it('makes links INERT and reports them for the parent to show', () => {
+    const { srcDoc, links } = buildEmailBody(
+      '<p>See <a href="https://example.com/deal?id=7">this offer</a> today</p>',
+      [],
+    );
+    // The address never appears in the frame, and no anchor can be followed.
+    expect(srcDoc).not.toContain('example.com');
+    expect(srcDoc).not.toContain('<script');
+    expect(srcDoc).toContain('[1]');
+    expect(links).toEqual([{ index: 1, text: 'this offer', url: 'https://example.com/deal?id=7' }]);
+  });
+
+  it('does not present a javascript: or data: link as a link at all', () => {
+    const { srcDoc, links } = buildEmailBody(
+      `<a href="javascript:steal()">click</a><a href="data:text/html,<script>x</script>">or here</a>`,
+      [],
+    );
+    expect(links).toEqual([]);
+    expect(srcDoc).not.toContain('javascript:');
+  });
+
+  it('drops a form, so no message can post anywhere', () => {
+    const { srcDoc } = buildEmailBody(
+      '<form action="https://evil.example/steal"><input name="password"></form>',
+      [],
+    );
+    expect(srcDoc).not.toContain('evil.example');
+    expect(srcDoc).not.toContain('<input');
+  });
+});

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailMessage.test.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailMessage.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import * as XLSX from 'xlsx';
-import { attachmentLine, mailboxText } from '../emailMessage';
+import { attachmentLine, inlineBudgeted, mailboxText, referencedContentIds, type EmailAttachmentView } from '../emailMessage';
 import { parseEmlMessage } from '../emlMessage';
 import { parseMsgMessage } from '../msgMessage';
 
@@ -350,5 +350,29 @@ describe('email helpers', () => {
     // It may import a parser; what it must NOT drag in is the presentation code.
     expect(read('../xmlReading.ts')).not.toContain('jszip');
     expect(read('../xmlReading.ts')).not.toContain("'./pptxOutline'");
+  });
+});
+
+describe('the inline-image budget', () => {
+  const part = (id: string, size: number): EmailAttachmentView => ({
+    name: `${id}.png`,
+    mimeType: 'image/png',
+    sizeBytes: size,
+    contentId: id,
+    bytes: new Uint8Array(size),
+  });
+
+  it('spends the budget on the images the BODY shows, not on the ones that come first', () => {
+    // 10 MB of unreferenced parts ahead of the one the message actually
+    // displays: in document order they ate the budget and the shown picture
+    // was the one that went undrawn.
+    const parts = [part('unused-a', 6_000_000), part('unused-b', 6_000_000), part('shown', 1_000)];
+    const out = inlineBudgeted(parts, referencedContentIds('<img src="cid:shown">'));
+    expect(out.find((p) => p.contentId === 'shown')?.bytes).toBeDefined();
+  });
+
+  it('reads the cid: references an HTML body makes, however they are quoted', () => {
+    const ids = referencedContentIds(`<img src="cid:A@x"><img src='cid:b@y'><td background="cid:<C@z>">`);
+    expect([...ids].sort()).toEqual(['a@x', 'b@y', 'c@z']);
   });
 });

--- a/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailMessage.test.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/__tests__/emailMessage.test.ts
@@ -2,7 +2,15 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import * as XLSX from 'xlsx';
-import { attachmentLine, inlineBudgeted, mailboxText, referencedContentIds, type EmailAttachmentView } from '../emailMessage';
+import {
+  MAX_INLINE_IMAGE_BYTES,
+  MAX_INLINE_IMAGE_TOTAL_BYTES,
+  attachmentLine,
+  inlineBudgeted,
+  mailboxText,
+  referencedContentIds,
+  type EmailAttachmentView,
+} from '../emailMessage';
 import { parseEmlMessage } from '../emlMessage';
 import { parseMsgMessage } from '../msgMessage';
 
@@ -363,12 +371,30 @@ describe('the inline-image budget', () => {
   });
 
   it('spends the budget on the images the BODY shows, not on the ones that come first', () => {
-    // 10 MB of unreferenced parts ahead of the one the message actually
-    // displays: in document order they ate the budget and the shown picture
-    // was the one that went undrawn.
-    const parts = [part('unused-a', 6_000_000), part('unused-b', 6_000_000), part('shown', 1_000)];
+    // Four unreferenced parts at the per-part maximum come to EXACTLY the
+    // aggregate budget, so in document order there is nothing left for the
+    // small image the body actually displays and it is the one that goes
+    // undrawn. The sizes are the whole test: pick them so the budget is not
+    // reached (as this test first did) and it passes either way, pinning
+    // nothing — which is how the broken regex under it went unnoticed.
+    const four = MAX_INLINE_IMAGE_TOTAL_BYTES / MAX_INLINE_IMAGE_BYTES;
+    const parts = [
+      ...Array.from({ length: four }, (_, i) => part(`unused-${i}`, MAX_INLINE_IMAGE_BYTES)),
+      part('shown', 1_000),
+    ];
     const out = inlineBudgeted(parts, referencedContentIds('<img src="cid:shown">'));
     expect(out.find((p) => p.contentId === 'shown')?.bytes).toBeDefined();
+    // …and the budget still BINDS: one unreferenced part lost its bytes to
+    // make room, rather than everything being kept.
+    expect(out.filter((p) => p.bytes !== undefined).length).toBe(four);
+  });
+
+  it('reads a cid: whose id contains an s — the letter is not a delimiter', () => {
+    // Written with an unescaped `s`, the class excluded the LETTER s: an id
+    // like `photos@x` truncated to `photo` and `shown` matched nothing at all,
+    // which silently turned the priority sort back into document order.
+    expect([...referencedContentIds('<img src="cid:photos@x">')]).toEqual(['photos@x']);
+    expect([...referencedContentIds('<img src="cid:shown">')]).toEqual(['shown']);
   });
 
   it('reads the cid: references an HTML body makes, however they are quoted', () => {

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emailBody.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emailBody.ts
@@ -43,8 +43,15 @@ export interface EmailBodyDocument {
   srcDoc: string;
   /** Every link the body carried, in document order. */
   links: EmailLink[];
-  /** How many images were dropped for pointing somewhere remote. */
+  /** How many images were dropped for pointing somewhere REMOTE. */
   blockedRemoteImages: number;
+  /**
+   * How many images the sender EMBEDDED but this viewer could not draw — the
+   * part was missing from the file, or past the inline budget. Counted apart
+   * from remote ones because the honest sentence differs: nothing was withheld
+   * to protect the reader, the picture simply is not available.
+   */
+  unavailableInlineImages: number;
 }
 
 /** Schemes a link may name. Anything else is not shown as a link at all. */
@@ -85,6 +92,7 @@ export function buildEmailBody(html: string, attachments: readonly EmailAttachme
 
   // Images: the sender's own parts become data: URIs, everything remote goes.
   let blockedRemoteImages = 0;
+  let unavailableInlineImages = 0;
   for (const img of Array.from(doc.querySelectorAll('img'))) {
     const src = img.getAttribute('src') ?? '';
     const cid = contentIdOf(src);
@@ -94,7 +102,13 @@ export function buildEmailBody(html: string, attachments: readonly EmailAttachme
         img.setAttribute('src', uri);
         continue;
       }
-    } else if (src.trim().toLowerCase().startsWith('data:image/')) {
+      // Named a part this message does not carry, or one whose bytes the
+      // inline budget declined to hold.
+      img.remove();
+      unavailableInlineImages += 1;
+      continue;
+    }
+    if (src.trim().toLowerCase().startsWith('data:image/')) {
       continue; // already inline
     }
     img.remove();
@@ -141,9 +155,14 @@ export function buildEmailBody(html: string, attachments: readonly EmailAttachme
       title: 'Message',
       libModuleSources: [],
       includeRuntime: false,
-      bodyHtml: sanitizeAgentHtml(doc.body.innerHTML),
+      // The WHOLE document, not `body.innerHTML`: mail routinely puts its CSS
+      // in `<head><style>`, and the sanitizer hoists that into the body before
+      // serializing. Passing the body alone silently dropped the styling of
+      // every message written the ordinary way.
+      bodyHtml: sanitizeAgentHtml(doc.documentElement.outerHTML),
     }),
     links,
     blockedRemoteImages,
+    unavailableInlineImages,
   };
 }

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emailBody.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emailBody.ts
@@ -1,0 +1,149 @@
+import { buildSandboxedHtml, sanitizeAgentHtml } from './htmlSandbox';
+import type { EmailAttachmentView } from './emailMessage';
+
+/**
+ * Turn a message's HTML body into something safe to SHOW.
+ *
+ * The threat model for an email body is not the one for agent-authored HTML,
+ * and it is worth stating because it decides every rule below. A message comes
+ * from outside: the sender chose its markup, and two of the things a sender
+ * may want are hostile to the reader.
+ *
+ *  - SCRIPT. Never runs. The frame is mounted `sandbox=""` — not
+ *    `allow-scripts` like the agent-HTML renderer — so nothing in the message
+ *    executes, and the CSP's `script-src` is moot rather than load-bearing.
+ *  - THE TRACKING PIXEL. A remote image is a beacon: fetching it tells the
+ *    sender the message was opened, when, from which address. `img-src data:`
+ *    forbids every remote fetch, so the message renders without ever telling
+ *    its sender it was read. Images the sender EMBEDDED (referenced `cid:`,
+ *    carried in the file itself) are rewritten to `data:` URIs and do render —
+ *    that is the fidelity worth having, and it costs no network at all.
+ *
+ * Links are the third case, and they get a different answer. A click cannot be
+ * intercepted inside a script-free frame, so a live anchor would open its
+ * destination with no chance to show the reader where it goes. Every anchor is
+ * therefore made INERT and numbered, and its URL is handed back in `links` for
+ * the parent to render in trusted UI — where the reader sees the whole address
+ * before anything opens. Reverse-tabnabbing and referrer leakage stop being
+ * possible rather than being mitigated.
+ */
+
+/** One link found in the body, numbered as the rendering marks it. */
+export interface EmailLink {
+  /** 1-based, matching the `[n]` marker shown after the link text. */
+  index: number;
+  /** The link's own text, trimmed and bounded. */
+  text: string;
+  /** Its full destination, exactly as written. */
+  url: string;
+}
+
+export interface EmailBodyDocument {
+  /** A complete document for `<iframe srcDoc>`; makes zero network requests. */
+  srcDoc: string;
+  /** Every link the body carried, in document order. */
+  links: EmailLink[];
+  /** How many images were dropped for pointing somewhere remote. */
+  blockedRemoteImages: number;
+}
+
+/** Schemes a link may name. Anything else is not shown as a link at all. */
+const PRESENTABLE_SCHEMES = /^(https?|mailto):/i;
+
+/** Elements that never belong in a rendered message, whatever the sender meant. */
+const DROP = ['script', 'form', 'input', 'button', 'select', 'textarea', 'object', 'embed', 'iframe', 'link', 'meta', 'base'];
+
+/** Longest link text kept for the panel — a whole paragraph inside an anchor is not a label. */
+const MAX_LINK_TEXT = 200;
+
+/** `data:` URI for an inline part, or undefined when its bytes were not retained. */
+function dataUri(part: EmailAttachmentView): string | undefined {
+  if (!part.bytes || part.bytes.length === 0) return undefined;
+  let binary = '';
+  // Chunked: `String.fromCharCode(...bytes)` on a multi-megabyte part exceeds
+  // the argument limit and throws.
+  for (let i = 0; i < part.bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...part.bytes.subarray(i, i + 0x8000));
+  }
+  return `data:${part.mimeType ?? 'application/octet-stream'};base64,${btoa(binary)}`;
+}
+
+/** The `cid:` value an `<img src>` names, lowercased and unbracketed. */
+function contentIdOf(src: string): string | undefined {
+  const trimmed = src.trim();
+  if (!/^cid:/i.test(trimmed)) return undefined;
+  return trimmed.slice(4).replace(/^<|>$/g, '').toLowerCase();
+}
+
+export function buildEmailBody(html: string, attachments: readonly EmailAttachmentView[]): EmailBodyDocument {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+
+  const inlineByCid = new Map<string, EmailAttachmentView>();
+  for (const part of attachments) {
+    if (part.contentId && part.bytes) inlineByCid.set(part.contentId.toLowerCase(), part);
+  }
+
+  // Images: the sender's own parts become data: URIs, everything remote goes.
+  let blockedRemoteImages = 0;
+  for (const img of Array.from(doc.querySelectorAll('img'))) {
+    const src = img.getAttribute('src') ?? '';
+    const cid = contentIdOf(src);
+    if (cid !== undefined) {
+      const uri = inlineByCid.get(cid) && dataUri(inlineByCid.get(cid) as EmailAttachmentView);
+      if (uri !== undefined) {
+        img.setAttribute('src', uri);
+        continue;
+      }
+    } else if (src.trim().toLowerCase().startsWith('data:image/')) {
+      continue; // already inline
+    }
+    img.remove();
+    blockedRemoteImages += 1;
+  }
+
+  // Links: inert, numbered, and reported to the caller.
+  const links: EmailLink[] = [];
+  for (const anchor of Array.from(doc.querySelectorAll('a'))) {
+    const href = (anchor.getAttribute('href') ?? '').trim();
+    // Removed whatever it says: the sanitizer would strip it anyway, and an
+    // anchor with no href cannot be followed even if a future change to the
+    // frame's sandbox let it try.
+    anchor.removeAttribute('href');
+    anchor.removeAttribute('target');
+    if (!PRESENTABLE_SCHEMES.test(href)) continue;
+    const index = links.length + 1;
+    links.push({ index, text: (anchor.textContent ?? '').trim().slice(0, MAX_LINK_TEXT), url: href });
+    const marker = doc.createElement('sup');
+    marker.textContent = `[${index}]`;
+    anchor.after(marker);
+  }
+
+  for (const tag of DROP) {
+    for (const el of Array.from(doc.querySelectorAll(tag))) el.remove();
+  }
+
+  // Event handlers go too. The shared sanitizer keeps them ON PURPOSE — it
+  // serves agent HTML, which is allowed to run its own scripts — and the frame
+  // here forbids scripts outright, so an `onerror` could not fire. Removing
+  // them anyway means the document does not merely fail to execute an attack;
+  // it does not carry one.
+  for (const el of Array.from(doc.querySelectorAll('*'))) {
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.toLowerCase().startsWith('on')) el.removeAttribute(attr.name);
+    }
+  }
+
+  return {
+    // Through the shared sanitizer as well: it enforces the URL policy this
+    // function relies on (`data:image/` and nothing else) and strips event
+    // handlers, so a gap here cannot become a rendered attack.
+    srcDoc: buildSandboxedHtml({
+      title: 'Message',
+      libModuleSources: [],
+      includeRuntime: false,
+      bodyHtml: sanitizeAgentHtml(doc.body.innerHTML),
+    }),
+    links,
+    blockedRemoteImages,
+  };
+}

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
@@ -50,6 +50,46 @@ export function isInlineImagePart(mimeType: string | undefined, contentId: strin
   );
 }
 
+/** The Content-IDs an HTML body actually references as `cid:…`, lowercased. */
+export function referencedContentIds(html: string | undefined): Set<string> {
+  const out = new Set<string>();
+  if (html === undefined) return out;
+  for (const m of html.matchAll(/["'(]s*cid:([^"')s>]+)/gi)) {
+    out.add(m[1].replace(/^<|>$/g, '').toLowerCase());
+  }
+  return out;
+}
+
+/**
+ * Drop retained bytes past the aggregate inline budget. Shared by both parsers
+ * so the rule cannot drift between `.eml` and `.msg`.
+ *
+ * Parts the body REFERENCES are considered first, whatever their order in the
+ * file: a message may carry inline images it never shows, and spending the
+ * budget on those in document order left the picture the reader was actually
+ * meant to see undrawn while an unreferenced one sat in memory.
+ */
+export function inlineBudgeted(
+  parts: EmailAttachmentView[],
+  referenced: Set<string>,
+): EmailAttachmentView[] {
+  const order = parts
+    .map((part, index) => ({ index, shown: referenced.has((part.contentId ?? '').toLowerCase()) }))
+    .sort((a, b) => Number(b.shown) - Number(a.shown) || a.index - b.index);
+  const keep = new Set<number>();
+  let held = 0;
+  for (const { index } of order) {
+    const bytes = parts[index].bytes;
+    if (bytes === undefined) continue;
+    if (held + bytes.byteLength > MAX_INLINE_IMAGE_TOTAL_BYTES) continue;
+    held += bytes.byteLength;
+    keep.add(index);
+  }
+  return parts.map((part, index) =>
+    part.bytes !== undefined && !keep.has(index) ? { ...part, bytes: undefined } : part,
+  );
+}
+
 /** Where the body text came from — drives the honest notes in the viewer. */
 export type EmailBodySource = 'text' | 'html' | 'rtf-only' | 'none';
 

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
@@ -4,9 +4,12 @@ import { Parser } from 'htmlparser2';
  * The shared view model + text helpers for the email viewer (`EmailRenderer`),
  * the browser twin of the backend's `email-text.ts` — the same honest story
  * agents get through `read_file`: headers as labelled fields, the body as
- * PLAIN TEXT (the text part preferred, an HTML-only body stripped to text —
- * nothing from an email is ever rendered as HTML), attachments listed by
- * name. Parsers: `emlMessage.ts` (postal-mime) and `msgMessage.ts` (CFB via
+ * text (`body` — the text part preferred, an HTML body stripped to text) plus
+ * the sender's own HTML when there is one (`bodyHtml`), attachments listed by
+ * name. `body` is what an agent reads through `read_file`; the viewer renders
+ * `bodyHtml` in a sandbox that can neither run a script nor fetch a byte (see
+ * `emailBody.ts`), so a human sees the message and an agent reads the same
+ * message, without either being handed live markup. Parsers: `emlMessage.ts` (postal-mime) and `msgMessage.ts` (CFB via
  * SheetJS) fill this model; the renderer never sees a format.
  */
 
@@ -14,6 +17,37 @@ export interface EmailAttachmentView {
   name: string;
   mimeType?: string;
   sizeBytes?: number;
+  /**
+   * The attachment's Content-ID with its angle brackets removed, when the
+   * message gave it one. An HTML body references such a part as `cid:<id>`,
+   * which is how a sender embeds a picture IN the message rather than linking
+   * to one on their server.
+   */
+  contentId?: string;
+  /**
+   * Raw bytes — retained ONLY for a part small enough to inline and referenced
+   * by Content-ID, because that is the only thing the viewer renders from
+   * bytes. An ordinary 40 MB attachment is described, never held.
+   */
+  bytes?: Uint8Array;
+}
+
+/** Bounds on what may be held in memory for inline rendering. */
+export const MAX_INLINE_IMAGE_BYTES = 4 * 1024 * 1024;
+export const MAX_INLINE_IMAGE_TOTAL_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Should this part's bytes be kept for inline rendering? Only a Content-ID'd
+ * image within bounds: everything else is listed by name and nothing more.
+ */
+export function isInlineImagePart(mimeType: string | undefined, contentId: string | undefined, size: number): boolean {
+  return (
+    contentId !== undefined &&
+    contentId !== '' &&
+    (mimeType ?? '').toLowerCase().startsWith('image/') &&
+    size > 0 &&
+    size <= MAX_INLINE_IMAGE_BYTES
+  );
 }
 
 /** Where the body text came from — drives the honest notes in the viewer. */
@@ -29,6 +63,12 @@ export interface EmailMessageView {
   date?: string;
   /** Plain-text body ('' when there is none, or it exists only as RTF). */
   body: string;
+  /**
+   * The HTML body as the sender wrote it, when there is one. The viewer
+   * renders this in a sandbox; `body` remains the text an agent reads, so the
+   * two surfaces never disagree about what the message SAYS.
+   */
+  bodyHtml?: string;
   bodySource: EmailBodySource;
   attachments: EmailAttachmentView[];
 }

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emailMessage.ts
@@ -54,7 +54,12 @@ export function isInlineImagePart(mimeType: string | undefined, contentId: strin
 export function referencedContentIds(html: string | undefined): Set<string> {
   const out = new Set<string>();
   if (html === undefined) return out;
-  for (const m of html.matchAll(/["'(]s*cid:([^"')s>]+)/gi)) {
+  // The delimiter before `cid:` is a quote or `(` (url(...)), then optional
+  // whitespace. Both escapes matter: written unescaped, `\s` is a literal `s`
+  // — the class stops excluding whitespace and starts excluding the LETTER,
+  // truncating `photos@x` to `photo` and failing outright on an id that starts
+  // with one.
+  for (const m of html.matchAll(/["'(]\s*cid:([^"')\s>]+)/gi)) {
     out.add(m[1].replace(/^<|>$/g, '').toLowerCase());
   }
   return out;

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emlMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emlMessage.ts
@@ -2,7 +2,9 @@ import PostalMime from 'postal-mime';
 import type { Address, Email } from 'postal-mime';
 import {
   MAX_EMAIL_BYTES,
+  MAX_INLINE_IMAGE_TOTAL_BYTES,
   htmlToEmailText,
+  isInlineImagePart,
   isoDate,
   type EmailAttachmentView,
   type EmailMessageView,
@@ -53,16 +55,39 @@ export async function parseEmlMessage(bytes: ArrayBuffer): Promise<EmailMessageV
     subject: email.subject,
     date: email.date !== undefined ? isoDate(email.date) : undefined,
     body: body.replace(/\s+$/, ''),
+    bodyHtml: html,
     bodySource: text !== undefined ? 'text' : html !== undefined ? 'html' : 'none',
-    attachments: email.attachments.map(
-      (a): EmailAttachmentView => ({
-        name: a.filename ?? 'unnamed attachment',
-        mimeType: a.mimeType,
-        sizeBytes:
-          typeof a.content === 'string' ? new TextEncoder().encode(a.content).byteLength : a.content.byteLength,
+    attachments: inlineBudgeted(
+      email.attachments.map((a): EmailAttachmentView => {
+        const bytes =
+          typeof a.content === 'string' ? new TextEncoder().encode(a.content) : new Uint8Array(a.content);
+        // postal-mime keeps the angle brackets: `<abc@host>`.
+        const contentId = a.contentId?.replace(/^<|>$/g, '');
+        return {
+          name: a.filename ?? 'unnamed attachment',
+          mimeType: a.mimeType,
+          sizeBytes: bytes.byteLength,
+          contentId,
+          bytes: isInlineImagePart(a.mimeType, contentId, bytes.byteLength) ? bytes : undefined,
+        };
       }),
     ),
   };
+}
+
+/**
+ * Drop retained bytes past the aggregate inline budget: one message may carry
+ * many small images, and the per-part bound alone does not cap their sum. The
+ * parts stay listed — only the bytes go, and the picture simply does not draw.
+ */
+function inlineBudgeted(parts: EmailAttachmentView[]): EmailAttachmentView[] {
+  let held = 0;
+  return parts.map((part) => {
+    if (part.bytes === undefined) return part;
+    if (held + part.bytes.byteLength > MAX_INLINE_IMAGE_TOTAL_BYTES) return { ...part, bytes: undefined };
+    held += part.bytes.byteLength;
+    return part;
+  });
 }
 
 /** `Name <addr>, addr2, Group: member, member` — groups flattened inline. */

--- a/packages/core-frontend/src/modules/workspace/components/renderers/emlMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/emlMessage.ts
@@ -2,10 +2,11 @@ import PostalMime from 'postal-mime';
 import type { Address, Email } from 'postal-mime';
 import {
   MAX_EMAIL_BYTES,
-  MAX_INLINE_IMAGE_TOTAL_BYTES,
   htmlToEmailText,
+  inlineBudgeted,
   isInlineImagePart,
   isoDate,
+  referencedContentIds,
   type EmailAttachmentView,
   type EmailMessageView,
 } from './emailMessage';
@@ -71,23 +72,9 @@ export async function parseEmlMessage(bytes: ArrayBuffer): Promise<EmailMessageV
           bytes: isInlineImagePart(a.mimeType, contentId, bytes.byteLength) ? bytes : undefined,
         };
       }),
+      referencedContentIds(html),
     ),
   };
-}
-
-/**
- * Drop retained bytes past the aggregate inline budget: one message may carry
- * many small images, and the per-part bound alone does not cap their sum. The
- * parts stay listed — only the bytes go, and the picture simply does not draw.
- */
-function inlineBudgeted(parts: EmailAttachmentView[]): EmailAttachmentView[] {
-  let held = 0;
-  return parts.map((part) => {
-    if (part.bytes === undefined) return part;
-    if (held + part.bytes.byteLength > MAX_INLINE_IMAGE_TOTAL_BYTES) return { ...part, bytes: undefined };
-    held += part.bytes.byteLength;
-    return part;
-  });
 }
 
 /** `Name <addr>, addr2, Group: member, member` — groups flattened inline. */

--- a/packages/core-frontend/src/modules/workspace/components/renderers/htmlSandbox.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/htmlSandbox.ts
@@ -281,6 +281,13 @@ interface BuildSandboxedHtmlOptions {
   title: string;
   /** knowledge-base JS library files, in dependency order. */
   libModuleSources: string[];
+  /**
+   * Emit the runtime (library + nav bridge)? The EMAIL viewer passes false:
+   * its frame is mounted `sandbox=""`, so a script could never run, and
+   * shipping one anyway leaves dead code in a document whose whole claim is
+   * that it executes nothing.
+   */
+  includeRuntime?: boolean;
   /** Sanitized agent HTML, body content only. */
   bodyHtml: string;
 }
@@ -323,9 +330,9 @@ export function buildSandboxedHtml(opts: BuildSandboxedHtmlOptions): string {
 <title>${safeTitle}</title>
 </head>
 <body>
-<script type="module">
+${opts.includeRuntime === false ? '' : `<script type="module">
 ${inlineLib}
-</script>
+</script>`}
 ${opts.bodyHtml}
 </body>
 </html>`;

--- a/packages/core-frontend/src/modules/workspace/components/renderers/msgMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/msgMessage.ts
@@ -1,7 +1,9 @@
 import * as XLSX from 'xlsx';
 import {
   MAX_EMAIL_BYTES,
+  MAX_INLINE_IMAGE_TOTAL_BYTES,
   htmlToEmailText,
+  isInlineImagePart,
   isoDate,
   mailboxText,
   type EmailAttachmentView,
@@ -35,6 +37,21 @@ import {
  * verbatim by the caller — for non-CFB bytes and CFB files with no MAPI
  * streams at all.
  */
+/**
+ * Drop retained bytes past the aggregate inline budget — one message may carry
+ * many small images, and the per-part bound alone does not cap their sum. The
+ * parts stay listed; only the bytes go.
+ */
+function inlineBudgeted(parts: EmailAttachmentView[]): EmailAttachmentView[] {
+  let held = 0;
+  return parts.map((part) => {
+    if (part.bytes === undefined) return part;
+    if (held + part.bytes.byteLength > MAX_INLINE_IMAGE_TOTAL_BYTES) return { ...part, bytes: undefined };
+    held += part.bytes.byteLength;
+    return part;
+  });
+}
+
 export function parseMsgMessage(bytes: ArrayBuffer): EmailMessageView {
   if (bytes.byteLength > MAX_EMAIL_BYTES) {
     throw new Error(
@@ -88,16 +105,26 @@ export function parseMsgMessage(bytes: ArrayBuffer): EmailMessageView {
     subject: stringProp(streams, '', '0037'),
     date: messageDate(streams.get('__properties_version1.0')),
     body,
+    bodyHtml: html,
     bodySource,
-    attachments: storageDirs(streams, '__attach_version1.0_#').map(
-      (dir): EmailAttachmentView => ({
-        name:
-          stringProp(streams, dir, '3707') ??
-          stringProp(streams, dir, '3704') ??
-          stringProp(streams, dir, '3001') ??
-          'unnamed attachment',
-        mimeType: stringProp(streams, dir, '370E'),
-        sizeBytes: streams.get(`${dir}__substg1.0_37010102`)?.byteLength,
+    attachments: inlineBudgeted(
+      storageDirs(streams, '__attach_version1.0_#').map((dir): EmailAttachmentView => {
+        const content = streams.get(`${dir}__substg1.0_37010102`);
+        const mimeType = stringProp(streams, dir, '370E');
+        // PidTagAttachContentId (0x3712) — what an HTML body's `cid:` names.
+        const contentId = stringProp(streams, dir, '3712')?.replace(/^<|>$/g, '');
+        return {
+          name:
+            stringProp(streams, dir, '3707') ??
+            stringProp(streams, dir, '3704') ??
+            stringProp(streams, dir, '3001') ??
+            'unnamed attachment',
+          mimeType,
+          sizeBytes: content?.byteLength,
+          contentId,
+          bytes:
+            content && isInlineImagePart(mimeType, contentId, content.byteLength) ? content : undefined,
+        };
       }),
     ),
   };

--- a/packages/core-frontend/src/modules/workspace/components/renderers/msgMessage.ts
+++ b/packages/core-frontend/src/modules/workspace/components/renderers/msgMessage.ts
@@ -1,11 +1,12 @@
 import * as XLSX from 'xlsx';
 import {
   MAX_EMAIL_BYTES,
-  MAX_INLINE_IMAGE_TOTAL_BYTES,
   htmlToEmailText,
+  inlineBudgeted,
   isInlineImagePart,
   isoDate,
   mailboxText,
+  referencedContentIds,
   type EmailAttachmentView,
   type EmailBodySource,
   type EmailMessageView,
@@ -37,21 +38,6 @@ import {
  * verbatim by the caller — for non-CFB bytes and CFB files with no MAPI
  * streams at all.
  */
-/**
- * Drop retained bytes past the aggregate inline budget — one message may carry
- * many small images, and the per-part bound alone does not cap their sum. The
- * parts stay listed; only the bytes go.
- */
-function inlineBudgeted(parts: EmailAttachmentView[]): EmailAttachmentView[] {
-  let held = 0;
-  return parts.map((part) => {
-    if (part.bytes === undefined) return part;
-    if (held + part.bytes.byteLength > MAX_INLINE_IMAGE_TOTAL_BYTES) return { ...part, bytes: undefined };
-    held += part.bytes.byteLength;
-    return part;
-  });
-}
-
 export function parseMsgMessage(bytes: ArrayBuffer): EmailMessageView {
   if (bytes.byteLength > MAX_EMAIL_BYTES) {
     throw new Error(
@@ -126,6 +112,7 @@ export function parseMsgMessage(bytes: ArrayBuffer): EmailMessageView {
             content && isInlineImagePart(mimeType, contentId, content.byteLength) ? content : undefined,
         };
       }),
+      referencedContentIds(html),
     ),
   };
 }


### PR DESCRIPTION
The email viewer stripped every HTML body to text. Safe, but it reads badly: a message written as HTML arrived as a wall of prose with its structure, emphasis and embedded pictures gone. This renders it the way a mail client does — with the two things a sender might want that a reader does not, taken away.

## The three rules

**Scripts never run.** The frame is `sandbox=""` — *not* `allow-scripts` like the agent-HTML renderer — so nothing in a stranger's mail executes, and the CSP's `script-src` is moot rather than load-bearing. Event handlers are stripped too: the shared sanitiser keeps them *on purpose*, because it serves HTML that is allowed its own scripts. So the document does not merely fail to execute an attack; it does not carry one.

**The tracking pixel cannot fire.** `img-src data:` forbids every remote fetch, so opening a message never tells its sender it was read, when, or from which address. What the sender *embedded* still renders: a `cid:` part is rewritten to a `data:` URI from bytes already inside the file — no network at all. Blocked remote images are counted and reported, so the reader can tell "no picture" from "picture withheld".

**Links are inert, numbered, and listed below the body** in trusted UI with copy and open-behind-confirmation. This one is not a preference: a click inside a script-free frame *cannot be intercepted*, so the real choice was a live anchor that opens its destination unseen, or no anchor at all. Reverse-tabnabbing and referrer leakage stop being possible rather than being mitigated, and a phishing destination is read before it is visited.

## Reuse

No new sanitiser. `htmlSandbox.ts` already allows `data:image/` **and nothing else** — precisely the email policy — so the existing pass enforces it, and `buildSandboxedHtml` gains one option (`includeRuntime: false`) to keep the nav-bridge script out of a document whose whole claim is that it runs nothing.

## Bounds

Parsers retain a part's bytes only when it is a Content-ID'd image within bounds (4 MB each, 16 MB per message). An ordinary 40 MB attachment is described and never held.

## Not changed

`read_file` is untouched. Agents read `body` — the text — and always did; the viewer renders `bodyHtml`, the same message. A message with no HTML part still falls back to plain text.

Tests assert the security properties on the document that goes into the frame: embedded image renders, remote image dropped, script/handlers absent, policy present, links inert and reported, `javascript:`/`data:` links not presented as links, forms dropped. Suite 1487 frontend, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render HTML email bodies in a sandboxed iframe so structure and embedded images display without letting the message execute or fetch. Previously we showed text only; now we render the sender’s HTML while blocking scripts and remote images, make links inert and list them below, and clearly report withheld vs unavailable images.

- `emailBody.ts`: sanitizes the whole document (preserves `<head><style>`), inlines `cid:` images as `data:` URIs, drops remote images, makes links inert and numbered with a `links` list, removes scripts/forms/event handlers, and counts `blockedRemoteImages` vs `unavailableInlineImages`.
- `EmailRenderer`: mounts `iframe sandbox=""` with CSP (`default-src 'none'; img-src data:`), updates the banner copy, shows separate image counters, and renders a trusted link panel with copy and confirm-open. Uses shared `copyToClipboard` from `lib/clipboard.ts`.
- Message model/parsers: add `bodyHtml` to `EmailMessageView`; attachments now carry `contentId` and optional `bytes`. Enforce 4 MB per image, 16 MB total; `inlineBudgeted` prioritizes Content-IDs the HTML actually references and is shared by `.eml` and `.msg`. Fix `referencedContentIds` to correctly read `cid:` references (quotes/whitespace/brackets).
- `htmlSandbox.ts`: add `includeRuntime`; set to false for email so no runtime script ships.
- Clipboard: move helper to `lib/clipboard.ts`, guard `navigator.clipboard`, and fix copy-button timer so feedback is accurate.
- Tests cover embedded vs remote image handling, inert links and collection, handler/form removal, head CSS retention, banner copy, and regressions for the `cid:` regex and inline-image budget.

<sup>Written for commit ea392a6868d951043bf097241d4781292fde819f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

