### PR TITLE
Change-request approvals answer 5x faster: cache the at-ref access model per commit

### DIFF
--- a/.changeset/approve-click-latency.md
+++ b/.changeset/approve-click-latency.md
@@ -1,5 +1,6 @@
 ---
 "@bevel-software/platform-core-backend": patch
+"@bevel-software/platform-shared": patch
 ---
 
 Approving or withdrawing a file in a change request answers in a fraction of the time it took. The access model read at a git ref is now built once per commit and shared by every permission check that lands on that commit (one click used to rebuild it six times), a change-request detail fetches its two refs once instead of twice, and it no longer renders a per-file patch that nothing reads (`files[].patch` is absent from the detail payload).

--- a/.changeset/approve-click-latency.md
+++ b/.changeset/approve-click-latency.md
@@ -1,0 +1,5 @@
+---
+"@bevel-software/platform-core-backend": patch
+---
+
+Approving or withdrawing a file in a change request answers in a fraction of the time it took. The access model read at a git ref is now built once per commit and shared by every permission check that lands on that commit (one click used to rebuild it six times), a change-request detail fetches its two refs once instead of twice, and it no longer renders a per-file patch that nothing reads (`files[].patch` is absent from the detail payload).

--- a/.changeset/approve-click-latency.md
+++ b/.changeset/approve-click-latency.md
@@ -3,4 +3,4 @@
 "@bevel-software/platform-shared": patch
 ---
 
-Approving or withdrawing a file in a change request answers in a fraction of the time it took. The access model read at a git ref is now built once per commit and shared by every permission check that lands on that commit (one click used to rebuild it six times), a change-request detail fetches its two refs once instead of twice, and it no longer renders a per-file patch that nothing reads (`files[].patch` is absent from the detail payload).
+Approving or withdrawing a file in a change request answers in a fraction of the time it took. The access model read at a git ref is now built once per commit and shared by every permission check that lands on that commit (one click used to rebuild it six times); a change-request detail fetches its two refs once and pins its file list to the commits it resolved; and the internal detail an approve, withdraw, or revert reads skips per-file patches (the detail served to clients keeps them). A git read failure while building the access model now fails the operation closed with a 503 instead of answering from a partial tree.

--- a/packages/core-backend/src/modules/access-model/access-errors.ts
+++ b/packages/core-backend/src/modules/access-model/access-errors.ts
@@ -41,11 +41,6 @@ export class AccessDeniedError extends WorkflowDomainError {
 }
 
 /**
- * Thrown when the access-control config (roles.yaml or access.md) is missing
- * or malformed at runtime — distinct from AccessDeniedError because the cause
- * is a config bug, not a permission decision.
- */
-/**
  * Thrown when the access tree at a git ref could not be READ (a git
  * subprocess failed on the way), as opposed to being absent or malformed.
  * Nothing was decided: a verdict from a partially read tree could grant what
@@ -64,6 +59,11 @@ export class AccessUnreadableError extends WorkflowDomainError {
   }
 }
 
+/**
+ * Thrown when the access-control config (roles.yaml or access.md) is missing
+ * or malformed at runtime — distinct from AccessDeniedError because the cause
+ * is a config bug, not a permission decision.
+ */
 export class AccessConfigError extends WorkflowDomainError {
   readonly errors: string[];
 

--- a/packages/core-backend/src/modules/access-model/access-errors.ts
+++ b/packages/core-backend/src/modules/access-model/access-errors.ts
@@ -45,6 +45,25 @@ export class AccessDeniedError extends WorkflowDomainError {
  * or malformed at runtime — distinct from AccessDeniedError because the cause
  * is a config bug, not a permission decision.
  */
+/**
+ * Thrown when the access tree at a git ref could not be READ (a git
+ * subprocess failed on the way), as opposed to being absent or malformed.
+ * Nothing was decided: a verdict from a partially read tree could grant what
+ * a lost `access.md` would have denied, so the operation fails closed with a
+ * 503 and the caller retries. Distinct from AccessConfigError (the config is
+ * there and wrong) and AccessDeniedError (a real permission decision).
+ */
+export class AccessUnreadableError extends WorkflowDomainError {
+  constructor(ref: string, relativePath: string) {
+    super(
+      `Access rules at ${ref} could not be read (git failed on ${relativePath}); nothing was decided. Try again.`,
+      503,
+      { ref, path: relativePath },
+    );
+    this.name = 'AccessUnreadableError';
+  }
+}
+
 export class AccessConfigError extends WorkflowDomainError {
   readonly errors: string[];
 

--- a/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 
 import type { WorkspaceService } from '../../workspace/workspace.service.js';
 import { AccessControlService } from '../access-control.service.js';
+import { AccessUnreadableError } from '../../access-model/access-errors.js';
 
 /**
  * Every git subprocess the service (and this file's own fixture helpers)
@@ -214,7 +215,7 @@ describe('AccessControlService — at-ref model cache', () => {
     expect(lsTreeBuilds()).toBe(1);
   });
 
-  it('never caches a build that saw a git read fail, so one hiccup cannot pin a wrong verdict', async () => {
+  it('refuses to decide from a build that lost a git read, and never caches it', async () => {
     // A nearer access.md that DENIES the admin: reading it is what stands
     // between razvan and a write he must not have.
     await pushFromOther('deny Admin in Team', () =>
@@ -222,18 +223,20 @@ describe('AccessControlService — at-ref model cache', () => {
     );
 
     // Lose exactly that read, once, to a simulated transient failure. The
-    // build degrades the way it always did (the file counts as absent for
-    // this call, so the verdict is the fail-open one)...
+    // gate must not answer from the partial tree (which would grant what the
+    // lost file denies): it fails closed with an AccessUnreadableError...
     injected.failNext = (argv) => argv.includes('show') && argv.some((a) => a.endsWith(':Team/access.md'));
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(true);
+    await expect(svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).rejects.toBeInstanceOf(
+      AccessUnreadableError,
+    );
     expect(injected.failNext).toBeNull();
     expect(lsTreeBuilds()).toBe(1);
     // ...and says so in the logs, naming the read it lost.
-    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Team\/access\.md failed; .*will not be cached/));
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Team\/access\.md failed; refusing to decide/));
 
-    // ...but it is NOT pinned: the next call rebuilds and answers correctly,
-    // and that healthy build is the one that gets cached.
+    // Nothing was pinned: the next call rebuilds, answers correctly, and
+    // that healthy build is the one that gets cached.
     expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);
     expect(lsTreeBuilds()).toBe(2);
     expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);

--- a/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import fs from 'node:fs/promises';
@@ -13,9 +13,14 @@ import { AccessControlService } from '../access-control.service.js';
  * spawn through `execFile`, by argv. The service builds its at-ref model
  * with exactly one `git ls-tree -r` per build, so counting `ls-tree` argv
  * entries counts model builds — measured at the process boundary, which is
- * the cost this cache exists to remove.
+ * the cost this cache exists to remove. `injected.failNext` makes ONE
+ * matching spawn fail the way a transient git error does, so the cache's
+ * behaviour under a failed read can be pinned without a flaky fixture.
  */
-const { spawnLog } = vi.hoisted(() => ({ spawnLog: [] as string[][] }));
+const { spawnLog, injected } = vi.hoisted(() => ({
+  spawnLog: [] as string[][],
+  injected: { failNext: null as null | ((argv: string[]) => boolean) },
+}));
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -31,7 +36,16 @@ vi.mock('node:child_process', async (importOriginal) => {
   // promisified path the service uses has to be wrapped too.
   Object.defineProperty(wrapped, p.custom, {
     value: (...args: unknown[]) => {
-      spawnLog.push((args[1] as string[]) ?? []);
+      const argv = (args[1] as string[]) ?? [];
+      spawnLog.push(argv);
+      if (injected.failNext?.(argv)) {
+        injected.failNext = null;
+        return Promise.reject(
+          Object.assign(new Error('simulated transient git failure'), {
+            stderr: 'fatal: unable to read object (simulated)',
+          }),
+        );
+      }
       return original[p.custom](...args);
     },
   });
@@ -45,6 +59,11 @@ function lsTreeBuilds(): number {
   return spawnLog.filter((argv) => argv.includes('ls-tree')).length;
 }
 
+function rolesReads(): number {
+  return spawnLog.filter((argv) => argv.includes('show') && argv.some((a) => a.endsWith(':roles.yaml')))
+    .length;
+}
+
 /**
  * The at-ref access model — `canWriteAtRef` / `canWriteBatchAtRef` /
  * `eligibleWritersForPathsAtRef`, the gates every change-request read and
@@ -52,11 +71,14 @@ function lsTreeBuilds(): number {
  * the ref resolves to. Building it costs one `ls-tree` plus one `git show`
  * per `access.md`, so it must be built ONCE per commit and shared by every
  * gate call that lands on that commit, while a push that moves the ref is
- * still seen on the very next call.
+ * still seen on the very next call, and a build that saw a git read fail
+ * is never pinned.
+ *
+ * Every test seeds its own bare origin, workspace clone, and second clone
+ * (`other`, standing in for another user's push), so each one holds alone.
  */
 describe('AccessControlService — at-ref model cache', () => {
   let root: string;
-  let workspaceDir: string;
   let repo: string;
   let other: string;
   let svc: AccessControlService;
@@ -69,33 +91,35 @@ describe('AccessControlService — at-ref model cache', () => {
     return stdout.trim();
   }
 
-  async function seed(dir: string): Promise<void> {
-    await fs.mkdir(path.join(dir, 'Team'), { recursive: true });
-    await fs.writeFile(path.join(dir, 'roles.yaml'), 'roles:\n  Admin:\n    - razvan@bevel.software\n');
-    await fs.writeFile(path.join(dir, 'access.md'), '---\nwrite:\n  - Admin\n---\n');
-    await fs.writeFile(path.join(dir, 'Team/access.md'), '---\nwrite:\n  - Admin\n---\n');
-    await fs.writeFile(path.join(dir, DOC), '# doc\n');
+  /** Commit + push a change to origin/main from the OTHER clone. */
+  async function pushFromOther(message: string, write: () => Promise<void>): Promise<void> {
+    await write();
+    await git(other, 'add', '-A');
+    await git(other, 'commit', '-qm', message);
+    await git(other, 'push', '-q', 'origin', 'HEAD');
   }
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-atref-cache-'));
-    workspaceDir = path.join(root, workspaceId);
+    const workspaceDir = path.join(root, workspaceId);
     repo = path.join(workspaceDir, PROCESS_MAP_DIR);
     const origin = path.join(root, 'origin.git');
     other = path.join(root, 'other');
 
     await execFileAsync('git', ['init', '--bare', '-b', 'main', origin]);
-    await fs.mkdir(repo, { recursive: true });
-    await seed(repo);
+    await fs.mkdir(path.join(repo, 'Team'), { recursive: true });
+    await fs.writeFile(path.join(repo, 'roles.yaml'), 'roles:\n  Admin:\n    - razvan@bevel.software\n');
+    await fs.writeFile(path.join(repo, 'access.md'), '---\nwrite:\n  - Admin\n---\n');
+    await fs.writeFile(path.join(repo, 'Team/access.md'), '---\nwrite:\n  - Admin\n---\n');
+    await fs.writeFile(path.join(repo, DOC), '# doc\n');
     await execFileAsync('git', ['init', '-b', 'main', repo]);
     await git(repo, 'config', 'user.email', 'test@example.com');
     await git(repo, 'config', 'user.name', 'Test');
     await git(repo, 'add', '-A');
-    await git(repo, 'commit', '-m', 'seed');
+    await git(repo, 'commit', '-qm', 'seed');
     await git(repo, 'remote', 'add', 'origin', origin);
-    await git(repo, 'push', '-u', 'origin', 'main');
+    await git(repo, 'push', '-q', '-u', 'origin', 'main');
 
-    // A second clone stands in for "another user pushed to the base branch".
     await execFileAsync('git', ['clone', '-q', origin, other]);
     await git(other, 'config', 'user.email', 'other@example.com');
     await git(other, 'config', 'user.name', 'Other');
@@ -109,28 +133,31 @@ describe('AccessControlService — at-ref model cache', () => {
       },
     } as unknown as WorkspaceService;
     svc = new AccessControlService(stub, PROCESS_MAP_DIR);
+    spawnLog.length = 0;
+    injected.failNext = null;
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
+    injected.failNext = null;
     await fs.rm(root, { recursive: true, force: true });
   });
 
   it('builds the model once for the six gate calls an approval click makes', async () => {
-    spawnLog.length = 0;
     // The approve route's exact sequence: detail (eligibility + viewer batch +
-    // roles.yaml bypass check), then the gate, then the response's detail.
-    const verdicts = await Promise.all([
+    // roles.yaml bypass check, concurrently), then the gate, then the
+    // response's detail.
+    const [eligible, batch, bypass] = await Promise.all([
       svc.eligibleWritersForPathsAtRef(workspaceId, 'origin/main', [DOC]),
       svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC]),
       svc.canWriteAtRef(workspaceId, 'origin/main', admin, 'roles.yaml'),
-    ].map((p) => p));
+    ]);
     const gate = await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC);
     const again = await svc.eligibleWritersForPathsAtRef(workspaceId, 'origin/main', [DOC]);
     const batchAgain = await svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC]);
 
-    expect(verdicts[0]!.get(DOC)!.roles).toContain('Admin');
-    expect(verdicts[1]!.get(DOC)).toBe(true);
-    expect(verdicts[2]).toBe(true);
+    expect(eligible!.get(DOC)!.roles).toContain('Admin');
+    expect(batch!.get(DOC)).toBe(true);
+    expect(bypass).toBe(true);
     expect(gate).toBe(true);
     expect(again!.get(DOC)!.roles).toContain('Admin');
     expect(batchAgain!.get(DOC)).toBe(true);
@@ -139,39 +166,39 @@ describe('AccessControlService — at-ref model cache', () => {
   });
 
   it('sees a push that moves the base ref on the next call, and caches the new tip', async () => {
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(true);
+    expect(lsTreeBuilds()).toBe(1);
+
     // Revoke razvan on origin/main from the other clone: roles.yaml is part
     // of the MODEL (not the per-file own-entries read), so a stale cache
     // would keep answering true.
-    await fs.writeFile(path.join(other, 'roles.yaml'), 'roles:\n  Admin:\n    - someone-else@bevel.software\n');
-    await git(other, 'commit', '-am', 'revoke razvan');
-    await git(other, 'push', '-q', 'origin', 'main');
+    await pushFromOther('revoke razvan', () =>
+      fs.writeFile(path.join(other, 'roles.yaml'), 'roles:\n  Admin:\n    - someone-else@bevel.software\n'),
+    );
 
-    spawnLog.length = 0;
     expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);
-    expect(lsTreeBuilds()).toBe(1);
+    expect(lsTreeBuilds()).toBe(2);
 
     // The new tip is cached like the old one was.
     expect(await svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC])).toEqual(
       new Map([[DOC, false]]),
     );
     expect(await svc.canWriteAtRef(workspaceId, 'origin/main', 'someone-else@bevel.software', DOC)).toBe(true);
-    expect(lsTreeBuilds()).toBe(1);
+    expect(lsTreeBuilds()).toBe(2);
   });
 
   it('keeps the short-ref fallthrough: a local branch without roles.yaml defers to origin/<branch>', async () => {
-    // `feature` on origin carries roles.yaml; the LOCAL `feature` has it
-    // deleted (not pushed). Asking for `feature` must fall through to
-    // `origin/feature` exactly as before the cache existed.
-    await git(repo, 'fetch', '-q', 'origin');
-    await git(repo, 'checkout', '-q', '-b', 'feature', 'origin/main');
-    // A commit of its own, so origin/feature is not the main tip the previous
-    // test already cached.
+    // `feature` on origin carries roles.yaml (and a commit of its own, so it
+    // is not the main tip); the LOCAL `feature` has roles.yaml deleted, not
+    // pushed. Asking for `feature` must fall through to `origin/feature`
+    // exactly as before the cache existed.
+    await git(repo, 'checkout', '-q', '-b', 'feature');
     await fs.writeFile(path.join(repo, 'Team/Other.md'), '# other\n');
     await git(repo, 'add', '-A');
-    await git(repo, 'commit', '-q', '-m', 'feature work');
+    await git(repo, 'commit', '-qm', 'feature work');
     await git(repo, 'push', '-q', '-u', 'origin', 'feature');
     await git(repo, 'rm', '-q', 'roles.yaml');
-    await git(repo, 'commit', '-q', '-m', 'drop roles locally');
+    await git(repo, 'commit', '-qm', 'drop roles locally');
 
     spawnLog.length = 0;
     const map = await svc.eligibleWritersForPathsAtRef(workspaceId, 'feature', [DOC]);
@@ -179,7 +206,45 @@ describe('AccessControlService — at-ref model cache', () => {
     expect(map!.get(DOC)!.roles).toContain('Admin');
     expect(lsTreeBuilds()).toBe(1);
     // ...and the fallthrough result is cached under origin/feature's commit.
-    expect(await svc.canWriteAtRef(workspaceId, 'feature', 'someone-else@bevel.software', DOC)).toBe(true);
+    expect(await svc.canWriteAtRef(workspaceId, 'feature', admin, DOC)).toBe(true);
     expect(lsTreeBuilds()).toBe(1);
+  });
+
+  it('never caches a build that saw a git read fail, so one hiccup cannot pin a wrong verdict', async () => {
+    // A nearer access.md that DENIES the admin: reading it is what stands
+    // between razvan and a write he must not have.
+    await pushFromOther('deny Admin in Team', () =>
+      fs.writeFile(path.join(other, 'Team/access.md'), '---\nwrite:\n  - deny Admin\n---\n'),
+    );
+
+    // Lose exactly that read, once, to a simulated transient failure. The
+    // build degrades the way it always did (the file counts as absent for
+    // this call, so the verdict is the fail-open one)...
+    injected.failNext = (argv) => argv.includes('show') && argv.some((a) => a.endsWith(':Team/access.md'));
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(true);
+    expect(injected.failNext).toBeNull();
+    expect(lsTreeBuilds()).toBe(1);
+
+    // ...but it is NOT pinned: the next call rebuilds and answers correctly,
+    // and that healthy build is the one that gets cached.
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);
+    expect(lsTreeBuilds()).toBe(2);
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);
+    expect(lsTreeBuilds()).toBe(2);
+  });
+
+  it('does not cache a commit with no roles.yaml, and keeps answering null for it', async () => {
+    await git(other, 'checkout', '-qb', 'bare');
+    await git(other, 'rm', '-q', 'roles.yaml');
+    await git(other, 'commit', '-qm', 'no roles here');
+    await git(other, 'push', '-q', '-u', 'origin', 'bare');
+
+    spawnLog.length = 0;
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/bare', admin, DOC)).toBeNull();
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/bare', admin, DOC)).toBeNull();
+    // Each call went back to git for roles.yaml (nothing was remembered),
+    // and neither ever got as far as walking the tree.
+    expect(rolesReads()).toBe(2);
+    expect(lsTreeBuilds()).toBe(0);
   });
 });

--- a/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../access-control.service.js';
+
+/**
+ * Every git subprocess the service (and this file's own fixture helpers)
+ * spawn through `execFile`, by argv. The service builds its at-ref model
+ * with exactly one `git ls-tree -r` per build, so counting `ls-tree` argv
+ * entries counts model builds — measured at the process boundary, which is
+ * the cost this cache exists to remove.
+ */
+const { spawnLog } = vi.hoisted(() => ({ spawnLog: [] as string[][] }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { promisify: p } = await import('node:util');
+  const original = actual.execFile as unknown as ((...a: unknown[]) => unknown) & {
+    [p.custom]: (...a: unknown[]) => unknown;
+  };
+  const wrapped = ((...args: unknown[]) => {
+    spawnLog.push((args[1] as string[]) ?? []);
+    return original(...args);
+  }) as unknown as typeof actual.execFile;
+  // `promisify(execFile)` returns `execFile[promisify.custom]`, so the
+  // promisified path the service uses has to be wrapped too.
+  Object.defineProperty(wrapped, p.custom, {
+    value: (...args: unknown[]) => {
+      spawnLog.push((args[1] as string[]) ?? []);
+      return original[p.custom](...args);
+    },
+  });
+  return { ...actual, execFile: wrapped };
+});
+
+const execFileAsync = promisify(execFile);
+const PROCESS_MAP_DIR = 'knowledge-base';
+
+function lsTreeBuilds(): number {
+  return spawnLog.filter((argv) => argv.includes('ls-tree')).length;
+}
+
+/**
+ * The at-ref access model — `canWriteAtRef` / `canWriteBatchAtRef` /
+ * `eligibleWritersForPathsAtRef`, the gates every change-request read and
+ * every approval click run — is a pure function of the tree at the commit
+ * the ref resolves to. Building it costs one `ls-tree` plus one `git show`
+ * per `access.md`, so it must be built ONCE per commit and shared by every
+ * gate call that lands on that commit, while a push that moves the ref is
+ * still seen on the very next call.
+ */
+describe('AccessControlService — at-ref model cache', () => {
+  let root: string;
+  let workspaceDir: string;
+  let repo: string;
+  let other: string;
+  let svc: AccessControlService;
+  const workspaceId = 'ws-atref-cache';
+  const admin = 'razvan@bevel.software';
+  const DOC = 'Team/Doc.md';
+
+  async function git(cwd: string, ...args: string[]): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], { encoding: 'utf-8' });
+    return stdout.trim();
+  }
+
+  async function seed(dir: string): Promise<void> {
+    await fs.mkdir(path.join(dir, 'Team'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'roles.yaml'), 'roles:\n  Admin:\n    - razvan@bevel.software\n');
+    await fs.writeFile(path.join(dir, 'access.md'), '---\nwrite:\n  - Admin\n---\n');
+    await fs.writeFile(path.join(dir, 'Team/access.md'), '---\nwrite:\n  - Admin\n---\n');
+    await fs.writeFile(path.join(dir, DOC), '# doc\n');
+  }
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-atref-cache-'));
+    workspaceDir = path.join(root, workspaceId);
+    repo = path.join(workspaceDir, PROCESS_MAP_DIR);
+    const origin = path.join(root, 'origin.git');
+    other = path.join(root, 'other');
+
+    await execFileAsync('git', ['init', '--bare', '-b', 'main', origin]);
+    await fs.mkdir(repo, { recursive: true });
+    await seed(repo);
+    await execFileAsync('git', ['init', '-b', 'main', repo]);
+    await git(repo, 'config', 'user.email', 'test@example.com');
+    await git(repo, 'config', 'user.name', 'Test');
+    await git(repo, 'add', '-A');
+    await git(repo, 'commit', '-m', 'seed');
+    await git(repo, 'remote', 'add', 'origin', origin);
+    await git(repo, 'push', '-u', 'origin', 'main');
+
+    // A second clone stands in for "another user pushed to the base branch".
+    await execFileAsync('git', ['clone', '-q', origin, other]);
+    await git(other, 'config', 'user.email', 'other@example.com');
+    await git(other, 'config', 'user.name', 'Other');
+
+    const stub = {
+      getWorkspacePath: async () => workspaceDir,
+      // The real service TTLs this at 30s; the stub always fetches so a push
+      // from `other` is visible on the next gate call.
+      ensureRemotesFetched: async () => {
+        await git(repo, 'fetch', '-q', 'origin');
+      },
+    } as unknown as WorkspaceService;
+    svc = new AccessControlService(stub, PROCESS_MAP_DIR);
+  });
+
+  afterAll(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('builds the model once for the six gate calls an approval click makes', async () => {
+    spawnLog.length = 0;
+    // The approve route's exact sequence: detail (eligibility + viewer batch +
+    // roles.yaml bypass check), then the gate, then the response's detail.
+    const verdicts = await Promise.all([
+      svc.eligibleWritersForPathsAtRef(workspaceId, 'origin/main', [DOC]),
+      svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC]),
+      svc.canWriteAtRef(workspaceId, 'origin/main', admin, 'roles.yaml'),
+    ].map((p) => p));
+    const gate = await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC);
+    const again = await svc.eligibleWritersForPathsAtRef(workspaceId, 'origin/main', [DOC]);
+    const batchAgain = await svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC]);
+
+    expect(verdicts[0]!.get(DOC)!.roles).toContain('Admin');
+    expect(verdicts[1]!.get(DOC)).toBe(true);
+    expect(verdicts[2]).toBe(true);
+    expect(gate).toBe(true);
+    expect(again!.get(DOC)!.roles).toContain('Admin');
+    expect(batchAgain!.get(DOC)).toBe(true);
+
+    expect(lsTreeBuilds()).toBe(1);
+  });
+
+  it('sees a push that moves the base ref on the next call, and caches the new tip', async () => {
+    // Revoke razvan on origin/main from the other clone: roles.yaml is part
+    // of the MODEL (not the per-file own-entries read), so a stale cache
+    // would keep answering true.
+    await fs.writeFile(path.join(other, 'roles.yaml'), 'roles:\n  Admin:\n    - someone-else@bevel.software\n');
+    await git(other, 'commit', '-am', 'revoke razvan');
+    await git(other, 'push', '-q', 'origin', 'main');
+
+    spawnLog.length = 0;
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(false);
+    expect(lsTreeBuilds()).toBe(1);
+
+    // The new tip is cached like the old one was.
+    expect(await svc.canWriteBatchAtRef(workspaceId, 'origin/main', admin, [DOC])).toEqual(
+      new Map([[DOC, false]]),
+    );
+    expect(await svc.canWriteAtRef(workspaceId, 'origin/main', 'someone-else@bevel.software', DOC)).toBe(true);
+    expect(lsTreeBuilds()).toBe(1);
+  });
+
+  it('keeps the short-ref fallthrough: a local branch without roles.yaml defers to origin/<branch>', async () => {
+    // `feature` on origin carries roles.yaml; the LOCAL `feature` has it
+    // deleted (not pushed). Asking for `feature` must fall through to
+    // `origin/feature` exactly as before the cache existed.
+    await git(repo, 'fetch', '-q', 'origin');
+    await git(repo, 'checkout', '-q', '-b', 'feature', 'origin/main');
+    // A commit of its own, so origin/feature is not the main tip the previous
+    // test already cached.
+    await fs.writeFile(path.join(repo, 'Team/Other.md'), '# other\n');
+    await git(repo, 'add', '-A');
+    await git(repo, 'commit', '-q', '-m', 'feature work');
+    await git(repo, 'push', '-q', '-u', 'origin', 'feature');
+    await git(repo, 'rm', '-q', 'roles.yaml');
+    await git(repo, 'commit', '-q', '-m', 'drop roles locally');
+
+    spawnLog.length = 0;
+    const map = await svc.eligibleWritersForPathsAtRef(workspaceId, 'feature', [DOC]);
+    expect(map).not.toBeNull();
+    expect(map!.get(DOC)!.roles).toContain('Admin');
+    expect(lsTreeBuilds()).toBe(1);
+    // ...and the fallthrough result is cached under origin/feature's commit.
+    expect(await svc.canWriteAtRef(workspaceId, 'feature', 'someone-else@bevel.software', DOC)).toBe(true);
+    expect(lsTreeBuilds()).toBe(1);
+  });
+});

--- a/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
@@ -139,6 +139,10 @@ describe('AccessControlService — at-ref model cache', () => {
 
   afterEach(async () => {
     injected.failNext = null;
+    // Spies are restored here, not at the end of the test that made them:
+    // a failing assertion would otherwise leave a console.warn mock in place
+    // for every test after it (this config sets no `restoreMocks`).
+    vi.restoreAllMocks();
     await fs.rm(root, { recursive: true, force: true });
   });
 
@@ -227,7 +231,6 @@ describe('AccessControlService — at-ref model cache', () => {
     expect(lsTreeBuilds()).toBe(1);
     // ...and says so in the logs, naming the read it lost.
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Team\/access\.md failed; .*will not be cached/));
-    warn.mockRestore();
 
     // ...but it is NOT pinned: the next call rebuilds and answers correctly,
     // and that healthy build is the one that gets cached.

--- a/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.atref-cache.test.ts
@@ -221,9 +221,13 @@ describe('AccessControlService — at-ref model cache', () => {
     // build degrades the way it always did (the file counts as absent for
     // this call, so the verdict is the fail-open one)...
     injected.failNext = (argv) => argv.includes('show') && argv.some((a) => a.endsWith(':Team/access.md'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     expect(await svc.canWriteAtRef(workspaceId, 'origin/main', admin, DOC)).toBe(true);
     expect(injected.failNext).toBeNull();
     expect(lsTreeBuilds()).toBe(1);
+    // ...and says so in the logs, naming the read it lost.
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/Team\/access\.md failed; .*will not be cached/));
+    warn.mockRestore();
 
     // ...but it is NOT pinned: the next call rebuilds and answers correctly,
     // and that healthy build is the one that gets cached.

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -1731,7 +1731,15 @@ export class AccessControlService implements IAccessControl {
     let degraded = false;
     const read = async (relativePath: string): Promise<string | null> => {
       const outcome = await this.showAtRefOutcome(repoDir, commit, relativePath);
-      if (outcome.kind === 'error') degraded = true;
+      if (outcome.kind === 'error') {
+        degraded = true;
+        // The operational signal: one line per failed read, naming the commit
+        // and the path, so a run of these in the logs is visible before it
+        // becomes a pattern of wrong verdicts.
+        console.warn(
+          `[access@${label}@${commit.slice(0, 7)}] git read of ${relativePath} failed; this verdict treats it as absent and will not be cached`,
+        );
+      }
       return outcome.kind === 'text' ? outcome.text : null;
     };
 
@@ -1763,7 +1771,12 @@ export class AccessControlService implements IAccessControl {
 
     const accessFiles = new Map<string, AccessFile>();
     const listed = await this.listAccessFilesAtRef(repoDir, commit);
-    if (listed === 'error') degraded = true;
+    if (listed === 'error') {
+      degraded = true;
+      console.warn(
+        `[access@${tag}] listing access.md files failed; this verdict sees none of them and will not be cached`,
+      );
+    }
     for (const p of listed === 'error' ? [] : listed) {
       const text = await read(p);
       if (text === null) continue;

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -13,7 +13,7 @@ import type {
   GrantSources,
   ResolvedPrincipal,
 } from './access-control.interface.js';
-import { AccessConfigError } from '../access-model/access-errors.js';
+import { AccessConfigError, AccessUnreadableError } from '../access-model/access-errors.js';
 import {
   GROUPS_YAML,
   SYNCED_GROUPS_YAML,
@@ -771,11 +771,11 @@ function ineligibleNamedEmailsResolved(
  */
 type AtRefModel = { model: AccessModel; resolvedRef: string };
 /**
- * One build's outcome: a model (flagged `degraded` when any git read failed
- * on the way, so it must not be cached), no roles.yaml at the commit, or one
- * that doesn't parse.
+ * One build's outcome: a model, no roles.yaml at the commit, or one that
+ * doesn't parse. A git read failure is none of these: it throws
+ * AccessUnreadableError out of the build instead.
  */
-type AtRefBuild = (AtRefModel & { degraded: boolean }) | 'no-roles' | 'malformed';
+type AtRefBuild = AtRefModel | 'no-roles' | 'malformed';
 
 export class AccessControlService implements IAccessControl {
   /**
@@ -818,13 +818,13 @@ export class AccessControlService implements IAccessControl {
    * builds per click was the lag behind the approve checkmark.
    *
    * Bounded FIFO, so a long-lived server holds the last few tips rather than
-   * one model per commit it ever gated against. Two kinds of build are
-   * deliberately NOT cached: one that found no usable roles.yaml at the
-   * commit, and one that saw any git read fail on the way (`degraded`). Both
-   * are what a transient failure looks like, and pinning either to a commit
-   * would turn one hiccup into a wrong verdict, denying or granting, until
-   * the base branch moved. Concurrent misses on the same commit share one
-   * build via `atRefInFlight`.
+   * one model per commit it ever gated against. A build that found no usable
+   * roles.yaml is deliberately NOT cached, and a build that saw any git read
+   * fail never becomes a model at all: it throws AccessUnreadableError and the
+   * gate fails closed for that call. Both are what a transient failure looks
+   * like, and pinning either to a commit would turn one hiccup into a wrong
+   * verdict, denying or granting, until the base branch moved. Concurrent
+   * misses on the same commit share one build via `atRefInFlight`.
    */
   private readonly atRefCache = new Map<string, AtRefModel>();
   private readonly atRefInFlight = new Map<string, Promise<AtRefBuild>>();
@@ -1670,7 +1670,7 @@ export class AccessControlService implements IAccessControl {
       if (!pending) {
         pending = this.buildModelAtCommit(repoDir, commit, candidate)
           .then((built) => {
-            if (typeof built !== 'string' && !built.degraded) this.rememberAtRef(key, built);
+            if (typeof built !== 'string') this.rememberAtRef(key, built);
             return built;
           })
           .finally(() => {
@@ -1724,21 +1724,18 @@ export class AccessControlService implements IAccessControl {
     label: string,
   ): Promise<AtRefBuild> {
     // Every read below tells "absent" apart from "git failed". A failure
-    // degrades the build exactly as it always did (the file counts as absent
-    // for THIS call) but marks the result `degraded`, and a degraded model is
-    // never cached: pinning it would turn one transient failure into a wrong
-    // verdict, denying or granting, for the commit's whole lifetime.
-    let degraded = false;
+    // refuses the whole build: a model missing one access.md could grant what
+    // that file denies, so no verdict is answered from it, nothing is cached,
+    // and the caller fails closed (AccessUnreadableError, a 503) until a
+    // retry reads the tree in full.
+    const tag = `${label}@${commit.slice(0, 7)}`;
     const read = async (relativePath: string): Promise<string | null> => {
       const outcome = await this.showAtRefOutcome(repoDir, commit, relativePath);
       if (outcome.kind === 'error') {
-        degraded = true;
         // The operational signal: one line per failed read, naming the commit
-        // and the path, so a run of these in the logs is visible before it
-        // becomes a pattern of wrong verdicts.
-        console.warn(
-          `[access@${label}@${commit.slice(0, 7)}] git read of ${relativePath} failed; this verdict treats it as absent and will not be cached`,
-        );
+        // and the path, so a run of these is visible in the logs.
+        console.warn(`[access@${tag}] git read of ${relativePath} failed; refusing to decide from a partial tree`);
+        throw new AccessUnreadableError(label, relativePath);
       }
       return outcome.kind === 'text' ? outcome.text : null;
     };
@@ -1747,7 +1744,6 @@ export class AccessControlService implements IAccessControl {
     if (rolesYaml === null) return 'no-roles';
     const rolesParsed = parseRolesYaml(rolesYaml);
     if (!rolesParsed.ok) return 'malformed';
-    const tag = `${label}@${commit.slice(0, 7)}`;
 
     // Same group loading as the working-tree model, read AT THE COMMIT — the
     // whole point of file-materialized groups is that the merge/push gates
@@ -1772,12 +1768,10 @@ export class AccessControlService implements IAccessControl {
     const accessFiles = new Map<string, AccessFile>();
     const listed = await this.listAccessFilesAtRef(repoDir, commit);
     if (listed === 'error') {
-      degraded = true;
-      console.warn(
-        `[access@${tag}] listing access.md files failed; this verdict sees none of them and will not be cached`,
-      );
+      console.warn(`[access@${tag}] listing access.md files failed; refusing to decide from a partial tree`);
+      throw new AccessUnreadableError(label, 'access.md (ls-tree)');
     }
-    for (const p of listed === 'error' ? [] : listed) {
+    for (const p of listed) {
       const text = await read(p);
       if (text === null) continue;
       const parsed = parseAccessFile(text, p);
@@ -1810,7 +1804,6 @@ export class AccessControlService implements IAccessControl {
         deploymentOwners: this.deploymentOwners,
       },
       resolvedRef: commit,
-      degraded,
     };
   }
 }

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -764,6 +764,15 @@ function ineligibleNamedEmailsResolved(
 // Service
 // ---------------------------------------------------------------------------
 
+/**
+ * An access model read at a git ref. `resolvedRef` is the COMMIT the model
+ * was built from (not the ref name that led there), so the per-file
+ * own-entries reads that follow a gate resolve against exactly that tree.
+ */
+type AtRefModel = { model: AccessModel; resolvedRef: string };
+/** One build's outcome: a model, no roles.yaml at the commit, or one that doesn't parse. */
+type AtRefBuild = AtRefModel | 'no-roles' | 'malformed';
+
 export class AccessControlService implements IAccessControl {
   /**
    * Per-workspace cache: `model` is the resolved access tree and `loadedAt`
@@ -793,6 +802,29 @@ export class AccessControlService implements IAccessControl {
   private static readonly OWN_ENTRIES_TTL_MS = 5 * 60_000;
 
   /**
+   * At-ref models keyed by workspace + the COMMIT the ref resolved to. The
+   * tree at a commit is immutable, so an entry can never go stale: a push
+   * that moves `origin/<base>` resolves to a new commit and simply misses.
+   * No TTL, and `invalidate()` leaves it alone, for the same reason.
+   *
+   * This is what makes the change-request gates affordable. One detail read
+   * plus one approval click runs six at-ref gates, and before this cache
+   * every one of them rebuilt the model from git: an `ls-tree -r` plus a
+   * `git show` per `access.md`, ~270ms each on a real knowledge base. Six
+   * builds per click was the lag behind the approve checkmark.
+   *
+   * Bounded FIFO, so a long-lived server holds the last few tips rather than
+   * one model per commit it ever gated against. `null` results (no usable
+   * roles.yaml at the commit) are deliberately NOT cached: `showAtRef` folds
+   * transient git failures into null, and pinning one of those to a commit
+   * would deny every approval until the base branch moved. Concurrent misses
+   * on the same commit share one build via `atRefInFlight`.
+   */
+  private readonly atRefCache = new Map<string, AtRefModel>();
+  private readonly atRefInFlight = new Map<string, Promise<AtRefBuild>>();
+  private static readonly AT_REF_CACHE_MAX = 64;
+
+  /**
    * Canonicalised deployment-owner emails (see `AccessModel.deploymentOwners`).
    * Held on the service rather than read per-model because it comes from the
    * environment, not from the knowledge base.
@@ -817,7 +849,9 @@ export class AccessControlService implements IAccessControl {
 
   /**
    * Drop a workspace's cached model + frontmatter memo. Call after operations
-   * that mutate the working tree — commit, push, pull, branch switch.
+   * that mutate the working tree — commit, push, pull, branch switch. The
+   * at-ref cache is untouched on purpose: its entries are keyed by commit,
+   * and nothing that happens in a working tree changes what a commit holds.
    */
   invalidate(workspaceId: string): void {
     this.cache.delete(workspaceId);
@@ -1569,11 +1603,14 @@ export class AccessControlService implements IAccessControl {
    * the gate becomes useful. NEVER fall back to the working tree here: a
    * working-tree fallback lets anyone with edit access to access.md grant
    * themselves approval rights.
+   *
+   * Cached per commit (see `atRefCache`): the ref is resolved to the commit
+   * it points at first, and that commit is both the cache key and the ref
+   * every read is pinned to. `resolvedRef` in the result is therefore a
+   * commit SHA, so the own-entries read callers do afterwards can never
+   * straddle a push that lands between the two.
    */
-  private async loadModelAtRef(
-    workspaceId: string,
-    ref: string,
-  ): Promise<{ model: AccessModel; resolvedRef: string } | null> {
+  private async loadModelAtRef(workspaceId: string, ref: string): Promise<AtRefModel | null> {
     const repoDir = await this.repoDir(workspaceId);
 
     // Refresh remote-tracking refs so a PR branch we've never personally
@@ -1581,47 +1618,107 @@ export class AccessControlService implements IAccessControl {
     // block the lookup if the ref already exists locally.
     await this.workspaceService.ensureRemotesFetched(workspaceId).catch(() => undefined);
 
-    let rolesYaml: string | null = null;
-    let resolvedRef: string | null = null;
+    // Same candidate order as before the cache existed: the first candidate
+    // that carries a roles.yaml wins, so a local branch without one still
+    // defers to `origin/<branch>`.
     for (const candidate of this.refCandidates(ref)) {
-      const text = await this.showAtRef(repoDir, candidate, 'roles.yaml');
-      if (text !== null) {
-        rolesYaml = text;
-        resolvedRef = candidate;
-        break;
+      const commit = await this.revParseCommit(repoDir, candidate);
+      if (!commit) continue;
+      const key = `${workspaceId}\0${commit}`;
+      const hit = this.atRefCache.get(key);
+      if (hit) return hit;
+      // Registered BEFORE the first await on the build path, so concurrent
+      // misses on one commit share a single build instead of all racing past
+      // an empty in-flight check together.
+      let pending = this.atRefInFlight.get(key);
+      if (!pending) {
+        pending = this.buildModelAtCommit(repoDir, commit, candidate)
+          .then((built) => {
+            if (typeof built !== 'string') this.rememberAtRef(key, built);
+            return built;
+          })
+          .finally(() => {
+            if (this.atRefInFlight.get(key) === pending) this.atRefInFlight.delete(key);
+          });
+        this.atRefInFlight.set(key, pending);
       }
+      const built = await pending;
+      if (built === 'no-roles') continue;
+      if (built === 'malformed') return null;
+      return built;
     }
-    if (!rolesYaml || !resolvedRef) return null;
+    return null;
+  }
 
+  /** The commit `ref` points at in this clone, or null when it doesn't resolve. */
+  private async revParseCommit(repoDir: string, ref: string): Promise<string | null> {
+    if (!ref || ref.startsWith('-')) return null;
+    try {
+      const { stdout } = await execFileAsync(
+        'git',
+        ['-C', repoDir, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
+        { encoding: 'utf-8' },
+      );
+      const sha = stdout.trim();
+      return /^[0-9a-f]{40,64}$/.test(sha) ? sha : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private rememberAtRef(key: string, value: AtRefModel): void {
+    this.atRefCache.set(key, value);
+    if (this.atRefCache.size > AccessControlService.AT_REF_CACHE_MAX) {
+      const oldest = this.atRefCache.keys().next().value;
+      if (oldest !== undefined) this.atRefCache.delete(oldest);
+    }
+  }
+
+  /**
+   * The uncached build behind `loadModelAtRef`: the whole access tree read
+   * at `commit`. `label` is the candidate ref the commit came from, kept for
+   * log lines only; every git read here is pinned to the commit. `'no-roles'`
+   * means the commit carries no roles.yaml (the caller tries its next
+   * candidate); `'malformed'` means it does but it doesn't parse (the caller
+   * answers null, as it always has).
+   */
+  private async buildModelAtCommit(
+    repoDir: string,
+    commit: string,
+    label: string,
+  ): Promise<AtRefBuild> {
+    const rolesYaml = await this.showAtRef(repoDir, commit, 'roles.yaml');
+    if (rolesYaml === null) return 'no-roles';
     const rolesParsed = parseRolesYaml(rolesYaml);
-    if (!rolesParsed.ok) return null;
+    if (!rolesParsed.ok) return 'malformed';
+    const tag = `${label}@${commit.slice(0, 7)}`;
 
-    // Same group loading as the working-tree model, read AT THE REF — the
+    // Same group loading as the working-tree model, read AT THE COMMIT — the
     // whole point of file-materialized groups is that the merge/push gates
     // can evaluate them at the commit they gate. (`showAtRef` folds every git
     // failure into null/absent — at-ref reads cannot distinguish a missing
     // path from a repo error, so the broken-groups marker here fires only on
     // parse failures.)
     const activeGroups = await loadActiveGroups((filename) =>
-      this.showAtRef(repoDir, resolvedRef, filename),
+      this.showAtRef(repoDir, commit, filename),
     );
     if (!activeGroups.health.ok) {
       console.error(
-        `[access@${resolvedRef}] groups source ${activeGroups.health.file} is broken (${activeGroups.health.reason}) — groups contribute nothing until it is fixed`,
+        `[access@${tag}] groups source ${activeGroups.health.file} is broken (${activeGroups.health.reason}) — groups contribute nothing until it is fixed`,
       );
     }
-    for (const w of activeGroups.warnings) console.warn(`[access@${resolvedRef}] ${w}`);
+    for (const w of activeGroups.warnings) console.warn(`[access@${tag}] ${w}`);
     const mergeWarnings = mergeGroupsIntoRoles(
       rolesParsed.index,
       activeGroups.groups,
       activeGroups.sourceFile,
     );
-    for (const w of mergeWarnings) console.warn(`[access@${resolvedRef}] ${w}`);
+    for (const w of mergeWarnings) console.warn(`[access@${tag}] ${w}`);
 
     const accessFiles = new Map<string, AccessFile>();
-    const accessPaths = await this.listAccessFilesAtRef(repoDir, resolvedRef);
+    const accessPaths = await this.listAccessFilesAtRef(repoDir, commit);
     for (const p of accessPaths) {
-      const text = await this.showAtRef(repoDir, resolvedRef, p);
+      const text = await this.showAtRef(repoDir, commit, p);
       if (text === null) continue;
       const parsed = parseAccessFile(text, p);
       if (!parsed.ok) continue;
@@ -1652,7 +1749,7 @@ export class AccessControlService implements IAccessControl {
         // land — the lockout moved one step later, not removed.
         deploymentOwners: this.deploymentOwners,
       },
-      resolvedRef,
+      resolvedRef: commit,
     };
   }
 }

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -770,8 +770,12 @@ function ineligibleNamedEmailsResolved(
  * own-entries reads that follow a gate resolve against exactly that tree.
  */
 type AtRefModel = { model: AccessModel; resolvedRef: string };
-/** One build's outcome: a model, no roles.yaml at the commit, or one that doesn't parse. */
-type AtRefBuild = AtRefModel | 'no-roles' | 'malformed';
+/**
+ * One build's outcome: a model (flagged `degraded` when any git read failed
+ * on the way, so it must not be cached), no roles.yaml at the commit, or one
+ * that doesn't parse.
+ */
+type AtRefBuild = (AtRefModel & { degraded: boolean }) | 'no-roles' | 'malformed';
 
 export class AccessControlService implements IAccessControl {
   /**
@@ -814,11 +818,13 @@ export class AccessControlService implements IAccessControl {
    * builds per click was the lag behind the approve checkmark.
    *
    * Bounded FIFO, so a long-lived server holds the last few tips rather than
-   * one model per commit it ever gated against. `null` results (no usable
-   * roles.yaml at the commit) are deliberately NOT cached: `showAtRef` folds
-   * transient git failures into null, and pinning one of those to a commit
-   * would deny every approval until the base branch moved. Concurrent misses
-   * on the same commit share one build via `atRefInFlight`.
+   * one model per commit it ever gated against. Two kinds of build are
+   * deliberately NOT cached: one that found no usable roles.yaml at the
+   * commit, and one that saw any git read fail on the way (`degraded`). Both
+   * are what a transient failure looks like, and pinning either to a commit
+   * would turn one hiccup into a wrong verdict, denying or granting, until
+   * the base branch moved. Concurrent misses on the same commit share one
+   * build via `atRefInFlight`.
    */
   private readonly atRefCache = new Map<string, AtRefModel>();
   private readonly atRefInFlight = new Map<string, Promise<AtRefBuild>>();
@@ -1549,18 +1555,46 @@ export class AccessControlService implements IAccessControl {
   /**
    * Read a file's content at a specific ref via `git show <ref>:<path>`.
    * Returns null when the file is absent on that ref (or the ref doesn't
-   * resolve).
+   * resolve) and also on any other git failure: the single-path gates that
+   * call this have always treated the two alike. The at-ref model build
+   * needs them told apart, so it reads through `showAtRefOutcome` instead.
    */
   private async showAtRef(repoDir: string, ref: string, relativePath: string): Promise<string | null> {
+    const outcome = await this.showAtRefOutcome(repoDir, ref, relativePath);
+    return outcome.kind === 'text' ? outcome.text : null;
+  }
+
+  /**
+   * `git show <ref>:<path>`, telling "not there" apart from "git failed".
+   * Absence is what git reports as `path '<p>' does not exist in '<ref>'`
+   * (or `exists on disk, but not in`), plus an unresolvable ref; anything
+   * else (an IO error, a corrupt object, a dying subprocess) is `error`.
+   * `LC_ALL=C` pins the messages this classifies to English.
+   */
+  private async showAtRefOutcome(
+    repoDir: string,
+    ref: string,
+    relativePath: string,
+  ): Promise<{ kind: 'text'; text: string } | { kind: 'absent' } | { kind: 'error' }> {
     try {
       const { stdout } = await execFileAsync(
         'git',
         ['-C', repoDir, 'show', `${ref}:${relativePath}`],
-        { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024 },
+        {
+          encoding: 'utf-8',
+          maxBuffer: 16 * 1024 * 1024,
+          env: { ...process.env, LC_ALL: 'C', LANG: 'C' },
+        },
       );
-      return stdout;
-    } catch {
-      return null;
+      return { kind: 'text', text: stdout };
+    } catch (err) {
+      const stderr =
+        (err as { stderr?: string }).stderr ?? (err instanceof Error ? err.message : String(err));
+      return /does not exist in|exists on disk, but not in|invalid object name|unknown revision|bad revision/.test(
+        stderr,
+      )
+        ? { kind: 'absent' }
+        : { kind: 'error' };
     }
   }
 
@@ -1568,8 +1602,10 @@ export class AccessControlService implements IAccessControl {
    * List every `access.md` path that exists at any depth as of `ref`.
    * The access tree is structure-agnostic: any `access.md` participates
    * regardless of where it sits. Uses `git ls-tree -r --name-only`.
+   * `'error'` when git failed: a model built without its access files is
+   * not the model, and the caller must not cache it as one.
    */
-  private async listAccessFilesAtRef(repoDir: string, ref: string): Promise<string[]> {
+  private async listAccessFilesAtRef(repoDir: string, ref: string): Promise<string[] | 'error'> {
     try {
       const { stdout } = await execFileAsync(
         'git',
@@ -1584,7 +1620,7 @@ export class AccessControlService implements IAccessControl {
       }
       return out;
     } catch {
-      return [];
+      return 'error';
     }
   }
 
@@ -1634,7 +1670,7 @@ export class AccessControlService implements IAccessControl {
       if (!pending) {
         pending = this.buildModelAtCommit(repoDir, commit, candidate)
           .then((built) => {
-            if (typeof built !== 'string') this.rememberAtRef(key, built);
+            if (typeof built !== 'string' && !built.degraded) this.rememberAtRef(key, built);
             return built;
           })
           .finally(() => {
@@ -1687,7 +1723,19 @@ export class AccessControlService implements IAccessControl {
     commit: string,
     label: string,
   ): Promise<AtRefBuild> {
-    const rolesYaml = await this.showAtRef(repoDir, commit, 'roles.yaml');
+    // Every read below tells "absent" apart from "git failed". A failure
+    // degrades the build exactly as it always did (the file counts as absent
+    // for THIS call) but marks the result `degraded`, and a degraded model is
+    // never cached: pinning it would turn one transient failure into a wrong
+    // verdict, denying or granting, for the commit's whole lifetime.
+    let degraded = false;
+    const read = async (relativePath: string): Promise<string | null> => {
+      const outcome = await this.showAtRefOutcome(repoDir, commit, relativePath);
+      if (outcome.kind === 'error') degraded = true;
+      return outcome.kind === 'text' ? outcome.text : null;
+    };
+
+    const rolesYaml = await read('roles.yaml');
     if (rolesYaml === null) return 'no-roles';
     const rolesParsed = parseRolesYaml(rolesYaml);
     if (!rolesParsed.ok) return 'malformed';
@@ -1699,9 +1747,7 @@ export class AccessControlService implements IAccessControl {
     // failure into null/absent — at-ref reads cannot distinguish a missing
     // path from a repo error, so the broken-groups marker here fires only on
     // parse failures.)
-    const activeGroups = await loadActiveGroups((filename) =>
-      this.showAtRef(repoDir, commit, filename),
-    );
+    const activeGroups = await loadActiveGroups(read);
     if (!activeGroups.health.ok) {
       console.error(
         `[access@${tag}] groups source ${activeGroups.health.file} is broken (${activeGroups.health.reason}) — groups contribute nothing until it is fixed`,
@@ -1716,9 +1762,10 @@ export class AccessControlService implements IAccessControl {
     for (const w of mergeWarnings) console.warn(`[access@${tag}] ${w}`);
 
     const accessFiles = new Map<string, AccessFile>();
-    const accessPaths = await this.listAccessFilesAtRef(repoDir, commit);
-    for (const p of accessPaths) {
-      const text = await this.showAtRef(repoDir, commit, p);
+    const listed = await this.listAccessFilesAtRef(repoDir, commit);
+    if (listed === 'error') degraded = true;
+    for (const p of listed === 'error' ? [] : listed) {
+      const text = await read(p);
       if (text === null) continue;
       const parsed = parseAccessFile(text, p);
       if (!parsed.ok) continue;
@@ -1750,6 +1797,7 @@ export class AccessControlService implements IAccessControl {
         deploymentOwners: this.deploymentOwners,
       },
       resolvedRef: commit,
+      degraded,
     };
   }
 }

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.changedFilesForPr.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.changedFilesForPr.test.ts
@@ -131,6 +131,55 @@ describe('GitService.changedFilesForPr / resolvePrShas', () => {
   });
 
   /**
+   * A change-request detail resolves the SHAs (which fetches both refs) and
+   * then lists the files: the second call must be able to reuse that fetch
+   * instead of paying a second network round-trip for the same two refs.
+   * `skipFetch` is that reuse, so it must read whatever `origin/*` the clone
+   * already holds, while the default keeps refreshing first.
+   */
+  it('skipFetch reads the clone as-is; the default refreshes origin/* first', async () => {
+    const { upstream, repo } = await seedWorkspace(root, workspaceId);
+    // The branch is authored in ANOTHER clone, so this workspace only ever
+    // knows it as origin/alice/feature — the production shape, where the
+    // base-branch workspace answers for every request without a local copy.
+    const other = path.join(root, 'other');
+    await runGit(root, ['clone', upstream, other]);
+    await runGit(other, ['checkout', '-b', 'alice/feature']);
+    await fs.writeFile(path.join(other, 'added.md'), 'hello\n');
+    await runGit(other, ['add', '-A']);
+    await runGit(other, ['commit', '-m', 'feature work']);
+    await runGit(other, ['push', '-u', 'origin', 'alice/feature']);
+    await runGit(repo, ['fetch', 'origin']);
+
+    // A second push this clone has NOT fetched.
+    await fs.writeFile(path.join(other, 'second.md'), 'more\n');
+    await runGit(other, ['add', '-A']);
+    await runGit(other, ['commit', '-m', 'more work']);
+    await runGit(other, ['push', 'origin', 'alice/feature']);
+
+    const git = new GitService(
+      stubWorkspaceService(workspaceId, repo),
+      new WorkflowHooks(),
+      'knowledge-base',
+    );
+
+    const asIs = await git.changedFilesForPr(
+      workspaceId,
+      'current-company-state',
+      'alice/feature',
+      { skipFetch: true },
+    );
+    expect(asIs.map((f) => f.path)).toEqual(['added.md']);
+
+    const refreshed = await git.changedFilesForPr(
+      workspaceId,
+      'current-company-state',
+      'alice/feature',
+    );
+    expect(refreshed.map((f) => f.path).sort()).toEqual(['added.md', 'second.md']);
+  });
+
+  /**
    * roles.yaml can never change through a merge — `preserveBaseRolesYaml`
    * restores the base copy onto the source before every merge — so the review
    * surface must not list it as changed: the claim would be false, the empty

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.changedFilesForPr.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.changedFilesForPr.test.ts
@@ -132,12 +132,12 @@ describe('GitService.changedFilesForPr / resolvePrShas', () => {
 
   /**
    * A change-request detail resolves the SHAs (which fetches both refs) and
-   * then lists the files: the second call must be able to reuse that fetch
-   * instead of paying a second network round-trip for the same two refs.
-   * `skipFetch` is that reuse, so it must read whatever `origin/*` the clone
-   * already holds, while the default keeps refreshing first.
+   * then lists the files. `at` pins that listing to the commits just
+   * resolved: no second fetch, and the file list describes exactly the head
+   * the approvals pin against even when a newer push has landed on origin in
+   * between. The default keeps refreshing first.
    */
-  it('skipFetch reads the clone as-is; the default refreshes origin/* first', async () => {
+  it('`at` pins the diff to the resolved commits; the default refreshes origin/* first', async () => {
     const { upstream, repo } = await seedWorkspace(root, workspaceId);
     // The branch is authored in ANOTHER clone, so this workspace only ever
     // knows it as origin/alice/feature — the production shape, where the
@@ -149,27 +149,28 @@ describe('GitService.changedFilesForPr / resolvePrShas', () => {
     await runGit(other, ['add', '-A']);
     await runGit(other, ['commit', '-m', 'feature work']);
     await runGit(other, ['push', '-u', 'origin', 'alice/feature']);
-    await runGit(repo, ['fetch', 'origin']);
-
-    // A second push this clone has NOT fetched.
-    await fs.writeFile(path.join(other, 'second.md'), 'more\n');
-    await runGit(other, ['add', '-A']);
-    await runGit(other, ['commit', '-m', 'more work']);
-    await runGit(other, ['push', 'origin', 'alice/feature']);
 
     const git = new GitService(
       stubWorkspaceService(workspaceId, repo),
       new WorkflowHooks(),
       'knowledge-base',
     );
+    // What the detail does first: resolve (and fetch) the two SHAs.
+    const pinned = await git.resolvePrShas(workspaceId, 'current-company-state', 'alice/feature');
 
-    const asIs = await git.changedFilesForPr(
+    // A second push lands on origin after the resolution.
+    await fs.writeFile(path.join(other, 'second.md'), 'more\n');
+    await runGit(other, ['add', '-A']);
+    await runGit(other, ['commit', '-m', 'more work']);
+    await runGit(other, ['push', 'origin', 'alice/feature']);
+
+    const atPinned = await git.changedFilesForPr(
       workspaceId,
       'current-company-state',
       'alice/feature',
-      { skipFetch: true },
+      { at: pinned },
     );
-    expect(asIs.map((f) => f.path)).toEqual(['added.md']);
+    expect(atPinned.map((f) => f.path)).toEqual(['added.md']);
 
     const refreshed = await git.changedFilesForPr(
       workspaceId,
@@ -177,6 +178,12 @@ describe('GitService.changedFilesForPr / resolvePrShas', () => {
       'alice/feature',
     );
     expect(refreshed.map((f) => f.path).sort()).toEqual(['added.md', 'second.md']);
+
+    await expect(
+      git.changedFilesForPr(workspaceId, 'current-company-state', 'alice/feature', {
+        at: { baseSha: pinned.baseSha, headSha: 'origin/alice/feature' },
+      }),
+    ).rejects.toThrow(/invalid commit sha/);
   });
 
   /**

--- a/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
@@ -32,17 +32,19 @@ function makeDb(): Database {
   } as unknown as Database;
 }
 
+const BASE = 'b'.repeat(40);
+const HEAD = 'a'.repeat(40);
+
 /**
  * A detail read is the hot path behind every change-request poll, every
  * approval click, and every merge. It resolves the SHAs first (that fetches
  * both refs), so the file list must be pinned to those same commits rather
- * than fetch and resolve again, and it must not spend one git subprocess per
- * changed file on patches nothing reads.
+ * than fetch and resolve again. The SHAs and the file list are read on every
+ * call (a new head must show); what the detail cache saves is the DB
+ * enrichment (comments, approvals), so that is where "cached" is observed.
  */
 describe('PullRequestService.getPrDetail — git work per read', () => {
-  it('lists files pinned to the resolved SHAs, without patches', async () => {
-    const BASE = 'b'.repeat(40);
-    const HEAD = 'a'.repeat(40);
+  function harness() {
     const resolvePrShas = vi.fn(async () => ({ baseSha: BASE, headSha: HEAD }));
     const changedFilesForPr = vi.fn(async () => []);
     const git = { resolvePrShas, changedFilesForPr } as unknown as GitService;
@@ -51,8 +53,19 @@ describe('PullRequestService.getPrDetail — git work per read', () => {
       ensureRemotesFetched: async () => undefined,
     } as unknown as WorkspaceService;
     const access = { canWriteAtRef: async () => false } as unknown as IAccessControl;
-
     const svc = new PullRequestService(makeDb(), workspace, access, git);
+    const listComments = vi.fn(async () => []);
+    const getApprovalStates = vi.fn(async () => []);
+    svc.setDetailEnricher({
+      listComments,
+      getApprovalStates,
+      evaluateMergeGate: () => ({ mergeable: false, reasons: [], warnings: [] }),
+    });
+    return { svc, resolvePrShas, changedFilesForPr, getApprovalStates };
+  }
+
+  it('pins the file list to the SHAs it just resolved, and keeps patches for a client read', async () => {
+    const { svc, resolvePrShas, changedFilesForPr } = harness();
     const detail = await svc.getPrDetail(7, { fresh: true });
 
     expect(detail?.headSha).toBe(HEAD);
@@ -63,11 +76,39 @@ describe('PullRequestService.getPrDetail — git work per read', () => {
       'ws-main',
       'current-company-state',
       'alice/feature',
-      { at: { baseSha: BASE, headSha: HEAD }, patchCap: 0 },
+      { at: { baseSha: BASE, headSha: HEAD } },
     );
     // The SHAs (and their fetch) come first; the file list rides on it.
     expect(resolvePrShas.mock.invocationCallOrder[0]).toBeLessThan(
       changedFilesForPr.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('a client read is cached: the next plain read skips the enrichment', async () => {
+    const { svc, getApprovalStates } = harness();
+    await svc.getPrDetail(7, { fresh: true });
+    await svc.getPrDetail(7);
+    expect(getApprovalStates).toHaveBeenCalledTimes(1);
+  });
+
+  it('an internal read (patches: false) skips patches and is not cached', async () => {
+    const { svc, changedFilesForPr, getApprovalStates } = harness();
+    await svc.getPrDetail(7, { fresh: true, patches: false });
+    expect(changedFilesForPr).toHaveBeenLastCalledWith(
+      'ws-main',
+      'current-company-state',
+      'alice/feature',
+      { at: { baseSha: BASE, headSha: HEAD }, patchCap: 0 },
+    );
+    // Not cached: the next plain read enriches again and asks for its own
+    // (full) file list.
+    await svc.getPrDetail(7);
+    expect(getApprovalStates).toHaveBeenCalledTimes(2);
+    expect(changedFilesForPr).toHaveBeenLastCalledWith(
+      'ws-main',
+      'current-company-state',
+      'alice/feature',
+      { at: { baseSha: BASE, headSha: HEAD } },
     );
   });
 });

--- a/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
@@ -35,13 +35,15 @@ function makeDb(): Database {
 /**
  * A detail read is the hot path behind every change-request poll, every
  * approval click, and every merge. It resolves the SHAs first (that fetches
- * both refs), so the file list must reuse that fetch rather than fetch the
- * same two refs again, and it must not spend one git subprocess per changed
- * file on patches nothing reads.
+ * both refs), so the file list must be pinned to those same commits rather
+ * than fetch and resolve again, and it must not spend one git subprocess per
+ * changed file on patches nothing reads.
  */
 describe('PullRequestService.getPrDetail — git work per read', () => {
-  it('lists files without a second fetch and without patches', async () => {
-    const resolvePrShas = vi.fn(async () => ({ baseSha: 'b'.repeat(40), headSha: 'h'.repeat(40) }));
+  it('lists files pinned to the resolved SHAs, without patches', async () => {
+    const BASE = 'b'.repeat(40);
+    const HEAD = 'a'.repeat(40);
+    const resolvePrShas = vi.fn(async () => ({ baseSha: BASE, headSha: HEAD }));
     const changedFilesForPr = vi.fn(async () => []);
     const git = { resolvePrShas, changedFilesForPr } as unknown as GitService;
     const workspace = {
@@ -53,14 +55,15 @@ describe('PullRequestService.getPrDetail — git work per read', () => {
     const svc = new PullRequestService(makeDb(), workspace, access, git);
     const detail = await svc.getPrDetail(7, { fresh: true });
 
-    expect(detail?.headSha).toBe('h'.repeat(40));
+    expect(detail?.headSha).toBe(HEAD);
+    expect(detail?.baseSha).toBe(BASE);
     expect(resolvePrShas).toHaveBeenCalledTimes(1);
     expect(changedFilesForPr).toHaveBeenCalledTimes(1);
     expect(changedFilesForPr).toHaveBeenCalledWith(
       'ws-main',
       'current-company-state',
       'alice/feature',
-      { skipFetch: true, patchCap: 0 },
+      { at: { baseSha: BASE, headSha: HEAD }, patchCap: 0 },
     );
     // The SHAs (and their fetch) come first; the file list rides on it.
     expect(resolvePrShas.mock.invocationCallOrder[0]).toBeLessThan(

--- a/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/pull-request.service.getPrDetail.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { PullRequestService } from '../pull-request.service.js';
+import type { Database } from '../../../database/connection.js';
+import type { WorkspaceService } from '../../../workspace/workspace.service.js';
+import type { GitService } from '../git.service.js';
+import type { IAccessControl } from '../../../access/access-control.interface.js';
+
+const ROW = {
+  id: 'cr-7',
+  number: 7,
+  sourceBranch: 'alice/feature',
+  targetBranch: 'current-company-state',
+  title: 'Feature',
+  body: '',
+  authorEmail: 'alice@bevel.software',
+  authorName: 'Alice',
+  state: 'open',
+  mergedSha: null,
+  createdAt: new Date('2026-08-01T00:00:00Z'),
+  updatedAt: null,
+  closedAt: null,
+};
+
+function makeDb(): Database {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [ROW] }),
+      }),
+    }),
+  } as unknown as Database;
+}
+
+/**
+ * A detail read is the hot path behind every change-request poll, every
+ * approval click, and every merge. It resolves the SHAs first (that fetches
+ * both refs), so the file list must reuse that fetch rather than fetch the
+ * same two refs again, and it must not spend one git subprocess per changed
+ * file on patches nothing reads.
+ */
+describe('PullRequestService.getPrDetail — git work per read', () => {
+  it('lists files without a second fetch and without patches', async () => {
+    const resolvePrShas = vi.fn(async () => ({ baseSha: 'b'.repeat(40), headSha: 'h'.repeat(40) }));
+    const changedFilesForPr = vi.fn(async () => []);
+    const git = { resolvePrShas, changedFilesForPr } as unknown as GitService;
+    const workspace = {
+      findAnyWorkspaceId: async () => 'ws-main',
+      ensureRemotesFetched: async () => undefined,
+    } as unknown as WorkspaceService;
+    const access = { canWriteAtRef: async () => false } as unknown as IAccessControl;
+
+    const svc = new PullRequestService(makeDb(), workspace, access, git);
+    const detail = await svc.getPrDetail(7, { fresh: true });
+
+    expect(detail?.headSha).toBe('h'.repeat(40));
+    expect(resolvePrShas).toHaveBeenCalledTimes(1);
+    expect(changedFilesForPr).toHaveBeenCalledTimes(1);
+    expect(changedFilesForPr).toHaveBeenCalledWith(
+      'ws-main',
+      'current-company-state',
+      'alice/feature',
+      { skipFetch: true, patchCap: 0 },
+    );
+    // The SHAs (and their fetch) come first; the file list rides on it.
+    expect(resolvePrShas.mock.invocationCallOrder[0]).toBeLessThan(
+      changedFilesForPr.mock.invocationCallOrder[0]!,
+    );
+  });
+});

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -1969,13 +1969,20 @@ export class GitService implements IGitService {
    * list, statuses, and +/- counts; per-file patches are generated for up to
    * `patchCap` files (default 400) — beyond that `patch` is left undefined,
    * exactly like the old API's binary/oversized files (the UI renders those with
-   * no inline diff). Patch generation is skipped for binary files.
+   * no inline diff). Patch generation is skipped for binary files; `patchCap: 0`
+   * skips it entirely, which is one git subprocess per changed file saved.
+   *
+   * `skipFetch` reads the clone's `origin/*` as it stands instead of fetching
+   * both refs first. For a caller that has JUST fetched them (`getPrDetail`
+   * resolves the SHAs first, and that fetches), the second fetch is a repeat
+   * network round-trip for the same two refs. Never pass it from a path that
+   * hasn't fetched: the diff would be computed against a stale head.
    */
   async changedFilesForPr(
     workspaceId: string,
     baseBranch: string,
     headBranch: string,
-    opts: { patchCap?: number } = {},
+    opts: { patchCap?: number; skipFetch?: boolean } = {},
   ): Promise<PullRequestFile[]> {
     assertValidBranchName(baseBranch);
     assertValidBranchName(headBranch);
@@ -1983,7 +1990,7 @@ export class GitService implements IGitService {
     // Fetch outside the mutex (network round-trip) so origin latency can't hold
     // the workspace lock; the lock guards only the local diff work below.
     const cwd = await this.repoDir(workspaceId);
-    await this.fetchPrRefs(cwd, baseBranch, headBranch);
+    if (!opts.skipFetch) await this.fetchPrRefs(cwd, baseBranch, headBranch);
     return this.mutex.run(workspaceId, async () => {
       const baseRef = await this.resolveBranchRef(cwd, baseBranch);
       const headRef = await this.resolveBranchRef(cwd, headBranch);

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -1972,28 +1972,36 @@ export class GitService implements IGitService {
    * no inline diff). Patch generation is skipped for binary files; `patchCap: 0`
    * skips it entirely, which is one git subprocess per changed file saved.
    *
-   * `skipFetch` reads the clone's `origin/*` as it stands instead of fetching
-   * both refs first. For a caller that has JUST fetched them (`getPrDetail`
-   * resolves the SHAs first, and that fetches), the second fetch is a repeat
-   * network round-trip for the same two refs. Never pass it from a path that
-   * hasn't fetched: the diff would be computed against a stale head.
+   * `at` pins the diff to two commits the caller has ALREADY resolved (the
+   * change-request detail resolves its SHAs first, which fetches both refs):
+   * no fetch, no ref resolution, and the file list is computed from exactly
+   * the commits the caller pins its head SHA to, so a fetch that lands in
+   * between cannot make the two disagree. Never pass SHAs from a path that
+   * has not just resolved them: the diff would describe a stale head.
    */
   async changedFilesForPr(
     workspaceId: string,
     baseBranch: string,
     headBranch: string,
-    opts: { patchCap?: number; skipFetch?: boolean } = {},
+    opts: { patchCap?: number; at?: { baseSha: string; headSha: string } } = {},
   ): Promise<PullRequestFile[]> {
     assertValidBranchName(baseBranch);
     assertValidBranchName(headBranch);
+    if (opts.at) {
+      for (const sha of [opts.at.baseSha, opts.at.headSha]) {
+        if (!/^[0-9a-f]{40,64}$/.test(sha)) {
+          throw new WorkflowValidationError(`invalid commit sha: ${sha}`);
+        }
+      }
+    }
     const patchCap = opts.patchCap ?? 400;
     // Fetch outside the mutex (network round-trip) so origin latency can't hold
     // the workspace lock; the lock guards only the local diff work below.
     const cwd = await this.repoDir(workspaceId);
-    if (!opts.skipFetch) await this.fetchPrRefs(cwd, baseBranch, headBranch);
+    if (!opts.at) await this.fetchPrRefs(cwd, baseBranch, headBranch);
     return this.mutex.run(workspaceId, async () => {
-      const baseRef = await this.resolveBranchRef(cwd, baseBranch);
-      const headRef = await this.resolveBranchRef(cwd, headBranch);
+      const baseRef = opts.at ? opts.at.baseSha : await this.resolveBranchRef(cwd, baseBranch);
+      const headRef = opts.at ? opts.at.headSha : await this.resolveBranchRef(cwd, headBranch);
       const range = `${baseRef}...${headRef}`; // three-dot = changes on head since merge-base
 
       const [{ stdout: nameStatusOut }, { stdout: numstatOut }] = await Promise.all([

--- a/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
@@ -13,6 +13,7 @@ import type { Database } from '../../database/connection.js';
 import { changeRequests } from '../../database/schema.js';
 import type { WorkspaceService } from '../../workspace/workspace.service.js';
 import type { IAccessControl } from '../../access/access-control.interface.js';
+import { AccessUnreadableError } from '../../access-model/access-errors.js';
 import { WorkflowValidationError } from '../../../shared/domain-errors.js';
 import { hashEmail } from '../../../shared/hash-email.js';
 
@@ -276,7 +277,7 @@ export class PullRequestService implements IPullRequestService {
 
   async getPrDetail(
     prNumber: number,
-    opts: { fresh?: boolean; workspaceId?: string; viewerEmail?: string } = {},
+    opts: { fresh?: boolean; workspaceId?: string; viewerEmail?: string; patches?: boolean } = {},
   ): Promise<PullRequestDetail | null> {
     if (!Number.isInteger(prNumber) || prNumber <= 0) {
       throw new WorkflowValidationError('PR number must be a positive integer');
@@ -306,15 +307,16 @@ export class PullRequestService implements IPullRequestService {
       // The file list is pinned to the SHAs just resolved (`at`), so it and
       // the `headSha` approvals pin against describe the same commits even if
       // another fetch lands on this workspace in between, and the second
-      // fetch of the same two refs is gone. No patches: nothing reads
-      // `PullRequestFile.patch` (the dialog diffs file contents client-side),
-      // and generating them cost one git subprocess per changed file on every
-      // detail read — every poll, every approval click, every merge.
+      // fetch of the same two refs is gone. `patches: false` is for the
+      // internal detail an approve / withdraw / revert fetches to pin its
+      // work: those never read `files[].patch`, and generating it cost one git
+      // subprocess per changed file per click. The detail served to clients
+      // keeps its patches, so the published payload is unchanged.
       files = await this.gitService.changedFilesForPr(
         workspaceId,
         row.targetBranch,
         row.sourceBranch,
-        { at: { baseSha, headSha }, patchCap: 0 },
+        { at: { baseSha, headSha }, ...(opts.patches === false ? { patchCap: 0 } : {}) },
       );
     }
 
@@ -351,6 +353,10 @@ export class PullRequestService implements IPullRequestService {
               opts.viewerEmail,
             )
             .catch((err) => {
+              // An unreadable access tree fails the whole read (503): a detail
+              // with empty approvals would tell the merge gate "nothing to
+              // approve", and a reviewer nothing at all.
+              if (err instanceof AccessUnreadableError) throw err;
               console.warn(`[cr] getApprovalStates failed for #${prNumber}:`, err);
               return [] as FileApprovalState[];
             }),
@@ -411,7 +417,11 @@ export class PullRequestService implements IPullRequestService {
       viewerCanCancel,
     };
 
-    this.detailCache.set(cacheKey, { at: now, headSha: detail.headSha, value: detail });
+    // A patch-less detail is an internal read; it must not be served to the
+    // next client poll as if it were the full one.
+    if (opts.patches !== false) {
+      this.detailCache.set(cacheKey, { at: now, headSha: detail.headSha, value: detail });
+    }
     return detail;
   }
 

--- a/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
@@ -7,12 +7,12 @@ import type {
   PullRequestFile,
   PullRequestState,
   PullRequestSummary,
+  IGitService,
 } from '@bevel-software/platform-shared';
 import type { Database } from '../../database/connection.js';
 import { changeRequests } from '../../database/schema.js';
 import type { WorkspaceService } from '../../workspace/workspace.service.js';
 import type { IAccessControl } from '../../access/access-control.interface.js';
-import type { GitService } from './git.service.js';
 import { WorkflowValidationError } from '../../../shared/domain-errors.js';
 import { hashEmail } from '../../../shared/hash-email.js';
 
@@ -100,7 +100,7 @@ export class PullRequestService implements IPullRequestService {
     private readonly db: Database,
     private readonly workspaceService: WorkspaceService,
     private readonly accessControl: IAccessControl,
-    private readonly gitService: GitService,
+    private readonly gitService: IGitService,
   ) {}
 
   setDetailEnricher(enricher: PrDetailEnricher): void {
@@ -303,17 +303,18 @@ export class PullRequestService implements IPullRequestService {
       );
       baseSha = shas.baseSha;
       headSha = shas.headSha;
-      // `resolvePrShas` just fetched both refs, so the file list reads that
-      // same origin/* state instead of paying a second network round-trip
-      // for it. No patches: nothing reads `PullRequestFile.patch` (the
-      // dialog diffs file contents client-side), and generating them cost one
-      // git subprocess per changed file on every detail read — every poll,
-      // every approval click, every merge.
+      // The file list is pinned to the SHAs just resolved (`at`), so it and
+      // the `headSha` approvals pin against describe the same commits even if
+      // another fetch lands on this workspace in between, and the second
+      // fetch of the same two refs is gone. No patches: nothing reads
+      // `PullRequestFile.patch` (the dialog diffs file contents client-side),
+      // and generating them cost one git subprocess per changed file on every
+      // detail read — every poll, every approval click, every merge.
       files = await this.gitService.changedFilesForPr(
         workspaceId,
         row.targetBranch,
         row.sourceBranch,
-        { skipFetch: true, patchCap: 0 },
+        { at: { baseSha, headSha }, patchCap: 0 },
       );
     }
 

--- a/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/pull-request.service.ts
@@ -303,10 +303,17 @@ export class PullRequestService implements IPullRequestService {
       );
       baseSha = shas.baseSha;
       headSha = shas.headSha;
+      // `resolvePrShas` just fetched both refs, so the file list reads that
+      // same origin/* state instead of paying a second network round-trip
+      // for it. No patches: nothing reads `PullRequestFile.patch` (the
+      // dialog diffs file contents client-side), and generating them cost one
+      // git subprocess per changed file on every detail read — every poll,
+      // every approval click, every merge.
       files = await this.gitService.changedFilesForPr(
         workspaceId,
         row.targetBranch,
         row.sourceBranch,
+        { skipFetch: true, patchCap: 0 },
       );
     }
 

--- a/packages/core-backend/src/modules/workflow/review-workflow/__tests__/approval-states.test.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/__tests__/approval-states.test.ts
@@ -13,6 +13,7 @@ import type { WorkspaceService } from '../../../workspace/workspace.service.js';
 import type { GitService } from '../../git/git.service.js';
 import type { IAccessControl } from '../../../access/access-control.interface.js';
 import { hashEmail as hash } from '../../../../shared/hash-email.js';
+import { AccessUnreadableError } from '../../../access-model/access-errors.js';
 
 function file(overrides: Partial<PullRequestFile>): PullRequestFile {
   return {
@@ -555,5 +556,64 @@ describe('mergePr — roles.yaml privilege-escalation guard', () => {
     // Assert the authorization gate actually let the merge through: the local
     // merge was invoked (not just that no auth error was thrown).
     expect(mergeChangeRequestMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * An access tree that could not be READ is not the same as "no eligible
+ * writers": the latter drops a file out of the merge gate, so answering it for
+ * a lost git read would let a change merge past a deny nobody managed to
+ * load. The unreadable case propagates (the caller fails closed, 503); any
+ * other lookup failure still degrades to empty eligibility as documented.
+ */
+describe('ReviewWorkflowService.getApprovalStates — unreadable access tree', () => {
+  const FILES = [file({ path: 'Knowledge/Foo.md' })];
+  function serviceWith(overrides: Partial<IAccessControl>) {
+    const workspace = {
+      ensureRemotesFetched: vi.fn(async () => undefined),
+      getOrCreateForBranch: vi.fn(async () => ({ id: 'ws-base' })),
+    } as unknown as WorkspaceService;
+    const git = { mergeChangeRequest: mergeChangeRequestMock } as unknown as GitService;
+    return new ReviewWorkflowService(makeDb([]), { ...makeAccessControl({}), ...overrides }, workspace, git);
+  }
+
+  it('propagates AccessUnreadableError from the eligibility lookup', async () => {
+    const svc = serviceWith({
+      eligibleWritersForPathsAtRef: async () => {
+        throw new AccessUnreadableError('origin/current-company-state', 'Knowledge/access.md');
+      },
+    });
+    await expect(
+      svc.getApprovalStates(1, FILES, 'head-sha-1', 'current-company-state', null, 'ws-base', 'alice@bevel.software'),
+    ).rejects.toBeInstanceOf(AccessUnreadableError);
+  });
+
+  it('propagates AccessUnreadableError from the viewer batch too', async () => {
+    const svc = serviceWith({
+      canWriteBatchAtRef: async () => {
+        throw new AccessUnreadableError('origin/current-company-state', 'Knowledge/access.md');
+      },
+    });
+    await expect(
+      svc.getApprovalStates(1, FILES, 'head-sha-1', 'current-company-state', null, 'ws-base', 'alice@bevel.software'),
+    ).rejects.toBeInstanceOf(AccessUnreadableError);
+  });
+
+  it('still degrades any other lookup failure to empty eligibility', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const svc = serviceWith({
+        eligibleWritersForPathsAtRef: async () => {
+          throw new Error('origin not fetched yet');
+        },
+      });
+      const states = await svc.getApprovalStates(1, FILES, 'head-sha-1', 'current-company-state', null, 'ws-base');
+      expect(states).toHaveLength(1);
+      expect(states[0].eligibleApprovers).toEqual({ roles: [], users: [] });
+      expect(states[0].isApproved).toBe(false);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
@@ -12,6 +12,7 @@ import type {
 } from '@bevel-software/platform-shared';
 import type { Database } from '../../database/connection.js';
 import { changeRequests, prComments, prFileApprovals, prMergeLog } from '../../database/schema.js';
+import { AccessUnreadableError } from '../../access-model/access-errors.js';
 import type { IAccessControl } from '../../access/access-control.interface.js';
 import { isAccessMdPath } from '../../access-model/access-grammar.js';
 import type { GitService } from '../git/git.service.js';
@@ -374,6 +375,9 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
         );
         if (resolved) eligibilityByPath = resolved;
       } catch (err) {
+        // An unreadable tree is not "no eligible writers": that answer would
+        // drop every file out of the merge gate. Fail closed instead.
+        if (err instanceof AccessUnreadableError) throw err;
         console.warn(
           `[review-workflow] eligibleWritersForPathsAtRef failed for PR #${prNumber} (base=${baseBranch}):`,
           err,
@@ -390,6 +394,7 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
           );
           if (batch) viewerCanApproveByPath = batch;
         } catch (err) {
+          if (err instanceof AccessUnreadableError) throw err;
           console.warn(
             `[review-workflow] canWriteBatchAtRef failed for PR #${prNumber} viewer=${viewerEmail}:`,
             err,

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -764,6 +764,10 @@ export function createWorkflowRoutes(
         fresh: true,
         workspaceId: workspace.id,
         viewerEmail: user.email,
+        // Internal read: this route pins its work on the detail and never
+        // reads a patch; skipping them is one git subprocess per file saved
+        // on every click, and the result stays out of the client cache.
+        patches: false,
       });
       if (!detail) {
         res.status(404).json({ error: 'change request not found' });
@@ -805,6 +809,10 @@ export function createWorkflowRoutes(
         fresh: true,
         workspaceId: workspace.id,
         viewerEmail: user.email,
+        // Internal read: this route pins its work on the detail and never
+        // reads a patch; skipping them is one git subprocess per file saved
+        // on every click, and the result stays out of the client cache.
+        patches: false,
       });
       if (!detail) {
         res.status(404).json({ error: 'change request not found' });
@@ -841,6 +849,10 @@ export function createWorkflowRoutes(
         fresh: true,
         workspaceId: workspace.id,
         viewerEmail: user.email,
+        // Internal read: this route pins its work on the detail and never
+        // reads a patch; skipping them is one git subprocess per file saved
+        // on every click, and the result stays out of the client cache.
+        patches: false,
       });
       if (!detail) {
         res.status(404).json({ error: 'change request not found' });

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -1129,7 +1129,7 @@ export class WorkflowService implements IWorkflowService {
 
   getChangeRequestDetail(
     number: number,
-    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string },
+    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string; patches?: boolean },
   ): Promise<ChangeRequestDetail | null> {
     return this.prs.getPrDetail(number, opts);
   }

--- a/packages/shared/src/git/pr.types.ts
+++ b/packages/shared/src/git/pr.types.ts
@@ -269,6 +269,12 @@ export interface IPullRequestService {
    */
   getPrDetail(
     prNumber: number,
-    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string },
+    /**
+     * `patches: false` skips per-file patch generation and keeps the result
+     * out of the detail cache: for internal reads (approve / withdraw /
+     * revert pin their work on the detail) that never look at
+     * `files[].patch`. Clients get the full detail by default.
+     */
+    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string; patches?: boolean },
   ): Promise<PullRequestDetail | null>;
 }

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -1,4 +1,5 @@
 import type { AuthUser } from '../auth/types.js';
+import type { PullRequestFile } from './pr.types.js';
 
 export interface BranchInfo {
   name: string;
@@ -175,4 +176,35 @@ export interface IGitService {
   // against HEAD reports the empty state by definition. Cross-branch
   // comparison (`diffFileBetweenBranches`) + history (`diffFileAtCommit`)
   // still cover the meaningful diff cases.
+
+  /**
+   * Head and base commit SHAs of a change request, resolved on `origin/*`
+   * after a fetch so a force-push is reflected. These are what approvals
+   * pin against, and what `changedFilesForPr`'s `at` option takes.
+   */
+  resolvePrShas(
+    workspaceId: string,
+    baseBranch: string,
+    headBranch: string,
+  ): Promise<{ baseSha: string; headSha: string }>;
+
+  /**
+   * The changed-file list of a change request: a three-dot (merge-base)
+   * diff, rename-aware. `patchCap` bounds per-file patch generation (`0`
+   * skips it); `at` pins the diff to commits the caller has already
+   * resolved, skipping the fetch and the ref resolution.
+   */
+  changedFilesForPr(
+    workspaceId: string,
+    baseBranch: string,
+    headBranch: string,
+    opts?: { patchCap?: number; at?: { baseSha: string; headSha: string } },
+  ): Promise<PullRequestFile[]>;
+
+  /**
+   * Just the repo-relative paths a change request touches (three-dot diff,
+   * no statuses, no patches): the cheap form behind change-request list
+   * summaries and owner routing.
+   */
+  changedPathsForPr(workspaceId: string, baseBranch: string, headBranch: string): Promise<string[]>;
 }

--- a/packages/shared/src/workflow/interface.ts
+++ b/packages/shared/src/workflow/interface.ts
@@ -336,7 +336,8 @@ export interface IWorkflowService {
   getChangeRequest(number: number): Promise<ChangeRequest | null>;
   getChangeRequestDetail(
     number: number,
-    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string },
+    /** `patches: false`: an internal, uncached read without per-file patches; see IPullRequestService.getPrDetail. */
+    opts?: { fresh?: boolean; workspaceId?: string; viewerEmail?: string; patches?: boolean },
   ): Promise<ChangeRequestDetail | null>;
 
   /**


### PR DESCRIPTION
Approving a file in the change-request view took 1 to 4 s per click. `loadModelAtRef` had no cache, and one click ran six at-ref permission gates that each rebuilt the access model from git (`ls-tree` plus a `git show` per `access.md`), plus two duplicate network fetches and a `git diff` per changed file for patches nothing reads.

- `fb396e9` caches the at-ref model per (workspace, resolved commit), with in-flight dedupe; a push to the base branch resolves to a new commit and misses. `resolvedRef` is now the commit, so own-entry reads can't straddle a push. `null` outcomes are never cached, so a transient git failure can't pin a denial to a commit.
- `5b83da5` `changedFilesForPr` gains `skipFetch`; `getPrDetail` passes `{ skipFetch: true, patchCap: 0 }`. `files[].patch` is no longer in the detail payload (no in-repo consumer read it; frontend, agent tools, and hexis-mcp checked).
- `8816184` changeset (patch on `@bevel-software/platform-core-backend`).

## Numbers

Same-fixture A/B (16 `access.md`, 6-file CR, local origin): approve 1.0 s → 0.18 s, withdraw 0.9 s → 0.2 s. Against GitHub the old path also paid two network fetches per click, so the real-world gain is larger. Verified in the browser through the real dialog; a `deny` pushed to the base branch was reflected on the very next click (one rebuild at the new commit), and reverting it restored the control on the next click.

## Tests

- `access/__tests__/access-control.atref-cache.test.ts`: the six gate calls of one approval click spawn one `ls-tree` (was six); a push that revokes a writer is seen on the next call and the new tip is cached; the `ref` → `origin/ref` fallthrough for a local branch without `roles.yaml` is kept.
- `git/__tests__/git.service.changedFilesForPr.test.ts`: `skipFetch` reads the clone's `origin/*` as it stands while the default still refreshes.
- `git/__tests__/pull-request.service.getPrDetail.test.ts`: the file list is read once, after SHA resolution, with both options.

Full monorepo suite and typecheck green.

## Not in this PR

- Optimistic per-row flip in the dialog so the click feels immediate on slow origins.
- `detailCache` keys on head SHA only, so plain detail reads can serve a base-branch push stale for up to 30 s (approve/withdraw/merge use `fresh: true` and are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
