### PR TITLE
Refuse an agent write that would land beside the repository instead of in it

### DIFF
--- a/.changeset/agent-writes-outside-repo.md
+++ b/.changeset/agent-writes-outside-repo.md
@@ -1,0 +1,5 @@
+---
+"@bevel-software/platform-core-backend": patch
+---
+
+An agent write that names a repo-relative path (`KnowledgeBase/Foo.md` instead of `knowledge-base/KnowledgeBase/Foo.md`) is refused with the corrected path, instead of landing beside the repository where nothing commits or pushes it. The workspace directory holds the clone as `knowledge-base/` and the agent filesystem is rooted one level above it, so such a write used to succeed silently: the tool reported "committed + pushed", git saw nothing, and the explorer re-rooted on the stray `KnowledgeBase/` folder and showed the whole clone under Knowledge. Every creating operation on the lock-aware filesystem, `save_file`, and each `unzip` entry now require the prefix; the path inputs of every content tool and the root listing name it; and a commit that finds the bytes beside the repository throws instead of reporting nothing to commit. Removing a stray is still allowed, so a file the old behaviour left there can be cleaned up.

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -26,6 +26,12 @@ knowledge-base/
 └── access.md             ← repo-root access-control rules
 ```
 
+Tool paths are workspace-relative, and the workspace root holds this
+repository as the `knowledge-base/` folder: a file in it is
+`knowledge-base/KnowledgeBase/Foo.md`, never `KnowledgeBase/Foo.md`. A path
+without that prefix is refused, because it would land beside the repository
+where git never sees it.
+
 Only those two folders are structural, and only `Plugins/` has a layout the
 platform reads:
 

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -329,7 +329,7 @@ export async function createCoreServer(
     recoveryBotEmail: RECOVERY_BOT_EMAIL,
     hooks: core.workflowService.hooks,
   };
-  registerWorkflowTools(core.toolRegistry, toolsRouter, ta, th);
+  registerWorkflowTools(core.toolRegistry, toolsRouter, ta, th, core.kbDirName);
   registerWorkspaceTools(core.toolRegistry, toolsRouter, ta, th, core.spillStore, core.docExtractService, core.accessControl, core.kbDirName, sessionOntologyGate, core.routineWritePolicy, core.sessionSink);
   registerSkillsTools(core.toolRegistry, toolsRouter, ta, th, core.skillService);
   registerToolManualsTools(core.toolRegistry, toolsRouter, ta, th, core.toolManualService, {

--- a/packages/core-backend/src/modules/access/admin-locked-commit.ts
+++ b/packages/core-backend/src/modules/access/admin-locked-commit.ts
@@ -136,6 +136,7 @@ export class AdminLockedCommits {
         workspaceId,
         branch: this.defaultBranch,
         user: actor,
+        kbDirName: this.deps.kbDirName,
         validateWrite: this.deps.validateWrite,
       },
     );

--- a/packages/core-backend/src/modules/access/synced-groups-committer.ts
+++ b/packages/core-backend/src/modules/access/synced-groups-committer.ts
@@ -74,7 +74,7 @@ export function createSyncedGroupsCommitter(deps: {
       // roles admin's atomic writes use.
       const fsys = new LockingFilesystem(
         { basePath, contained: true },
-        { workflow: workflowService, workspaceId, branch, user: bot },
+        { workflow: workflowService, workspaceId, branch, user: bot, kbDirName },
       );
       try {
         await fsys.writeFiles(

--- a/packages/core-backend/src/modules/diff/__tests__/diff.routes.rejectPathsLocked.test.ts
+++ b/packages/core-backend/src/modules/diff/__tests__/diff.routes.rejectPathsLocked.test.ts
@@ -82,7 +82,7 @@ describe('rejectPathsLocked', () => {
     const h = await makeHarness();
     workspaceDir = h.workspaceDir;
 
-    await rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, [
+    await rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, 'knowledge-base', [
       'knowledge-base/a.md',
       'knowledge-base/added.md',
     ]);
@@ -104,7 +104,7 @@ describe('rejectPathsLocked', () => {
     const h = await makeHarness();
     workspaceDir = h.workspaceDir;
     await expect(
-      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, []),
+      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, 'knowledge-base', []),
     ).resolves.toBeUndefined();
     expect(h.calls).toEqual([]);
   });
@@ -119,7 +119,7 @@ describe('rejectPathsLocked', () => {
     workspaceDir = h.workspaceDir;
 
     await expect(
-      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, [
+      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, 'knowledge-base', [
         'knowledge-base/a.md',
         'knowledge-base/added.md',
       ]),
@@ -140,7 +140,7 @@ describe('rejectPathsLocked', () => {
     workspaceDir = h.workspaceDir;
 
     await expect(
-      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, [
+      rejectPathsLocked(h.workflow, h.diff, WORKSPACE_ID, USER, 'knowledge-base', [
         'knowledge-base/a.md',
       ]),
     ).rejects.toBeInstanceOf(WorkflowValidationError);

--- a/packages/core-backend/src/modules/diff/diff.routes.ts
+++ b/packages/core-backend/src/modules/diff/diff.routes.ts
@@ -45,6 +45,7 @@ export async function rejectPathsLocked(
   diffService: IDiffService,
   workspaceId: string,
   user: AuthUser,
+  kbDirName: string,
   paths: string[],
 ): Promise<void> {
   if (paths.length === 0) return;
@@ -54,7 +55,7 @@ export async function rejectPathsLocked(
   if (total === 0) return;
   const lockingFs = new LockingFilesystem(
     { basePath: plan.workspaceDir, contained: true },
-    { workflow: workflowService, workspaceId, branch, user },
+    { workflow: workflowService, workspaceId, branch, user, kbDirName },
   );
   try {
     await lockingFs.writeFiles(
@@ -265,7 +266,7 @@ export function createDiffRoutes(
           current?.changes.map((c) => c.path) ?? [],
         );
       }
-      await rejectPathsLocked(workflowService, diffService, req.params.id, user, paths);
+      await rejectPathsLocked(workflowService, diffService, req.params.id, user, kbDirName, paths);
       res.json({ session: await diffService.currentSession(req.params.id) });
     } catch (err) {
       const { status, body } = toHttpError(err);

--- a/packages/core-backend/src/modules/kb-fs/__tests__/locking-filesystem.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/locking-filesystem.test.ts
@@ -5,7 +5,10 @@ import os from 'node:os';
 import type { AuthUser, IWorkflowService } from '@bevel-software/platform-shared';
 import { LocalFilesystem } from '@mastra/core/workspace';
 import { LockingFilesystem } from '../locking-filesystem.js';
-import { PushNeedsAgentResolutionError } from '../../../shared/domain-errors.js';
+import { PushNeedsAgentResolutionError, WorkflowValidationError } from '../../../shared/domain-errors.js';
+
+/** The clone folder at the workspace root: every path the filesystem mutates lives under it. */
+const KB = 'knowledge-base';
 
 const USER: AuthUser = {
   id: 'user-1',
@@ -56,20 +59,20 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    await fsLayer.writeFile('Knowledge/Foo.md', 'hello\n');
+    await fsLayer.writeFile('knowledge-base/Knowledge/Foo.md', 'hello\n');
 
     expect(workflow.acquireLock).toHaveBeenCalledWith(
       'ws-feat',
       'feat',
-      'Knowledge/Foo.md',
+      'knowledge-base/Knowledge/Foo.md',
       USER,
     );
     expect(workflow.releaseLock).toHaveBeenCalledWith(
       'ws-feat',
       'feat',
-      'Knowledge/Foo.md',
+      'knowledge-base/Knowledge/Foo.md',
       USER,
     );
     // Acquire fires before release.
@@ -79,20 +82,21 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
       .invocationCallOrder[0];
     expect(acquireOrder).toBeLessThan(releaseOrder);
     // The bytes actually landed on disk.
-    expect(await fs.readFile(path.join(root, 'Knowledge/Foo.md'), 'utf-8')).toBe('hello\n');
+    expect(await fs.readFile(path.join(root, 'knowledge-base/Knowledge/Foo.md'), 'utf-8')).toBe('hello\n');
   });
 
   it('deleteFile acquires + deletes + releases', async () => {
-    const filePath = path.join(root, 'a.md');
+    const filePath = path.join(root, 'knowledge-base/a.md');
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, 'x', 'utf-8');
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    await fsLayer.deleteFile('a.md');
-    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'a.md', USER);
-    expect(workflow.releaseLock).toHaveBeenCalledWith('ws-feat', 'feat', 'a.md', USER);
+    await fsLayer.deleteFile('knowledge-base/a.md');
+    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/a.md', USER);
+    expect(workflow.releaseLock).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/a.md', USER);
     await expect(fs.access(filePath)).rejects.toBeDefined();
   });
 
@@ -100,49 +104,49 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    await fsLayer.mkdir('empty');
+    await fsLayer.mkdir('knowledge-base/empty');
     // .gitkeep got written through the lock path. The lock is on the
     // .gitkeep path (that's the file the commit attaches to).
     expect(workflow.acquireLock).toHaveBeenCalledWith(
       'ws-feat',
       'feat',
-      'empty/.gitkeep',
+      'knowledge-base/empty/.gitkeep',
       USER,
     );
     expect(workflow.releaseLock).toHaveBeenCalledWith(
       'ws-feat',
       'feat',
-      'empty/.gitkeep',
+      'knowledge-base/empty/.gitkeep',
       USER,
     );
-    expect(await fs.readFile(path.join(root, 'empty/.gitkeep'), 'utf-8')).toBe('');
+    expect(await fs.readFile(path.join(root, 'knowledge-base/empty/.gitkeep'), 'utf-8')).toBe('');
   });
 
   it('mkdir of an already-populated dir does NOT drop a .gitkeep', async () => {
-    await fs.mkdir(path.join(root, 'has-content'), { recursive: true });
-    await fs.writeFile(path.join(root, 'has-content/real.md'), 'hi', 'utf-8');
+    await fs.mkdir(path.join(root, 'knowledge-base/has-content'), { recursive: true });
+    await fs.writeFile(path.join(root, 'knowledge-base/has-content/real.md'), 'hi', 'utf-8');
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    await fsLayer.mkdir('has-content', { recursive: true });
+    await fsLayer.mkdir('knowledge-base/has-content', { recursive: true });
     expect(workflow.acquireLock).not.toHaveBeenCalled();
     expect(workflow.releaseLock).not.toHaveBeenCalled();
     // The existing file is untouched.
-    expect(await fs.readFile(path.join(root, 'has-content/real.md'), 'utf-8')).toBe('hi');
+    expect(await fs.readFile(path.join(root, 'knowledge-base/has-content/real.md'), 'utf-8')).toBe('hi');
   });
 
   it('rmdir is refused with a clear error — one-change-per-file invariant', async () => {
-    await fs.mkdir(path.join(root, 'doomed'), { recursive: true });
+    await fs.mkdir(path.join(root, 'knowledge-base/doomed'), { recursive: true });
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    await expect(fsLayer.rmdir('doomed')).rejects.toThrow(
+    await expect(fsLayer.rmdir('knowledge-base/doomed')).rejects.toThrow(
       /Recursive directory removal is not supported/i,
     );
     expect(workflow.acquireLock).not.toHaveBeenCalled();
@@ -157,7 +161,7 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
         acquired: false,
         lock: {
           branch: 'feat',
-          path: 'Locked.md',
+          path: 'knowledge-base/Locked.md',
           holderUserId: 'bob',
           holderName: 'Bob',
           acquiredAt: '',
@@ -167,11 +171,11 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
       });
       const fsLayer = new LockingFilesystem(
         { basePath: root, contained: true },
-        { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+        { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
       );
 
-      await expect(fsLayer.writeFile('Locked.md', 'x')).rejects.toThrow(
-        /Skipped editing "Locked\.md" — locked by Bob/,
+      await expect(fsLayer.writeFile('knowledge-base/Locked.md', 'x')).rejects.toThrow(
+        /Skipped editing "knowledge-base\/Locked\.md" — locked by Bob/,
       );
       expect(workflow.acquireLock).toHaveBeenCalledTimes(3);
       expect(workflow.releaseLock).not.toHaveBeenCalled();
@@ -183,7 +187,7 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
     const workflow = makeWorkflow();
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
     // Path traversal — Mastra's `contained: true` rejects this with a
     // PermissionError. The lock must still go away so the next caller
@@ -191,7 +195,7 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
     // push whatever partial state is on disk) must NOT fire — instead
     // we use the no-commit variant so partial writes don't silently
     // persist as committed changes.
-    await expect(fsLayer.writeFile('../escape.md', 'x')).rejects.toThrow();
+    await expect(fsLayer.writeFile('knowledge-base/../../escape.md', 'x')).rejects.toThrow();
     expect(workflow.releaseLockNoCommit).toHaveBeenCalled();
     expect(workflow.releaseLock).not.toHaveBeenCalled();
   });
@@ -209,8 +213,8 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
   });
 
   it('locks writes AND deletes, applies both, emits ONE batched onFilesChanged', async () => {
-    await fs.mkdir(path.join(root, 'Tools'), { recursive: true });
-    await fs.writeFile(path.join(root, 'Tools/old.tool'), '{}');
+    await fs.mkdir(path.join(root, 'knowledge-base/Tools'), { recursive: true });
+    await fs.writeFile(path.join(root, 'knowledge-base/Tools/old.tool'), '{}');
 
     const workflow = makeWorkflow();
     const emitted: unknown[] = [];
@@ -220,36 +224,36 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
         workflow,
         workspaceId: 'ws-feat',
         branch: 'feat',
-        user: USER,
+        user: USER, kbDirName: KB,
         fileChanges: { emit: (c: unknown) => emitted.push(c) } as never,
       },
     );
 
     const change = await fsLayer.writeFiles(
-      [{ path: 'Tools/new.tool', content: '{"type":"http","url":"https://x/m"}' }],
+      [{ path: 'knowledge-base/Tools/new.tool', content: '{"type":"http","url":"https://x/m"}' }],
       'batch',
-      ['Tools/old.tool'],
+      ['knowledge-base/Tools/old.tool'],
     );
 
     // Both paths locked; both mutations landed; commit returned.
-    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'Tools/new.tool', USER);
-    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'Tools/old.tool', USER);
-    expect(await fs.readFile(path.join(root, 'Tools/new.tool'), 'utf-8')).toContain('http');
-    await expect(fs.access(path.join(root, 'Tools/old.tool'))).rejects.toThrow();
+    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/Tools/new.tool', USER);
+    expect(workflow.acquireLock).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/Tools/old.tool', USER);
+    expect(await fs.readFile(path.join(root, 'knowledge-base/Tools/new.tool'), 'utf-8')).toContain('http');
+    await expect(fs.access(path.join(root, 'knowledge-base/Tools/old.tool'))).rejects.toThrow();
     expect(change).toEqual({});
     // ONE event carrying the whole batch (sorted), attributed to the user.
     expect(emitted).toHaveLength(1);
     expect(emitted[0]).toMatchObject({
       workspaceId: 'ws-feat',
       branch: 'feat',
-      paths: ['Tools/new.tool', 'Tools/old.tool'],
+      paths: ['knowledge-base/Tools/new.tool', 'knowledge-base/Tools/old.tool'],
       byUser: USER,
     });
   });
 
   it('a failing commit releases every lock WITHOUT committing and emits nothing', async () => {
-    await fs.mkdir(path.join(root, 'Tools'), { recursive: true });
-    await fs.writeFile(path.join(root, 'Tools/old.tool'), '{}');
+    await fs.mkdir(path.join(root, 'knowledge-base/Tools'), { recursive: true });
+    await fs.writeFile(path.join(root, 'knowledge-base/Tools/old.tool'), '{}');
 
     const workflow = makeWorkflow();
     (workflow.commitChanges as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('push exploded'));
@@ -260,16 +264,16 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
         workflow,
         workspaceId: 'ws-feat',
         branch: 'feat',
-        user: USER,
+        user: USER, kbDirName: KB,
         fileChanges: { emit: (c: unknown) => emitted.push(c) } as never,
       },
     );
 
     await expect(
       fsLayer.writeFiles(
-        [{ path: 'Tools/new.tool', content: '{"type":"http","url":"https://x/m"}' }],
+        [{ path: 'knowledge-base/Tools/new.tool', content: '{"type":"http","url":"https://x/m"}' }],
         'batch',
-        ['Tools/old.tool'],
+        ['knowledge-base/Tools/old.tool'],
       ),
     ).rejects.toThrow('push exploded');
 
@@ -277,8 +281,8 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
     // discards the uncommitted bytes (write reverted, delete restored) in the
     // real WorkflowService via git.discardPath. The committing release must
     // never run, and no change event fires for a failed batch.
-    expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith('ws-feat', 'feat', 'Tools/new.tool', USER);
-    expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith('ws-feat', 'feat', 'Tools/old.tool', USER);
+    expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/Tools/new.tool', USER);
+    expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/Tools/old.tool', USER);
     expect(workflow.releaseLock).not.toHaveBeenCalled();
     expect(emitted).toHaveLength(0);
   });
@@ -293,7 +297,7 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
     // push ladder) and still propagate the error.
     const workflow = makeWorkflow();
     (workflow.commitChanges as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new PushNeedsAgentResolutionError('feat', 'A.md', 'non-fast-forward', 'rebase failed'),
+      new PushNeedsAgentResolutionError('feat', 'knowledge-base/A.md', 'non-fast-forward', 'rebase failed'),
     );
     const emitted: unknown[] = [];
     const fsLayer = new LockingFilesystem(
@@ -302,16 +306,16 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
         workflow,
         workspaceId: 'ws-feat',
         branch: 'feat',
-        user: USER,
+        user: USER, kbDirName: KB,
         fileChanges: { emit: (c: unknown) => emitted.push(c) } as never,
       },
     );
 
     await expect(
-      fsLayer.writeFiles([{ path: 'A.md', content: 'x' }], 'batch'),
+      fsLayer.writeFiles([{ path: 'knowledge-base/A.md', content: 'x' }], 'batch'),
     ).rejects.toBeInstanceOf(PushNeedsAgentResolutionError);
 
-    expect(workflow.releaseLock).toHaveBeenCalledWith('ws-feat', 'feat', 'A.md', USER);
+    expect(workflow.releaseLock).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/A.md', USER);
     expect(workflow.releaseLockNoCommit).not.toHaveBeenCalled();
     expect(emitted).toHaveLength(0);
   });
@@ -326,11 +330,11 @@ describe('LockingFilesystem.writeFiles — batch with deletes + one batched chan
         workflow,
         workspaceId: 'ws-feat',
         branch: 'feat',
-        user: USER,
+        user: USER, kbDirName: KB,
         fileChanges: { emit: (c: unknown) => emitted.push(c) } as never,
       },
     );
-    await fsLayer.writeFiles([{ path: 'A.md', content: 'same' }], 'noop');
+    await fsLayer.writeFiles([{ path: 'knowledge-base/A.md', content: 'same' }], 'noop');
     expect(emitted).toHaveLength(0);
   });
 });
@@ -363,16 +367,16 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.writeFile('KnowledgeBase/new.md', '# New\n');
+    await fsLayer.writeFile('knowledge-base/KnowledgeBase/new.md', '# New\n');
     expect(creatorAccess.planForCreate).toHaveBeenCalledWith(
       'ws-feat',
       USER,
-      'KnowledgeBase/new.md',
+      'knowledge-base/KnowledgeBase/new.md',
       'file',
     );
-    expect(await fs.readFile(path.join(root, 'KnowledgeBase/new.md'), 'utf-8')).toBe(
+    expect(await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/new.md'), 'utf-8')).toBe(
       '---\nread: Alice <alice@example.com>\n---\n# New\n',
     );
   });
@@ -381,10 +385,10 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     const workflow = makeWorkflow();
     const creatorAccess = makeCreatorAccess();
     creatorAccess.planForCreate.mockImplementation(async (_w, _u, p: string) =>
-      p === 'KnowledgeBase/Mine/doc.md'
+      p === 'knowledge-base/KnowledgeBase/Mine/doc.md'
         ? {
             kind: 'seed-access-md',
-            wsRelPath: 'KnowledgeBase/Mine/access.md',
+            wsRelPath: 'knowledge-base/KnowledgeBase/Mine/access.md',
             apply: (current: string) =>
               current + '---\nread:\n  - Alice <alice@example.com>\n---\n',
           }
@@ -392,18 +396,18 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     );
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.writeFile('KnowledgeBase/Mine/doc.md', 'body');
+    await fsLayer.writeFile('knowledge-base/KnowledgeBase/Mine/doc.md', 'body');
     const locked = (workflow.acquireLock as ReturnType<typeof vi.fn>).mock.calls.map(
       (c) => c[2],
     );
-    expect(locked).toEqual(['KnowledgeBase/Mine/access.md', 'KnowledgeBase/Mine/doc.md']);
+    expect(locked).toEqual(['knowledge-base/KnowledgeBase/Mine/access.md', 'knowledge-base/KnowledgeBase/Mine/doc.md']);
     expect(
-      await fs.readFile(path.join(root, 'KnowledgeBase/Mine/access.md'), 'utf-8'),
+      await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/access.md'), 'utf-8'),
     ).toContain('Alice <alice@example.com>');
     // The file content is untouched — the grant lives in the seeded access.md.
-    expect(await fs.readFile(path.join(root, 'KnowledgeBase/Mine/doc.md'), 'utf-8')).toBe('body');
+    expect(await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/doc.md'), 'utf-8')).toBe('body');
     expect(creatorAccess.noteAccessFileWritten).toHaveBeenCalledWith('ws-feat');
   });
 
@@ -421,14 +425,14 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     );
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.mkdir('KnowledgeBase/Projects');
+    await fsLayer.mkdir('knowledge-base/KnowledgeBase/Projects');
     expect(
-      await fs.readFile(path.join(root, 'KnowledgeBase/Projects/access.md'), 'utf-8'),
+      await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/Projects/access.md'), 'utf-8'),
     ).toContain('Alice <alice@example.com>');
     await expect(
-      fs.access(path.join(root, 'KnowledgeBase/Projects/.gitkeep')),
+      fs.access(path.join(root, 'knowledge-base/KnowledgeBase/Projects/.gitkeep')),
     ).rejects.toBeDefined();
   });
 
@@ -437,32 +441,32 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     const creatorAccess = makeCreatorAccess();
     creatorAccess.planForCreate.mockResolvedValue({
       kind: 'seed-access-md',
-      wsRelPath: 'KnowledgeBase/Mine/access.md',
+      wsRelPath: 'knowledge-base/KnowledgeBase/Mine/access.md',
       apply: () => '---\nread:\n  - Alice <alice@example.com>\n---\n',
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
     await fsLayer.writeFiles(
       [
-        { path: 'KnowledgeBase/Mine/a.md', content: 'A' },
-        { path: 'KnowledgeBase/Mine/b.md', content: 'B' },
+        { path: 'knowledge-base/KnowledgeBase/Mine/a.md', content: 'A' },
+        { path: 'knowledge-base/KnowledgeBase/Mine/b.md', content: 'B' },
       ],
       'batch',
     );
     // One seed for the shared new folder, committed with the batch.
     expect(
-      await fs.readFile(path.join(root, 'KnowledgeBase/Mine/access.md'), 'utf-8'),
+      await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/access.md'), 'utf-8'),
     ).toContain('Alice <alice@example.com>');
     expect(workflow.commitChanges).toHaveBeenCalledTimes(1);
     const locked = (workflow.acquireLock as ReturnType<typeof vi.fn>).mock.calls.map(
       (c) => c[2],
     );
     expect(locked).toEqual([
-      'KnowledgeBase/Mine/a.md',
-      'KnowledgeBase/Mine/b.md',
-      'KnowledgeBase/Mine/access.md',
+      'knowledge-base/KnowledgeBase/Mine/a.md',
+      'knowledge-base/KnowledgeBase/Mine/b.md',
+      'knowledge-base/KnowledgeBase/Mine/access.md',
     ]);
     expect(creatorAccess.noteAccessFileWritten).toHaveBeenCalledWith('ws-feat');
   });
@@ -474,14 +478,14 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // be dirty from ANOTHER save whose commit is still queued, and scoping the
     // batch to a merely-locked path would sweep those bytes in under this
     // batch's author/summary.
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
     const seedContent = '---\nread:\n  - Alice <alice@example.com>\n---\n';
-    await fs.writeFile(path.join(root, 'KnowledgeBase/Mine/access.md'), seedContent);
+    await fs.writeFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/access.md'), seedContent);
     const workflow = makeWorkflow();
     const creatorAccess = makeCreatorAccess();
     creatorAccess.planForCreate.mockResolvedValue({
       kind: 'seed-access-md',
-      wsRelPath: 'KnowledgeBase/Mine/access.md',
+      wsRelPath: 'knowledge-base/KnowledgeBase/Mine/access.md',
       apply: (current: string) => current, // grant already present → no-op
     });
     const emitted: { paths: string[] }[] = [];
@@ -491,22 +495,22 @@ describe('LockingFilesystem — creator read grants on creation', () => {
         workflow,
         workspaceId: 'ws-feat',
         branch: 'feat',
-        user: USER,
+        user: USER, kbDirName: KB,
         creatorAccess,
         fileChanges: { emit: (c: { paths: string[] }) => emitted.push(c) } as never,
       },
     );
-    await fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
+    await fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
 
     // The seed's lock cycle still ran (acquired + released)...
     const locked = (workflow.acquireLock as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[2]);
-    expect(locked).toContain('KnowledgeBase/Mine/access.md');
+    expect(locked).toContain('knowledge-base/KnowledgeBase/Mine/access.md');
     // ...but the commit is scoped to the caller's path only.
     const commitPaths = (workflow.commitChanges as ReturnType<typeof vi.fn>).mock.calls[0][3];
-    expect(commitPaths).toEqual(['KnowledgeBase/Mine/doc.md']);
-    expect(emitted[0].paths).toEqual(['KnowledgeBase/Mine/doc.md']);
+    expect(commitPaths).toEqual(['knowledge-base/KnowledgeBase/Mine/doc.md']);
+    expect(emitted[0].paths).toEqual(['knowledge-base/KnowledgeBase/Mine/doc.md']);
     // The seeded file is untouched.
-    expect(await fs.readFile(path.join(root, 'KnowledgeBase/Mine/access.md'), 'utf-8')).toBe(
+    expect(await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/access.md'), 'utf-8')).toBe(
       seedContent,
     );
   });
@@ -523,34 +527,34 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // resets its retry ladder — the prior save's bytes would publish under
     // the wrong name. The seed lock must release UNTOUCHED (drop the lock
     // row, leave disk and queue exactly as they are).
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
     const priorSave = '---\nread:\n  - Alice <alice@example.com>\n---\nprior queued bytes\n';
-    await fs.writeFile(path.join(root, 'KnowledgeBase/Mine/access.md'), priorSave);
+    await fs.writeFile(path.join(root, 'knowledge-base/KnowledgeBase/Mine/access.md'), priorSave);
     const workflow = makeWorkflow();
     const creatorAccess = makeCreatorAccess();
     creatorAccess.planForCreate.mockResolvedValue({
       kind: 'seed-access-md',
-      wsRelPath: 'KnowledgeBase/Mine/access.md',
+      wsRelPath: 'knowledge-base/KnowledgeBase/Mine/access.md',
       apply: (current: string) => current, // grant already present → no-op
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
+    await fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
 
     // The batch's OWN committed path releases no-commit (clean — discard no-ops)...
     expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith(
-      'ws-feat', 'feat', 'KnowledgeBase/Mine/doc.md', USER,
+      'ws-feat', 'feat', 'knowledge-base/KnowledgeBase/Mine/doc.md', USER,
     );
     // ...but the merely-locked seed path releases UNTOUCHED — never the
     // enqueue, never the discard.
     expect(workflow.releaseLockUntouched).toHaveBeenCalledWith(
-      'ws-feat', 'feat', 'KnowledgeBase/Mine/access.md', USER,
+      'ws-feat', 'feat', 'knowledge-base/KnowledgeBase/Mine/access.md', USER,
     );
     expect(workflow.releaseLock).not.toHaveBeenCalled();
     expect(workflow.releaseLockNoCommit).not.toHaveBeenCalledWith(
-      'ws-feat', 'feat', 'KnowledgeBase/Mine/access.md', USER,
+      'ws-feat', 'feat', 'knowledge-base/KnowledgeBase/Mine/access.md', USER,
     );
   });
 
@@ -564,18 +568,18 @@ describe('LockingFilesystem — creator read grants on creation', () => {
       .mockResolvedValue({ acquired: false, lock: { holderUserId: 'bob', holderName: 'Bob' } });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
     await expect(
       fsLayer.writeFiles(
         [
-          { path: 'A.md', content: 'a' },
-          { path: 'B.md', content: 'b' },
+          { path: 'knowledge-base/A.md', content: 'a' },
+          { path: 'knowledge-base/B.md', content: 'b' },
         ],
         'batch',
       ),
     ).rejects.toThrow(/locked by Bob/);
-    expect(workflow.releaseLockUntouched).toHaveBeenCalledWith('ws-feat', 'feat', 'A.md', USER);
+    expect(workflow.releaseLockUntouched).toHaveBeenCalledWith('ws-feat', 'feat', 'knowledge-base/A.md', USER);
     expect(workflow.releaseLock).not.toHaveBeenCalled();
     expect(workflow.releaseLockNoCommit).not.toHaveBeenCalled();
   }, 10_000);
@@ -586,9 +590,9 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // loop read the pre-image under this very lock, so it can put it back —
     // after which the path is byte-identical to before the batch and must
     // release untouched (a prior save's queued bytes, if any, survive).
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
     const priorBytes = 'prior queued bytes\n';
-    const seedPath = 'KnowledgeBase/Mine/access.md';
+    const seedPath = 'knowledge-base/KnowledgeBase/Mine/access.md';
     await fs.writeFile(path.join(root, seedPath), priorBytes);
     const workflow = makeWorkflow();
     const creatorAccess = makeCreatorAccess();
@@ -599,7 +603,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
     // Fail the SEED write once (simulating a mid-write death that left
     // partial bytes); every other write — including the restore — passes
@@ -617,7 +621,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
         return original.call(this as LocalFilesystem, p, c, o);
       });
     try {
-      await fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
+      await fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
     } finally {
       spy.mockRestore();
     }
@@ -625,7 +629,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     expect(await fs.readFile(path.join(root, seedPath), 'utf-8')).toBe(priorBytes);
     // The failed seed stays OUT of the commit scope and releases untouched.
     const commitPaths = (workflow.commitChanges as ReturnType<typeof vi.fn>).mock.calls[0][3];
-    expect(commitPaths).toEqual(['KnowledgeBase/Mine/doc.md']);
+    expect(commitPaths).toEqual(['knowledge-base/KnowledgeBase/Mine/doc.md']);
     expect(workflow.releaseLockUntouched).toHaveBeenCalledWith('ws-feat', 'feat', seedPath, USER);
     expect(workflow.releaseLockNoCommit).not.toHaveBeenCalledWith(
       'ws-feat', 'feat', seedPath, USER,
@@ -640,9 +644,9 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // on disk as if they were real; discarding to HEAD would destroy a prior
     // save's queued bytes. The right restore is the pre-image read under the
     // seed's own lock.
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
     const priorBytes = 'prior queued bytes\n';
-    const seedPath = 'KnowledgeBase/Mine/access.md';
+    const seedPath = 'knowledge-base/KnowledgeBase/Mine/access.md';
     await fs.writeFile(path.join(root, seedPath), priorBytes);
     const workflow = makeWorkflow();
     (workflow.commitChanges as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -656,10 +660,10 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
     await expect(
-      fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch'),
+      fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch'),
     ).rejects.toThrow('commit exploded');
     // The landed grant was rolled back to the pre-image, byte-identical…
     expect(await fs.readFile(path.join(root, seedPath), 'utf-8')).toBe(priorBytes);
@@ -667,7 +671,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // batch's to discard), while the caller's own write releases via discard.
     expect(workflow.releaseLockUntouched).toHaveBeenCalledWith('ws-feat', 'feat', seedPath, USER);
     expect(workflow.releaseLockNoCommit).toHaveBeenCalledWith(
-      'ws-feat', 'feat', 'KnowledgeBase/Mine/doc.md', USER,
+      'ws-feat', 'feat', 'knowledge-base/KnowledgeBase/Mine/doc.md', USER,
     );
     expect(workflow.releaseLockNoCommit).not.toHaveBeenCalledWith(
       'ws-feat', 'feat', seedPath, USER,
@@ -679,8 +683,8 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // pre-image restore failed, so the path holds known-partial bytes. The
     // release must reset it to HEAD (releaseLockNoCommit) — never enqueue the
     // corrupt bytes as a commit, never leave them for the next acquirer.
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
-    const seedPath = 'KnowledgeBase/Mine/access.md';
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
+    const seedPath = 'knowledge-base/KnowledgeBase/Mine/access.md';
     await fs.writeFile(path.join(root, seedPath), 'prior\n');
     const workflow = makeWorkflow();
     const creatorAccess = makeCreatorAccess();
@@ -691,7 +695,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
     const original = LocalFilesystem.prototype.writeFile;
     const spy = vi
@@ -701,7 +705,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
         return original.call(this as LocalFilesystem, p, c, o);
       });
     try {
-      await fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
+      await fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
     } finally {
       spy.mockRestore();
     }
@@ -713,7 +717,7 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     );
     expect(workflow.releaseLock).not.toHaveBeenCalled();
     const commitPaths = (workflow.commitChanges as ReturnType<typeof vi.fn>).mock.calls[0][3];
-    expect(commitPaths).toEqual(['KnowledgeBase/Mine/doc.md']);
+    expect(commitPaths).toEqual(['knowledge-base/KnowledgeBase/Mine/doc.md']);
   });
 
   it('push-retry unwind: committed paths re-arm via releaseLock, a merely-locked seed stays untouched', async () => {
@@ -722,8 +726,8 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     // IS the push-retry vehicle), while the seed that never wrote must NOT be
     // swept into the same enqueue — its path may carry a prior save's queued
     // row that a fresh enqueue would re-attribute and reset.
-    await fs.mkdir(path.join(root, 'KnowledgeBase/Mine'), { recursive: true });
-    const seedPath = 'KnowledgeBase/Mine/access.md';
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase/Mine'), { recursive: true });
+    const seedPath = 'knowledge-base/KnowledgeBase/Mine/access.md';
     await fs.writeFile(path.join(root, seedPath), 'grant already present\n');
     const workflow = makeWorkflow();
     (workflow.commitChanges as ReturnType<typeof vi.fn>).mockRejectedValue(
@@ -737,13 +741,13 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
     await expect(
-      fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch'),
+      fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch'),
     ).rejects.toBeInstanceOf(PushNeedsAgentResolutionError);
     expect(workflow.releaseLock).toHaveBeenCalledWith(
-      'ws-feat', 'feat', 'KnowledgeBase/Mine/doc.md', USER,
+      'ws-feat', 'feat', 'knowledge-base/KnowledgeBase/Mine/doc.md', USER,
     );
     expect(workflow.releaseLockUntouched).toHaveBeenCalledWith('ws-feat', 'feat', seedPath, USER);
     expect(workflow.releaseLock).not.toHaveBeenCalledWith('ws-feat', 'feat', seedPath, USER);
@@ -755,16 +759,16 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     const creatorAccess = makeCreatorAccess();
     creatorAccess.planForCreate.mockResolvedValue({
       kind: 'seed-access-md',
-      wsRelPath: 'KnowledgeBase/Mine/access.md',
+      wsRelPath: 'knowledge-base/KnowledgeBase/Mine/access.md',
       apply: () => '---\nread:\n  - Alice <alice@example.com>\n---\n',
     });
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.writeFiles([{ path: 'KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
+    await fsLayer.writeFiles([{ path: 'knowledge-base/KnowledgeBase/Mine/doc.md', content: 'body' }], 'batch');
     const commitPaths = (workflow.commitChanges as ReturnType<typeof vi.fn>).mock.calls[0][3];
-    expect(commitPaths).toEqual(['KnowledgeBase/Mine/doc.md', 'KnowledgeBase/Mine/access.md']);
+    expect(commitPaths).toEqual(['knowledge-base/KnowledgeBase/Mine/doc.md', 'knowledge-base/KnowledgeBase/Mine/access.md']);
   });
 
   it('a planner failure never blocks the write', async () => {
@@ -773,9 +777,160 @@ describe('LockingFilesystem — creator read grants on creation', () => {
     creatorAccess.planForCreate.mockRejectedValue(new Error('planner down'));
     const fsLayer = new LockingFilesystem(
       { basePath: root, contained: true },
-      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, creatorAccess },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess },
     );
-    await fsLayer.writeFile('KnowledgeBase/new.md', 'x');
-    expect(await fs.readFile(path.join(root, 'KnowledgeBase/new.md'), 'utf-8')).toBe('x');
+    await fsLayer.writeFile('knowledge-base/KnowledgeBase/new.md', 'x');
+    expect(await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/new.md'), 'utf-8')).toBe('x');
+  });
+});
+
+describe('LockingFilesystem refuses to create anything outside the repository folder', () => {
+  // The bug this pins: the filesystem is rooted at the WORKSPACE dir, one level
+  // above the git clone, so a repo-relative path (`KnowledgeBase/…`, the shape
+  // every doc and URL shows) is "contained" and its bytes land BESIDE the
+  // repository. The release commit then finds nothing dirty and returns null,
+  // the tool reports success, and the explorer re-roots on the stray folder.
+  // The refusal has to fire before any side effect: no lock, no creator-grant
+  // plan, no validator call, no bytes on disk.
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkTmpRoot();
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const STRAY = 'KnowledgeBase/Reviews/PR-12.html';
+  const CORRECTED = 'knowledge-base/KnowledgeBase/Reviews/PR-12.html';
+
+  function makeCreatorAccess() {
+    return {
+      planForCreate: vi.fn().mockResolvedValue(null),
+      grantInExtractedFile: vi.fn().mockResolvedValue(null),
+      noteAccessFileWritten: vi.fn(),
+    };
+  }
+
+  function layer(workflow: IWorkflowService) {
+    const creatorAccess = makeCreatorAccess();
+    const validateWrite = vi.fn();
+    const fsLayer = new LockingFilesystem(
+      { basePath: root, contained: true },
+      { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB, creatorAccess, validateWrite },
+    );
+    return { fsLayer, creatorAccess, validateWrite };
+  }
+
+  async function expectRefused(
+    op: Promise<unknown>,
+    workflow: IWorkflowService,
+    creatorAccess: ReturnType<typeof makeCreatorAccess>,
+    validateWrite: ReturnType<typeof vi.fn>,
+  ): Promise<void> {
+    await expect(op).rejects.toBeInstanceOf(WorkflowValidationError);
+    // The corrected path is spelled out, under the clone folder.
+    await expect(op).rejects.toThrow('"knowledge-base/KnowledgeBase/Reviews');
+    // Refused before any side effect.
+    expect(workflow.acquireLock).not.toHaveBeenCalled();
+    expect(workflow.releaseLock).not.toHaveBeenCalled();
+    expect(workflow.releaseLockNoCommit).not.toHaveBeenCalled();
+    expect(workflow.commitChanges).not.toHaveBeenCalled();
+    expect(creatorAccess.planForCreate).not.toHaveBeenCalled();
+    expect(validateWrite).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(root, 'KnowledgeBase'))).rejects.toBeDefined();
+  }
+
+  it('writeFile', async () => {
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(fsLayer.writeFile(STRAY, '<p>review</p>'), workflow, creatorAccess, validateWrite);
+  });
+
+  it('appendFile', async () => {
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(fsLayer.appendFile('KnowledgeBase/Reviews/review.log', 'line\n'), workflow, creatorAccess, validateWrite);
+  });
+
+  it('writeFiles refuses the whole batch when one path is outside: nothing written, nothing locked', async () => {
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(
+      fsLayer.writeFiles(
+        [
+          { path: 'knowledge-base/KnowledgeBase/ok.md', content: 'fine' },
+          { path: STRAY, content: '<p>review</p>' },
+        ],
+        'batch',
+      ),
+      workflow,
+      creatorAccess,
+      validateWrite,
+    );
+    await expect(fs.access(path.join(root, 'knowledge-base/KnowledgeBase/ok.md'))).rejects.toBeDefined();
+  });
+
+  it('mkdir', async () => {
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(fsLayer.mkdir('KnowledgeBase/Reviews'), workflow, creatorAccess, validateWrite);
+  });
+
+  it('moveFile refuses a destination outside the repository and leaves the source in place', async () => {
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase'), { recursive: true });
+    await fs.writeFile(path.join(root, 'knowledge-base/KnowledgeBase/PR-12.html'), 'x');
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(
+      fsLayer.moveFile('knowledge-base/KnowledgeBase/PR-12.html', STRAY),
+      workflow,
+      creatorAccess,
+      validateWrite,
+    );
+    expect(await fs.readFile(path.join(root, 'knowledge-base/KnowledgeBase/PR-12.html'), 'utf-8')).toBe('x');
+  });
+
+  it('copyFile refuses a destination outside the repository', async () => {
+    await fs.mkdir(path.join(root, 'knowledge-base/KnowledgeBase'), { recursive: true });
+    await fs.writeFile(path.join(root, 'knowledge-base/KnowledgeBase/PR-12.html'), 'x');
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expectRefused(
+      fsLayer.copyFile('knowledge-base/KnowledgeBase/PR-12.html', STRAY),
+      workflow,
+      creatorAccess,
+      validateWrite,
+    );
+  });
+
+  it('the folder is matched as a whole segment: `knowledge-based/x.md` is outside too', async () => {
+    const workflow = makeWorkflow();
+    const { fsLayer } = layer(workflow);
+    await expect(fsLayer.writeFile('knowledge-based/x.md', 'x')).rejects.toBeInstanceOf(WorkflowValidationError);
+    expect(workflow.acquireLock).not.toHaveBeenCalled();
+  });
+
+  it('deleteFile still removes a file the old behaviour left beside the repository', async () => {
+    // Removal is deliberately not gated: an agent that discovers a stray it
+    // created before this guard existed must be able to clean it up.
+    await fs.mkdir(path.join(root, 'KnowledgeBase/Reviews'), { recursive: true });
+    await fs.writeFile(path.join(root, STRAY), 'stray');
+    const workflow = makeWorkflow();
+    const { fsLayer } = layer(workflow);
+    await fsLayer.deleteFile(STRAY);
+    await expect(fs.access(path.join(root, STRAY))).rejects.toBeDefined();
+  });
+
+  it('moveFile still rescues a stray INTO the repository', async () => {
+    await fs.mkdir(path.join(root, 'KnowledgeBase/Reviews'), { recursive: true });
+    await fs.writeFile(path.join(root, STRAY), 'stray');
+    await fs.mkdir(path.join(root, 'knowledge-base'), { recursive: true });
+    const workflow = makeWorkflow();
+    const { fsLayer } = layer(workflow);
+    await fsLayer.moveFile(STRAY, CORRECTED);
+    expect(await fs.readFile(path.join(root, CORRECTED), 'utf-8')).toBe('stray');
+    await expect(fs.access(path.join(root, STRAY))).rejects.toBeDefined();
   });
 });

--- a/packages/core-backend/src/modules/kb-fs/__tests__/locking-filesystem.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/locking-filesystem.test.ts
@@ -189,13 +189,20 @@ describe('LockingFilesystem — every mutating op runs acquire → super → rel
       { basePath: root, contained: true },
       { workflow, workspaceId: 'ws-feat', branch: 'feat', user: USER, kbDirName: KB },
     );
-    // Path traversal — Mastra's `contained: true` rejects this with a
-    // PermissionError. The lock must still go away so the next caller
-    // can edit a different file, but releaseLock (which would commit +
-    // push whatever partial state is on disk) must NOT fire — instead
-    // we use the no-commit variant so partial writes don't silently
-    // persist as committed changes.
-    await expect(fsLayer.writeFile('knowledge-base/../../escape.md', 'x')).rejects.toThrow();
+    // The underlying write dies (disk full, permissions, whatever). The lock
+    // must still go away so the next caller can edit a different file, but
+    // releaseLock (which would commit + push whatever partial state is on
+    // disk) must NOT fire — instead we use the no-commit variant so partial
+    // writes don't silently persist as committed changes.
+    const spy = vi
+      .spyOn(LocalFilesystem.prototype, 'writeFile')
+      .mockRejectedValue(new Error('disk exploded'));
+    try {
+      await expect(fsLayer.writeFile('knowledge-base/Boom.md', 'x')).rejects.toThrow('disk exploded');
+    } finally {
+      spy.mockRestore();
+    }
+    expect(workflow.acquireLock).toHaveBeenCalled();
     expect(workflow.releaseLockNoCommit).toHaveBeenCalled();
     expect(workflow.releaseLock).not.toHaveBeenCalled();
   });
@@ -903,6 +910,19 @@ describe('LockingFilesystem refuses to create anything outside the repository fo
       creatorAccess,
       validateWrite,
     );
+  });
+
+  it('a `..` under the prefix is refused before the lock: the bytes would land beside the clone', async () => {
+    // Containment is checked against the WORKSPACE dir, so the underlying
+    // filesystem would happily resolve `knowledge-base/../stray.md` to a file
+    // next to the clone. The prefix alone is not proof of being inside.
+    const workflow = makeWorkflow();
+    const { fsLayer, creatorAccess, validateWrite } = layer(workflow);
+    await expect(fsLayer.writeFile('knowledge-base/../stray.md', 'x')).rejects.toBeInstanceOf(WorkflowValidationError);
+    expect(workflow.acquireLock).not.toHaveBeenCalled();
+    expect(creatorAccess.planForCreate).not.toHaveBeenCalled();
+    expect(validateWrite).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(root, 'stray.md'))).rejects.toBeDefined();
   });
 
   it('the folder is matched as a whole segment: `knowledge-based/x.md` is outside too', async () => {

--- a/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
@@ -33,6 +33,12 @@ describe('isInsideRepo', () => {
     expect(isInsideRepo('knowledge-base//x.md', KB)).toBe(false);
   });
 
+  it('refuses backslashes anywhere: on Windows they separate segments too, and the commit layer rejects them', () => {
+    expect(isInsideRepo('knowledge-base/foo\\..\\..\\outside.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base\\KnowledgeBase\\x.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base/KnowledgeBase/a\\b.md', KB)).toBe(false);
+  });
+
   it('tolerates a trailing slash on a directory path', () => {
     expect(isInsideRepo('knowledge-base/', KB)).toBe(true);
     expect(isInsideRepo('knowledge-base/KnowledgeBase/Projects/', KB)).toBe(true);
@@ -75,5 +81,23 @@ describe('assertInsideRepo', () => {
   it('suggests the path with the traversal collapsed, back under the prefix', () => {
     expect(() => assertInsideRepo('knowledge-base/../stray.md', KB)).toThrow('"knowledge-base/stray.md"');
     expect(() => assertInsideRepo('knowledge-base/../../escape.md', KB)).toThrow('"knowledge-base/escape.md"');
+  });
+
+  it('suggests a forward-slash path for a backslash one', () => {
+    expect(() => assertInsideRepo('knowledge-base/foo\\..\\..\\outside.md', KB)).toThrow('"knowledge-base/outside.md"');
+    expect(() => assertInsideRepo('KnowledgeBase\\Reviews\\PR-12.html', KB)).toThrow('"knowledge-base/KnowledgeBase/Reviews/PR-12.html"');
+  });
+
+  it('never suggests a path that still climbs: a bare `..` corrects to the repository folder', () => {
+    for (const p of ['..', '../', '../..', '../../', 'knowledge-base/..']) {
+      let message = '';
+      try {
+        assertInsideRepo(p, KB);
+      } catch (e) {
+        message = (e as Error).message;
+      }
+      expect(message, p).toContain('Use "knowledge-base/" instead');
+      expect(message, p).not.toMatch(/Use "[^"]*\.\.[^"]*" instead/);
+    }
   });
 });

--- a/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { assertInsideRepo, isInsideRepo } from '../repo-path.js';
+import { WorkflowValidationError } from '../../../shared/domain-errors.js';
+
+const KB = 'knowledge-base';
+
+describe('isInsideRepo', () => {
+  it('accepts the repository folder and anything under it', () => {
+    expect(isInsideRepo('knowledge-base', KB)).toBe(true);
+    expect(isInsideRepo('knowledge-base/KnowledgeBase/Foo.md', KB)).toBe(true);
+    expect(isInsideRepo('knowledge-base/roles.yaml', KB)).toBe(true);
+  });
+
+  it('refuses a repo-relative path: it would land beside the repository, where git never looks', () => {
+    expect(isInsideRepo('KnowledgeBase/Reviews/PR-12.html', KB)).toBe(false);
+    expect(isInsideRepo('review.log', KB)).toBe(false);
+    expect(isInsideRepo('tmp/spill.txt', KB)).toBe(false);
+  });
+
+  it('matches the folder as a whole segment, not as a string prefix', () => {
+    expect(isInsideRepo('knowledge-based/x.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base-old/x.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base.bak', KB)).toBe(false);
+  });
+
+  it('refuses dressed-up forms of the prefix that the commit layer would reject anyway', () => {
+    expect(isInsideRepo('./knowledge-base/x.md', KB)).toBe(false);
+    expect(isInsideRepo('/knowledge-base/x.md', KB)).toBe(false);
+    expect(isInsideRepo('', KB)).toBe(false);
+  });
+});
+
+describe('assertInsideRepo', () => {
+  it('passes silently for a path inside the repository', () => {
+    expect(() => assertInsideRepo('knowledge-base/KnowledgeBase/Foo.md', KB)).not.toThrow();
+  });
+
+  it('throws a 400 that names the prefix and spells out the corrected path', () => {
+    let err: unknown;
+    try {
+      assertInsideRepo('KnowledgeBase/Reviews/PR-12.html', KB);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(WorkflowValidationError);
+    const e = err as WorkflowValidationError;
+    expect(e.status).toBe(400);
+    // The offending path, the rule, and the exact path to use instead: an
+    // agent reading this error can retry without guessing.
+    expect(e.message).toContain('"KnowledgeBase/Reviews/PR-12.html"');
+    expect(e.message).toContain('"knowledge-base/"');
+    expect(e.message).toContain('"knowledge-base/KnowledgeBase/Reviews/PR-12.html"');
+    expect(e.payload).toMatchObject({
+      kind: 'path-outside-repo',
+      path: 'KnowledgeBase/Reviews/PR-12.html',
+      kbDirName: KB,
+    });
+  });
+});

--- a/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
@@ -75,6 +75,9 @@ describe('assertInsideRepo', () => {
       kind: 'path-outside-repo',
       path: 'KnowledgeBase/Reviews/PR-12.html',
       kbDirName: KB,
+      // On its own as well: the pending-commits worker's notice reads it from
+      // here, because the message it keeps is truncated.
+      corrected: 'knowledge-base/KnowledgeBase/Reviews/PR-12.html',
     });
   });
 

--- a/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/repo-path.test.ts
@@ -23,6 +23,21 @@ describe('isInsideRepo', () => {
     expect(isInsideRepo('knowledge-base.bak', KB)).toBe(false);
   });
 
+  it('refuses traversal that starts under the prefix and climbs back out', () => {
+    // `knowledge-base/../stray.md` starts with the clone folder but resolves
+    // beside it: the containment check is against the WORKSPACE dir, so the
+    // filesystem would accept it and the bytes would land outside git.
+    expect(isInsideRepo('knowledge-base/../stray.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base/KnowledgeBase/../../stray.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base/./x.md', KB)).toBe(false);
+    expect(isInsideRepo('knowledge-base//x.md', KB)).toBe(false);
+  });
+
+  it('tolerates a trailing slash on a directory path', () => {
+    expect(isInsideRepo('knowledge-base/', KB)).toBe(true);
+    expect(isInsideRepo('knowledge-base/KnowledgeBase/Projects/', KB)).toBe(true);
+  });
+
   it('refuses dressed-up forms of the prefix that the commit layer would reject anyway', () => {
     expect(isInsideRepo('./knowledge-base/x.md', KB)).toBe(false);
     expect(isInsideRepo('/knowledge-base/x.md', KB)).toBe(false);
@@ -55,5 +70,10 @@ describe('assertInsideRepo', () => {
       path: 'KnowledgeBase/Reviews/PR-12.html',
       kbDirName: KB,
     });
+  });
+
+  it('suggests the path with the traversal collapsed, back under the prefix', () => {
+    expect(() => assertInsideRepo('knowledge-base/../stray.md', KB)).toThrow('"knowledge-base/stray.md"');
+    expect(() => assertInsideRepo('knowledge-base/../../escape.md', KB)).toThrow('"knowledge-base/escape.md"');
   });
 });

--- a/packages/core-backend/src/modules/kb-fs/locking-filesystem.ts
+++ b/packages/core-backend/src/modules/kb-fs/locking-filesystem.ts
@@ -44,6 +44,7 @@ import {
 import type { AuthUser, Change, IWorkflowService } from '@bevel-software/platform-shared';
 import { PushNeedsAgentResolutionError } from '../../shared/domain-errors.js';
 import type { FileChangeNotifier } from './file-change-notifier.js';
+import { assertInsideRepo } from './repo-path.js';
 import type { CreationGrantPlan, ICreatorAccess } from '../access-model/creator.js';
 
 /** How many times to retry a contended acquire before giving up. */
@@ -62,6 +63,16 @@ export interface LockingFilesystemContext {
   workspaceId: string;
   branch: string;
   user: AuthUser;
+  /**
+   * The clone folder at the workspace root (`knowledge-base`). The filesystem
+   * is rooted one level ABOVE the repository, so containment alone lets a
+   * repo-relative path (`KnowledgeBase/…`) land beside the clone, where git
+   * never sees it and the release commit quietly no-ops. Every op that
+   * creates or modifies bytes is refused unless its path starts with this
+   * folder; removals stay open so a stray the old behaviour left there can
+   * still be cleaned up.
+   */
+  kbDirName: string;
   /**
    * Optional pre-disk write validator. Invoked with the (workspace-relative
    * path, full content) of every WHOLE-FILE write BEFORE the bytes land. Throw
@@ -104,6 +115,7 @@ export class LockingFilesystem extends LocalFilesystem {
     content: FileContent,
     options?: WriteOptions,
   ): Promise<void> {
+    this.assertInsideRepo(inputPath);
     // Pre-disk gate (e.g. reject a roles.yaml edit that would lock out admins).
     // Runs OUTSIDE the lock so a refusal never acquires/holds one.
     this.lockContext.validateWrite?.(inputPath, content);
@@ -121,6 +133,7 @@ export class LockingFilesystem extends LocalFilesystem {
   }
 
   override async appendFile(inputPath: string, content: FileContent): Promise<void> {
+    this.assertInsideRepo(inputPath);
     return this.withLock(inputPath, () => super.appendFile(inputPath, content));
   }
 
@@ -129,12 +142,16 @@ export class LockingFilesystem extends LocalFilesystem {
   }
 
   override async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    this.assertInsideRepo(dest);
     // Lock on `dest`. `src` is read-only from this op's perspective — copy
     // creates a new file at dest without disturbing src on disk.
     return this.withLock(dest, () => super.copyFile(src, dest, options));
   }
 
   override async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    // Only the destination is gated: moving a stray INTO the repository is how
+    // a file the old behaviour left beside the clone gets rescued.
+    this.assertInsideRepo(dest);
     // A move mutates two paths: the source is deleted and the destination
     // is created. Only locking `dest` would let a concurrent writer hold
     // the source's lock and mutate it under us, and would also leave the
@@ -183,6 +200,9 @@ export class LockingFilesystem extends LocalFilesystem {
     deletes: string[] = [],
   ): Promise<Change | null> {
     const { workflow, workspaceId, branch, user } = this.lockContext;
+    // Fail the whole batch before any plan, validator or lock: one stray path
+    // must not let its siblings land while it silently misses git.
+    for (const w of writes) this.assertInsideRepo(w.path);
     // Creator read grants for the batch: transform new markdown files'
     // content in place, and fold any subtree access.md seeds into the SAME
     // atomic batch (deduped — several files landing in one new folder share
@@ -479,6 +499,7 @@ export class LockingFilesystem extends LocalFilesystem {
   }
 
   override async mkdir(inputPath: string, options?: { recursive?: boolean }): Promise<void> {
+    this.assertInsideRepo(inputPath);
     // Creator read grant: planned BEFORE the dir exists (the plan's
     // new-directory detection needs the pre-creation tree), seeded right
     // after — so the new folder's access.md names the acting user under
@@ -525,6 +546,15 @@ export class LockingFilesystem extends LocalFilesystem {
       'Recursive directory removal is not supported through the lock-aware filesystem. ' +
         'Delete files individually so each removal lands as its own change.',
     );
+  }
+
+  /**
+   * Refuse a path that would put bytes beside the repository instead of in
+   * it. Runs before any side effect (plan, validator, lock, disk) so a refusal
+   * leaves nothing behind. See `LockingFilesystemContext.kbDirName`.
+   */
+  private assertInsideRepo(inputPath: string): void {
+    assertInsideRepo(inputPath, this.lockContext.kbDirName);
   }
 
   /**

--- a/packages/core-backend/src/modules/kb-fs/repo-path.ts
+++ b/packages/core-backend/src/modules/kb-fs/repo-path.ts
@@ -34,7 +34,9 @@ export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
  * Refuse a workspace-relative path that would land outside the repository.
  * The message carries the corrected path so an agent can retry without
  * guessing; the payload carries a typed discriminator for callers that
- * switch on it.
+ * switch on it, plus the same corrected path on its own, for a consumer
+ * that cannot rely on the message surviving intact (the pending-commits
+ * worker stores a sanitized, truncated copy).
  */
 export function assertInsideRepo(wsPath: string, kbDirName: string): void {
   if (isInsideRepo(wsPath, kbDirName)) return;
@@ -49,6 +51,6 @@ export function assertInsideRepo(wsPath: string, kbDirName: string): void {
   throw new WorkflowValidationError(
     `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative, must start with "${kbDirName}/" and may not contain "." or ".." segments or backslashes. ` +
       `Use "${corrected}" instead. A file written without that prefix lands beside the repository, where it is never committed or pushed.`,
-    { kind: 'path-outside-repo', path: wsPath, kbDirName },
+    { kind: 'path-outside-repo', path: wsPath, kbDirName, corrected },
   );
 }

--- a/packages/core-backend/src/modules/kb-fs/repo-path.ts
+++ b/packages/core-backend/src/modules/kb-fs/repo-path.ts
@@ -1,0 +1,34 @@
+import { WorkflowValidationError } from '../../shared/domain-errors.js';
+
+/**
+ * Workspace-relative paths and the repository folder.
+ *
+ * A workspace directory holds the git clone as `<kbDirName>/` (plus transient
+ * scratch such as `tmp/`). The agent filesystem, the lock keys and the human
+ * editor all speak WORKSPACE-relative paths, so a path reaches git only when
+ * it starts with that folder. `KnowledgeBase/Foo.md` on its own is not a
+ * shorthand for `knowledge-base/KnowledgeBase/Foo.md`: it is a different
+ * location, beside the clone, that nothing commits and nothing pushes.
+ */
+
+/** True when `wsPath` is the repository folder or lies under it. */
+export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
+  return wsPath === kbDirName || wsPath.startsWith(`${kbDirName}/`);
+}
+
+/**
+ * Refuse a workspace-relative path that would land outside the repository.
+ * The message carries the corrected path so an agent can retry without
+ * guessing; the payload carries a typed discriminator for callers that
+ * switch on it.
+ */
+export function assertInsideRepo(wsPath: string, kbDirName: string): void {
+  if (isInsideRepo(wsPath, kbDirName)) return;
+  const stripped = wsPath.replace(/^(\.\/|\/)+/, '');
+  const corrected = isInsideRepo(stripped, kbDirName) ? stripped : `${kbDirName}/${stripped}`;
+  throw new WorkflowValidationError(
+    `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative and must start with "${kbDirName}/". ` +
+      `Use "${corrected}" instead. A file written without that prefix lands beside the repository, where it is never committed or pushed.`,
+    { kind: 'path-outside-repo', path: wsPath, kbDirName },
+  );
+}

--- a/packages/core-backend/src/modules/kb-fs/repo-path.ts
+++ b/packages/core-backend/src/modules/kb-fs/repo-path.ts
@@ -19,11 +19,12 @@ import { WorkflowValidationError } from '../../shared/domain-errors.js';
  * starts with the folder yet resolves beside it, and the filesystem's own
  * containment is against the WORKSPACE dir, so it would accept that path.
  * `.` and `..` segments (and empty ones from `//`) are therefore refused
- * outright, which also matches what the commit layer accepts. A single
- * trailing slash on a directory path is tolerated.
+ * outright, and so is any backslash: on Windows it separates segments too,
+ * so `foo\..\..` would climb the same way. Both match what the commit layer
+ * accepts. A single trailing slash on a directory path is tolerated.
  */
 export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
-  if (typeof wsPath !== 'string') return false;
+  if (typeof wsPath !== 'string' || wsPath.includes('\\')) return false;
   const segments = wsPath.replace(/\/$/, '').split('/');
   if (segments[0] !== kbDirName) return false;
   return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
@@ -37,15 +38,16 @@ export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
  */
 export function assertInsideRepo(wsPath: string, kbDirName: string): void {
   if (isInsideRepo(wsPath, kbDirName)) return;
-  // The suggestion collapses what made the path wrong: leading `./` or `/`,
-  // and any `..` climbing back out, so the agent gets a path it can use.
+  // The suggestion collapses what made the path wrong: backslashes, leading
+  // `./` or `/`, and any `..` climbing back out (a bare `..` included, so the
+  // suggestion is never itself a climb). The agent gets a path it can use.
   const normalized = path.posix
-    .normalize(String(wsPath).replace(/^(\.\/|\/)+/, ''))
-    .replace(/^(\.\.\/)+/, '')
+    .normalize(String(wsPath).replace(/\\/g, '/').replace(/^(\.\/|\/)+/, ''))
+    .replace(/^(\.\.(\/|$))+/, '')
     .replace(/^\.$/, '');
   const corrected = isInsideRepo(normalized, kbDirName) ? normalized : `${kbDirName}/${normalized}`;
   throw new WorkflowValidationError(
-    `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative, must start with "${kbDirName}/" and may not contain "." or ".." segments. ` +
+    `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative, must start with "${kbDirName}/" and may not contain "." or ".." segments or backslashes. ` +
       `Use "${corrected}" instead. A file written without that prefix lands beside the repository, where it is never committed or pushed.`,
     { kind: 'path-outside-repo', path: wsPath, kbDirName },
   );

--- a/packages/core-backend/src/modules/kb-fs/repo-path.ts
+++ b/packages/core-backend/src/modules/kb-fs/repo-path.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { WorkflowValidationError } from '../../shared/domain-errors.js';
 
 /**
@@ -11,9 +12,21 @@ import { WorkflowValidationError } from '../../shared/domain-errors.js';
  * location, beside the clone, that nothing commits and nothing pushes.
  */
 
-/** True when `wsPath` is the repository folder or lies under it. */
+/**
+ * True when `wsPath` is the repository folder or lies under it.
+ *
+ * Judged segment by segment, not by string prefix: `knowledge-base/../x.md`
+ * starts with the folder yet resolves beside it, and the filesystem's own
+ * containment is against the WORKSPACE dir, so it would accept that path.
+ * `.` and `..` segments (and empty ones from `//`) are therefore refused
+ * outright, which also matches what the commit layer accepts. A single
+ * trailing slash on a directory path is tolerated.
+ */
 export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
-  return wsPath === kbDirName || wsPath.startsWith(`${kbDirName}/`);
+  if (typeof wsPath !== 'string') return false;
+  const segments = wsPath.replace(/\/$/, '').split('/');
+  if (segments[0] !== kbDirName) return false;
+  return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
 }
 
 /**
@@ -24,10 +37,15 @@ export function isInsideRepo(wsPath: string, kbDirName: string): boolean {
  */
 export function assertInsideRepo(wsPath: string, kbDirName: string): void {
   if (isInsideRepo(wsPath, kbDirName)) return;
-  const stripped = wsPath.replace(/^(\.\/|\/)+/, '');
-  const corrected = isInsideRepo(stripped, kbDirName) ? stripped : `${kbDirName}/${stripped}`;
+  // The suggestion collapses what made the path wrong: leading `./` or `/`,
+  // and any `..` climbing back out, so the agent gets a path it can use.
+  const normalized = path.posix
+    .normalize(String(wsPath).replace(/^(\.\/|\/)+/, ''))
+    .replace(/^(\.\.\/)+/, '')
+    .replace(/^\.$/, '');
+  const corrected = isInsideRepo(normalized, kbDirName) ? normalized : `${kbDirName}/${normalized}`;
   throw new WorkflowValidationError(
-    `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative and must start with "${kbDirName}/". ` +
+    `"${wsPath}" is outside the knowledge base repository: paths are workspace-relative, must start with "${kbDirName}/" and may not contain "." or ".." segments. ` +
       `Use "${corrected}" instead. A file written without that prefix lands beside the repository, where it is never committed or pushed.`,
     { kind: 'path-outside-repo', path: wsPath, kbDirName },
   );

--- a/packages/core-backend/src/modules/tool-helpers/tool-context.ts
+++ b/packages/core-backend/src/modules/tool-helpers/tool-context.ts
@@ -69,6 +69,7 @@ export function createToolContextResolver(deps: ToolContextDeps): ResolveToolCon
                 workspaceId,
                 branch: branchForWorkspaceId(workspaceId),
                 user,
+                kbDirName: deps.kbDirName,
                 validateWrite: validateRolesWrite,
                 creatorAccess: deps.creatorAccess,
               },

--- a/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/pending-commits.worker.test.ts
@@ -13,6 +13,7 @@ import type {
   PendingCommit,
   PendingCommitsService,
 } from '../pending-commits.service.js';
+import { assertInsideRepo } from '../../kb-fs/repo-path.js';
 
 /**
  * Unit tests for the queue-draining worker. The service + workflow layers
@@ -20,6 +21,8 @@ import type {
  * applies per claimed row:
  *
  *   - Success → markSucceeded, nothing else.
+ *   - Failure because the path is outside the repository → needs_attention +
+ *     feedback notice at once, whatever the budgets say.
  *   - Failure inside transient budget → markTransientFailure, no recovery agent.
  *   - Failure outside transient budget but inside recovery budget → spawn agent.
  *   - Failure outside recovery budget → mark needs_attention + send feedback notice.
@@ -67,6 +70,16 @@ function makeWorkspaces(): WorkspaceProvider {
   return {
     knownWorkspaces: () => [{ id: 'ws-1', branch: 'feat/x' }],
   };
+}
+
+/** The error `commitFile` throws for a path beside the clone, as the real producer builds it. */
+function captureRefusal(wsPath: string): unknown {
+  try {
+    assertInsideRepo(wsPath, 'knowledge-base');
+  } catch (err) {
+    return err;
+  }
+  throw new Error(`expected assertInsideRepo to refuse "${wsPath}"`);
 }
 
 function makeFeedback(): ISystemNoticeSink {
@@ -212,6 +225,39 @@ describe('PendingCommitsWorker.drainOnce', () => {
     expect(call.message).toContain('ws-1');
     expect(call.message).toContain('Foo.md');
     expect(call.message).toContain('unrecoverable');
+    expect(call.message).toContain('alice@example.com');
+  });
+
+  it('a path-outside-repo refusal escalates at once: no retry, no recovery agent, the notice names the corrected path', async () => {
+    // A fresh row with both budgets untouched: any other failure would be
+    // retried. This one cannot change on retry (the bytes are beside the
+    // clone, where git never looks) and gives a recovery agent nothing to
+    // repair, so the ladder is skipped and the row is flagged immediately.
+    const row = makeRow({ path: 'KnowledgeBase/Reviews/PR-12.html', attempts: 0, recoveryAgentRuns: 0 });
+    (service.claimNext as ReturnType<typeof vi.fn>).mockResolvedValueOnce(row);
+    // The commit layer's own refusal, built by its producer so the shape the
+    // worker switches on cannot drift from what is actually thrown.
+    workflow.runPendingCommit.mockRejectedValueOnce(captureRefusal('KnowledgeBase/Reviews/PR-12.html'));
+
+    await worker.drainOnce();
+
+    expect(service.markTransientFailure).not.toHaveBeenCalled();
+    expect(service.markRecoveryStarted).not.toHaveBeenCalled();
+    expect(recoveryAgent.run).not.toHaveBeenCalled();
+    // `last_error` gets the sanitized message (truncated to fit the column).
+    expect(service.markNeedsAttention).toHaveBeenCalledWith(
+      'row-1',
+      expect.stringContaining('"KnowledgeBase/Reviews/PR-12.html" is outside the knowledge base repository'),
+    );
+    expect(feedback.send).toHaveBeenCalledTimes(1);
+    const call = (feedback.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(call.source).toBe('system');
+    expect(call.user).toEqual(RECOVERY_BOT);
+    expect(call.message).toContain('outside the repository');
+    expect(call.message).toContain('Path:      KnowledgeBase/Reviews/PR-12.html');
+    // The correction survives the truncation: it rides on the error payload,
+    // not on the message.
+    expect(call.message).toContain('Use instead: knowledge-base/KnowledgeBase/Reviews/PR-12.html');
     expect(call.message).toContain('alice@example.com');
   });
 

--- a/packages/core-backend/src/modules/workflow/agent-tools/__tests__/workflow.tools.test.ts
+++ b/packages/core-backend/src/modules/workflow/agent-tools/__tests__/workflow.tools.test.ts
@@ -42,6 +42,13 @@ const workflowService = {
     calls.push(['createBranch', ws, name]);
     return { name, isProtected: false, ahead: 0, behind: 0, hasRemote: true };
   },
+  acquireLock: async (ws: string, branch: string, path: string) => {
+    calls.push(['acquireLock', ws, branch, path]);
+    return { acquired: true, lock: { branch, path, holderUserId: 'user-A', holderName: 'N' } };
+  },
+  releaseLock: async (ws: string, branch: string, path: string) => {
+    calls.push(['releaseLock', ws, branch, path]);
+  },
 } as never;
 const events = {
   emit: (p: unknown) => {
@@ -52,15 +59,18 @@ const events = {
 
 const internalToken = new InternalTokenService({ secret: 's' });
 let httpServer: HttpServer | undefined;
+/** The registry the tools were mounted into, so a test can inspect their definitions. */
+let registryRef: ToolRegistry | undefined;
 
 async function start(): Promise<string> {
   const registry = new ToolRegistry();
+  registryRef = registry;
   const toolAuth = createToolAuthMiddleware(externalApiKeyService, internalToken);
   const resolve = createToolContextResolver({ authService, workspaceService, workflowService, events, kbDirName: 'knowledge-base', creatorAccess: { planForCreate: async () => null, grantInExtractedFile: async () => null, noteAccessFileWritten: () => {} } });
   const toolHandler = createToolHandlerFactory(resolve);
 
   const router = express.Router();
-  registerWorkflowTools(registry, router, toolAuth, toolHandler);
+  registerWorkflowTools(registry, router, toolAuth, toolHandler, 'knowledge-base');
   router.use(createManualRoutes(registry, toolAuth));
 
   const app = express();
@@ -188,5 +198,45 @@ describe('registerWorkflowTools', () => {
     expect(internal).toContain('commit_change');
     expect(external).toContain('commit_change');
     expect(external).not.toContain('switch_branch'); // internal-only
+  });
+});
+
+describe('save_file and the repository folder', () => {
+  // `save_file` commits whatever is on disk at `path` through the lock
+  // protocol, bypassing the locking filesystem's own guard. A path without the
+  // clone-folder prefix names a file git can never see, so it is refused here,
+  // before a lock is taken, with the same corrected-path message the write
+  // tools give.
+  it('refuses a repo-relative path before taking any lock', async () => {
+    const base = await start();
+    const res = await post(`${base}/api/agent/tools/save_file`, writeTok(), {
+      path: 'KnowledgeBase/Reviews/PR-12.html',
+      branch: WS,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('"knowledge-base/KnowledgeBase/Reviews/PR-12.html"');
+    expect(calls.some((c) => c[0] === 'acquireLock')).toBe(false);
+  });
+
+  it('schedules a prefixed path as before', async () => {
+    const base = await start();
+    const res = await post(`${base}/api/agent/tools/save_file`, writeTok(), {
+      path: 'knowledge-base/KnowledgeBase/Reviews/PR-12.html',
+      branch: WS,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ saved: true, queued: true });
+    expect(calls).toContainEqual(['acquireLock', WS, WS, 'knowledge-base/KnowledgeBase/Reviews/PR-12.html']);
+    expect(calls).toContainEqual(['releaseLock', WS, WS, 'knowledge-base/KnowledgeBase/Reviews/PR-12.html']);
+  });
+
+  it('describes the prefix on its path input', async () => {
+    await start();
+    const tools = await registryRef!.listInternal();
+    const def = tools.find((t) => t.name === 'save_file');
+    // `toolDef` wraps a tool's inputs under a single `body` property.
+    const body = (def!.inputs as { properties: { body: { properties: Record<string, { description?: string }> } } }).properties.body;
+    expect(body.properties.path.description).toContain('`knowledge-base/`');
   });
 });

--- a/packages/core-backend/src/modules/workflow/agent-tools/__tests__/workflow.tools.test.ts
+++ b/packages/core-backend/src/modules/workflow/agent-tools/__tests__/workflow.tools.test.ts
@@ -219,6 +219,15 @@ describe('save_file and the repository folder', () => {
     expect(calls.some((c) => c[0] === 'acquireLock')).toBe(false);
   });
 
+  it('answers a missing path with a 400, not a crash', async () => {
+    const base = await start();
+    const res = await post(`${base}/api/agent/tools/save_file`, writeTok(), { branch: WS });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/path/i);
+    expect(calls.some((c) => c[0] === 'acquireLock')).toBe(false);
+  });
+
   it('schedules a prefixed path as before', async () => {
     const base = await start();
     const res = await post(`${base}/api/agent/tools/save_file`, writeTok(), {

--- a/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
+++ b/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
@@ -251,6 +251,9 @@ export function registerWorkflowTools(
       // protocol, bypassing the locking filesystem's own guard. A path without
       // the clone-folder prefix names a file git can never see: refuse it
       // before a lock is taken, with the same corrected-path message.
+      if (typeof path !== 'string' || path.length === 0) {
+        throw new ToolError('`path` is required and must be a non-empty string.', 400);
+      }
       assertInsideRepo(path, kbDirName);
       const workspaceId = workspaceIdForBranch(branch);
       const acquired = await ctx.workflowService.acquireLock(workspaceId, branch, path, ctx.user);

--- a/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
+++ b/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
@@ -6,6 +6,7 @@ import { toolDef, withBranchInput } from '../../tool-helpers/tool-def.js';
 import type { ToolHandlerFactory } from '../../tool-helpers/tool-handler.js';
 import { requireInternalSource } from '../../tool-auth/tool-auth.middleware.js';
 import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
+import { assertInsideRepo } from '../../kb-fs/repo-path.js';
 
 // A function, not a constant: the branch model is applied during boot, and a
 // module-scope capture would freeze this at the empty set that exists before it.
@@ -118,6 +119,8 @@ export function registerWorkflowTools(
   router: Router,
   toolAuth: RequestHandler,
   toolHandler: ToolHandlerFactory,
+  /** The clone folder at the workspace root; `save_file` refuses a path outside it. */
+  kbDirName: string,
 ): void {
   const mount = (spec: {
     name: string;
@@ -221,7 +224,13 @@ export function registerWorkflowTools(
       '`{ saved: false, reason }` rather than throwing. The commit lands asynchronously.',
     inputs: {
       type: 'object',
-      properties: { path: { type: 'string', minLength: 1, description: 'Workspace-relative path (as write_file expects).' } },
+      properties: {
+        path: {
+          type: 'string',
+          minLength: 1,
+          description: `Workspace-relative path, as write_file expects: starts with \`${kbDirName}/\` (e.g. \`${kbDirName}/KnowledgeBase/Foo.md\`).`,
+        },
+      },
       required: ['path'],
       additionalProperties: false,
     },
@@ -238,6 +247,11 @@ export function registerWorkflowTools(
     handler: async (args, ctx: ToolContext) => {
       const path = args.path as string;
       const branch = args.branch as string;
+      // This tool commits whatever is on disk at `path` through the lock
+      // protocol, bypassing the locking filesystem's own guard. A path without
+      // the clone-folder prefix names a file git can never see: refuse it
+      // before a lock is taken, with the same corrected-path message.
+      assertInsideRepo(path, kbDirName);
       const workspaceId = workspaceIdForBranch(branch);
       const acquired = await ctx.workflowService.acquireLock(workspaceId, branch, path, ctx.user);
       if (!acquired.acquired) {

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type { AuthUser } from '@bevel-software/platform-shared';
+import type { WorkspaceService } from '../../../workspace/workspace.service.js';
+import { WorkflowHooks } from '../../workflow-hooks.js';
+import { GitService } from '../git.service.js';
+import { WorkflowValidationError } from '../../../../shared/domain-errors.js';
+
+/**
+ * `commitFile` on a path whose bytes sit BESIDE the repository.
+ *
+ * The workspace dir holds the clone as `knowledge-base/`. A caller that
+ * writes a workspace-relative path without that prefix puts the file next to
+ * the clone, where `git status` inside the clone reports it clean. Before,
+ * `commitFile` read that as "nothing to commit" and returned null, so the
+ * write was reported as landed while git never saw it. Now it throws, and the
+ * pending-commits ladder escalates the row instead of dropping it.
+ *
+ * The three honest null cases must survive unchanged: a clean committed path,
+ * a path that exists nowhere (a queued re-apply of a committed deletion), and
+ * a repo-relative path some internal callers pass directly.
+ */
+
+const execFileAsync = promisify(execFile);
+const KB = 'knowledge-base';
+
+const USER: AuthUser = { id: 'u1', email: 'alice@example.com', name: 'Alice' };
+
+async function mkTmpRoot(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'bevel-git-stray-'));
+}
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Test',
+  GIT_AUTHOR_EMAIL: 't@x.com',
+  GIT_COMMITTER_NAME: 'Test',
+  GIT_COMMITTER_EMAIL: 't@x.com',
+};
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, env: GIT_ENV });
+  return stdout.toString().trim();
+}
+
+async function seedWorkspace(root: string, workspaceId: string): Promise<{ workspaceDir: string; repo: string }> {
+  const workspaceDir = path.join(root, workspaceId);
+  const repo = path.join(workspaceDir, KB);
+  await fs.mkdir(repo, { recursive: true });
+  await runGit(repo, ['init', '-b', 'main']);
+  await runGit(repo, ['config', 'user.email', 't@x.com']);
+  await runGit(repo, ['config', 'user.name', 'Test']);
+  await runGit(repo, ['config', 'gc.auto', '0']);
+  // One committed file so HEAD exists and the "clean path" cases have something to be clean about.
+  await fs.mkdir(path.join(repo, 'Knowledge'), { recursive: true });
+  await fs.writeFile(path.join(repo, 'Knowledge/A.md'), 'a\n');
+  await runGit(repo, ['add', 'Knowledge/A.md']);
+  await runGit(repo, ['commit', '-m', 'seed']);
+  return { workspaceDir, repo };
+}
+
+function stubWorkspaceService(workspaceId: string, workspaceDir: string): WorkspaceService {
+  return {
+    getWorkspacePath: async (id: string) => {
+      if (id !== workspaceId) throw new Error(`unexpected workspace ${id}`);
+      return workspaceDir;
+    },
+  } as unknown as WorkspaceService;
+}
+
+describe('GitService.commitFile with bytes beside the repository', () => {
+  let root: string;
+  const workspaceId = 'ws-stray';
+
+  beforeEach(async () => {
+    root = await mkTmpRoot();
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  it('throws instead of returning null when the file exists at the workspace root and not in the clone', async () => {
+    const { workspaceDir, repo } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    // The prefix-less write the agent made: beside the clone, not inside it.
+    await fs.mkdir(path.join(workspaceDir, 'KnowledgeBase/Reviews'), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, 'KnowledgeBase/Reviews/PR-12.html'), '<p>review</p>');
+    const headBefore = await runGit(repo, ['rev-parse', 'HEAD']);
+
+    const attempt = svc.commitFile(workspaceId, USER, 'KnowledgeBase/Reviews/PR-12.html');
+    await expect(attempt).rejects.toBeInstanceOf(WorkflowValidationError);
+    await expect(attempt).rejects.toThrow('"knowledge-base/KnowledgeBase/Reviews/PR-12.html"');
+
+    // Nothing landed, and the stray is left where it is for someone to recover.
+    expect(await runGit(repo, ['rev-parse', 'HEAD'])).toBe(headBefore);
+    expect(await fs.readFile(path.join(workspaceDir, 'KnowledgeBase/Reviews/PR-12.html'), 'utf-8')).toBe('<p>review</p>');
+  });
+
+  it('still returns null for a clean, committed path (the honest no-op)', async () => {
+    const { workspaceDir } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    expect(await svc.commitFile(workspaceId, USER, `${KB}/Knowledge/A.md`)).toBeNull();
+  });
+
+  it('still returns null for a path that exists nowhere (a queued re-apply of a committed deletion)', async () => {
+    const { workspaceDir } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    expect(await svc.commitFile(workspaceId, USER, `${KB}/Knowledge/Gone.md`)).toBeNull();
+  });
+
+  it('still returns null for a repo-relative path that is clean inside the clone (the form internal callers pass)', async () => {
+    const { workspaceDir } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    expect(await svc.commitFile(workspaceId, USER, 'Knowledge/A.md')).toBeNull();
+  });
+
+  it('still commits a prefixed path inside the clone', async () => {
+    const { workspaceDir, repo } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    await fs.writeFile(path.join(repo, 'Knowledge/B.md'), 'b\n');
+    const committed = await svc.commitFile(workspaceId, USER, `${KB}/Knowledge/B.md`);
+    expect(committed).not.toBeNull();
+    expect(committed!.authorEmail).toBe('alice@example.com');
+    expect(await runGit(repo, ['log', '--oneline'])).toMatch(/^\S+ .*\n\S+ seed$/);
+  });
+});

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
@@ -119,6 +119,35 @@ describe('GitService.commitFile with bytes beside the repository', () => {
     expect(await svc.commitFile(workspaceId, USER, 'Knowledge/A.md')).toBeNull();
   });
 
+  it('still returns null for a repo-relative path when the clone has that file too, even with a same-named file at the workspace root', async () => {
+    // Not provably stray: the clone holds `Knowledge/A.md` and it is clean, so
+    // a repo-relative caller's no-op stays honest whatever else sits beside
+    // the clone under the same name.
+    const { workspaceDir } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    await fs.mkdir(path.join(workspaceDir, 'Knowledge'), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, 'Knowledge/A.md'), 'a copy beside the clone\n');
+    expect(await svc.commitFile(workspaceId, USER, 'Knowledge/A.md')).toBeNull();
+  });
+
+  it('does not mistake an unreadable stray for an absent one', async () => {
+    // Only ENOENT means "nothing there". Any other stat failure must surface,
+    // or a stray the process cannot read is silently reported as committed.
+    if (process.getuid?.() === 0) return; // root ignores mode bits; nothing to prove here
+    const { workspaceDir } = await seedWorkspace(root, workspaceId);
+    const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
+    const strayDir = path.join(workspaceDir, 'KnowledgeBase');
+    await fs.mkdir(strayDir, { recursive: true });
+    await fs.writeFile(path.join(strayDir, 'PR-12.html'), 'x');
+    await fs.chmod(strayDir, 0o000);
+    try {
+      const attempt = svc.commitFile(workspaceId, USER, 'KnowledgeBase/PR-12.html');
+      await expect(attempt).rejects.toMatchObject({ code: 'EACCES' });
+    } finally {
+      await fs.chmod(strayDir, 0o755);
+    }
+  });
+
   it('still commits a prefixed path inside the clone', async () => {
     const { workspaceDir, repo } = await seedWorkspace(root, workspaceId);
     const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.commitFile.strayPath.test.ts
@@ -133,7 +133,9 @@ describe('GitService.commitFile with bytes beside the repository', () => {
   it('does not mistake an unreadable stray for an absent one', async () => {
     // Only ENOENT means "nothing there". Any other stat failure must surface,
     // or a stray the process cannot read is silently reported as committed.
-    if (process.getuid?.() === 0) return; // root ignores mode bits; nothing to prove here
+    // root ignores mode bits, and Windows has none to set (`chmod` there only
+    // toggles read-only, so the stat below still succeeds): nothing to prove.
+    if (process.getuid?.() === 0 || process.platform === 'win32') return;
     const { workspaceDir } = await seedWorkspace(root, workspaceId);
     const svc = new GitService(stubWorkspaceService(workspaceId, workspaceDir), new WorkflowHooks(), KB);
     const strayDir = path.join(workspaceDir, 'KnowledgeBase');

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -17,6 +17,7 @@ import type { WorkflowHooks, CommitValidationContext } from '../workflow-hooks.j
 import type { IAccessControl } from '../../access/access-control.interface.js';
 import { AccessDeniedError } from '../../access-model/access-errors.js';
 import { WorkspaceMutex } from '../../kb-fs/mutex.js';
+import { assertInsideRepo } from '../../kb-fs/repo-path.js';
 import { cloneTrackingConfigArgs, SAFE_IMPLICIT_FETCH_ARGS } from '../../kb-fs/clone-config.js';
 import {
   assertValidBranchName,
@@ -928,7 +929,10 @@ export class GitService implements IGitService {
       const { stdout: scoped } = await this.git(cwd, [
         'status', '--porcelain=v1', '--', repoRelativePath,
       ]);
-      if (!scoped.trim()) return null;
+      if (!scoped.trim()) {
+        await this.assertNoBytesBesideRepo(workspaceId, relativePath, repoRelativePath);
+        return null;
+      }
 
       // **No access check at commit time.** Per the "disk is the source of
       // truth" rule, by the time content is on disk it must not be rejected.
@@ -2381,6 +2385,36 @@ export class GitService implements IGitService {
       if (/does not exist in|exists on disk, but not in/.test(stderr)) return null;
       throw err;
     }
+  }
+
+  /**
+   * A clean `git status` for a path has two honest readings (already
+   * committed; a queued re-apply of something that landed) and one dishonest
+   * one: the bytes exist, but BESIDE the repository, because a caller wrote a
+   * workspace-relative path without the `<kbDirName>/` prefix. Git never sees
+   * that file, so returning null would report "nothing to commit" for a write
+   * that silently never landed. Throw instead; the pending-commits ladder
+   * escalates the row to a needs-attention notice rather than dropping it.
+   *
+   * Only a path that carried no prefix can be a stray (a prefixed one resolves
+   * inside the clone by construction), and only when something is actually on
+   * disk at the workspace-relative location. A repo-relative path some
+   * internal callers pass directly (`Knowledge/A.md`) has nothing at
+   * `<workspace>/Knowledge/A.md` and keeps its null.
+   */
+  private async assertNoBytesBesideRepo(
+    workspaceId: string,
+    relativePath: string,
+    repoRelativePath: string,
+  ): Promise<void> {
+    if (relativePath !== repoRelativePath) return;
+    const workspaceDir = await this.workspaceService.getWorkspacePath(workspaceId);
+    try {
+      await fs.stat(path.join(workspaceDir, relativePath));
+    } catch {
+      return;
+    }
+    assertInsideRepo(relativePath, this.kbDirName);
   }
 
   private async repoDir(workspaceId: string): Promise<string> {

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -245,6 +245,23 @@ async function synthesizeUntrackedSideDiff(
   }
 }
 
+/**
+ * `stat` for the stray check: false only when nothing can be there (ENOENT,
+ * or ENOTDIR when a parent segment is a file). Permission and I/O failures
+ * propagate: treating them as "absent" would let an unreadable stray pass as
+ * committed.
+ */
+async function existsForCommitCheck(absolutePath: string): Promise<boolean> {
+  try {
+    await fs.stat(absolutePath);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+    throw err;
+  }
+}
+
 export class GitService implements IGitService {
   // Per-workspace fetch state, kept OUTSIDE the workspace mutex on purpose.
   // `git fetch` only writes `refs/remotes/origin/*` and packs new objects —
@@ -930,7 +947,7 @@ export class GitService implements IGitService {
         'status', '--porcelain=v1', '--', repoRelativePath,
       ]);
       if (!scoped.trim()) {
-        await this.assertNoBytesBesideRepo(workspaceId, relativePath, repoRelativePath);
+        await this.assertNoBytesBesideRepo(workspaceId, cwd, relativePath, repoRelativePath);
         return null;
       }
 
@@ -2396,24 +2413,25 @@ export class GitService implements IGitService {
    * that silently never landed. Throw instead; the pending-commits ladder
    * escalates the row to a needs-attention notice rather than dropping it.
    *
-   * Only a path that carried no prefix can be a stray (a prefixed one resolves
-   * inside the clone by construction), and only when something is actually on
-   * disk at the workspace-relative location. A repo-relative path some
-   * internal callers pass directly (`Knowledge/A.md`) has nothing at
-   * `<workspace>/Knowledge/A.md` and keeps its null.
+   * The stray has to be PROVABLE, because some callers pass repo-relative
+   * paths on purpose (the decline-revert flow, the merge-time `roles.yaml`
+   * preservation): bytes at the workspace-relative location AND nothing at
+   * the same repo-relative location inside the clone. A clean, committed
+   * `roles.yaml` keeps its null even if something of that name sits beside the
+   * clone, so an unrelated stray cannot abort a merge. Only ENOENT (or a
+   * parent that is not a directory) means "absent"; any other stat failure
+   * surfaces, so an unreadable stray is never reported as committed.
    */
   private async assertNoBytesBesideRepo(
     workspaceId: string,
+    repoDir: string,
     relativePath: string,
     repoRelativePath: string,
   ): Promise<void> {
     if (relativePath !== repoRelativePath) return;
     const workspaceDir = await this.workspaceService.getWorkspacePath(workspaceId);
-    try {
-      await fs.stat(path.join(workspaceDir, relativePath));
-    } catch {
-      return;
-    }
+    if (!(await existsForCommitCheck(path.join(workspaceDir, relativePath)))) return;
+    if (await existsForCommitCheck(path.join(repoDir, repoRelativePath))) return;
     assertInsideRepo(relativePath, this.kbDirName);
   }
 

--- a/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.worker.ts
@@ -26,6 +26,7 @@ import type {
 } from './pending-commits.service.js';
 import { BACKOFF_MS, N_RECOVERY, N_TRANSIENT } from './pending-commits.service.js';
 import { sanitizeError } from './sanitize-error.js';
+import { WorkflowDomainError } from '../../shared/domain-errors.js';
 
 /**
  * Where the worker escalates terminal failures — the narrow, workflow-owned
@@ -276,6 +277,8 @@ export class PendingCommitsWorker {
   /**
    * Process a single claimed row. Outcome paths (see plan §lifecycle):
    *   - commit + push succeeds → delete the row.
+   *   - throws because the path is outside the repository → markNeedsAttention
+   *     + feedback notice at once (no retry can change it, see below).
    *   - throws, transient budget remains → markTransientFailure.
    *   - throws, transient exhausted, recovery budget remains → spawn agent.
    *   - throws, recovery exhausted → markNeedsAttention + feedback notice.
@@ -303,6 +306,19 @@ export class PendingCommitsWorker {
       // contain credentialed URLs ("https://x-access-token:ghp_…@…"); we
       // can't undo a persisted leak, so mask before any of them sees it.
       const message = sanitizeError(err);
+
+      const corrected = pathOutsideRepoCorrection(err);
+      if (corrected !== null) {
+        // The bytes sit BESIDE the clone (a workspace-relative path without
+        // the clone-folder prefix), so git will never see them: no retry can
+        // succeed, and a recovery agent has no commit to repair. Every attempt
+        // would throw this same refusal, so escalate now, with the corrected
+        // path in the notice, instead of spending the transient budget and
+        // N_RECOVERY agent runs to reach the same row state.
+        await this.escalate(row, message, strayPathNotice(row, message, corrected), 'path outside the repository');
+        return;
+      }
+
       const nextAttempts = row.attempts + 1;
 
       if (nextAttempts < N_TRANSIENT) {
@@ -346,28 +362,74 @@ export class PendingCommitsWorker {
       }
 
       // Recovery budget exhausted — escalate.
-      await this.deps.service.markNeedsAttention(row.id, message);
-      console.error(
-        `[pending-commits] TERMINAL ws=${row.workspaceId} branch=${row.branch} path=${row.path} after ${N_RECOVERY} recovery runs: ${message}`,
-      );
-      try {
-        await this.deps.feedback.send({
-          source: 'system',
-          user: this.deps.recoveryBot,
-          message: terminalFailureNotice(row, message),
-        });
-      } catch (feedbackErr) {
-        // Don't let a feedback-sink hiccup mask the underlying terminal
-        // failure — the row is already `needs_attention` and the next
-        // process restart will keep logging it. Just note that the
-        // notice didn't reach the dashboard.
-        console.error(
-          `[pending-commits] failed to emit terminal-failure feedback notice for ws=${row.workspaceId} path=${row.path}:`,
-          sanitizeError(feedbackErr),
-        );
-      }
+      await this.escalate(row, message, terminalFailureNotice(row, message), `after ${N_RECOVERY} recovery runs`);
     }
   }
+
+  /**
+   * The last step of every terminal path: flag the row `needs_attention`
+   * and tell the dashboard. `why` is the log line's reason; `notice` is the
+   * body the admin reads.
+   */
+  private async escalate(row: PendingCommit, message: string, notice: string, why: string): Promise<void> {
+    await this.deps.service.markNeedsAttention(row.id, message);
+    console.error(
+      `[pending-commits] TERMINAL ws=${row.workspaceId} branch=${row.branch} path=${row.path} ${why}: ${message}`,
+    );
+    try {
+      await this.deps.feedback.send({
+        source: 'system',
+        user: this.deps.recoveryBot,
+        message: notice,
+      });
+    } catch (feedbackErr) {
+      // Don't let a feedback-sink hiccup mask the underlying terminal
+      // failure — the row is already `needs_attention` and the next
+      // process restart will keep logging it. Just note that the
+      // notice didn't reach the dashboard.
+      console.error(
+        `[pending-commits] failed to emit terminal-failure feedback notice for ws=${row.workspaceId} path=${row.path}:`,
+        sanitizeError(feedbackErr),
+      );
+    }
+  }
+}
+
+/**
+ * The commit layer's refusal of a path whose bytes sit beside the clone
+ * rather than in it (`kb-fs/repo-path.ts`): the corrected path it carries,
+ * or null for any other error. Read from the payload, not the message: the
+ * message the worker keeps is sanitized and truncated to fit `last_error`,
+ * and the correction is what gets cut. Deterministic: the same row throws
+ * it on every attempt.
+ */
+function pathOutsideRepoCorrection(err: unknown): string | null {
+  if (!(err instanceof WorkflowDomainError) || err.payload?.kind !== 'path-outside-repo') return null;
+  const corrected = err.payload.corrected;
+  return typeof corrected === 'string' && corrected.length > 0 ? corrected : '(see error)';
+}
+
+function strayPathNotice(row: PendingCommit, error: string, corrected: string): string {
+  return [
+    '[pending_commits] Commit refused: the file is outside the repository.',
+    '',
+    `Workspace: ${row.workspaceId}`,
+    `Branch:    ${row.branch}`,
+    `Path:      ${row.path}`,
+    `Use instead: ${corrected}`,
+    `Original author: ${row.authorEmail}`,
+    `Queued at: ${row.queuedAt.toISOString()}`,
+    `Error: ${error}`,
+    '',
+    'The bytes were written beside the git clone (a workspace-relative path',
+    'without the clone-folder prefix), so git never sees them. Nothing was',
+    'committed, retrying cannot change that, and no recovery agent was run.',
+    '',
+    'Resolve manually:',
+    `  - move the file to "${corrected}" and save it again, or delete it if it`,
+    '    should be discarded',
+    '  - then delete the row from pending_commits.',
+  ].join('\n');
 }
 
 function terminalFailureNotice(row: PendingCommit, error: string): string {

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -1065,3 +1065,48 @@ describe('branch is a required parameter in the tool contract', () => {
     }
   });
 });
+
+/**
+ * The tools are rooted at the WORKSPACE dir, one level above the git clone, so
+ * a path has to start with the clone folder to reach git at all. Every place an
+ * agent reads before choosing a path says so, in the `path` input itself rather
+ * than only in prose it may not read: the root listing (where the folder is
+ * discoverable) and each content-writing tool.
+ */
+describe('path inputs tell the agent about the repository folder', () => {
+  // `toolDef` wraps a tool's inputs under a single `body` property.
+  const inputDescription = (def: { inputs?: unknown } | undefined, ...keys: string[]): string => {
+    let node = (def?.inputs ?? {}) as Record<string, unknown>;
+    for (const key of ['body', ...keys]) {
+      node = ((node.properties as Record<string, unknown> | undefined)?.[key] ?? {}) as Record<string, unknown>;
+      if (key === 'files') node = (node.items ?? {}) as Record<string, unknown>;
+    }
+    return typeof node.description === 'string' ? node.description : '';
+  };
+
+  it('every content-writing tool says paths start with `knowledge-base/`, so a repo-relative path is never guessed', async () => {
+    await start();
+    const tools = await toolRegistry.listInternal();
+    const byName = (name: string) => {
+      const def = tools.find((t) => t.name === name);
+      expect(def, name).toBeDefined();
+      return def;
+    };
+    for (const name of ['write_file', 'edit_file', 'mkdir', 'delete_file', 'unzip']) {
+      expect(inputDescription(byName(name), 'path'), name).toContain(`\`${KB_DIR}/\``);
+    }
+    expect(inputDescription(byName('write_files'), 'files', 'path'), 'write_files').toContain(`\`${KB_DIR}/\``);
+    for (const name of ['move_file', 'copy_file']) {
+      expect(inputDescription(byName(name), 'dest'), name).toContain(`\`${KB_DIR}/\``);
+    }
+  });
+
+  it('the root listing names the clone folder, so an agent that lists first learns the prefix', async () => {
+    await start();
+    const tools = await toolRegistry.listInternal();
+    const list = tools.find((t) => t.name === 'list_files');
+    expect(list).toBeDefined();
+    expect(list!.description).toContain(`\`${KB_DIR}/\``);
+    expect(inputDescription(list, 'path')).toContain(`\`${KB_DIR}/\``);
+  });
+});

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -20,6 +20,7 @@ import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 // Leaf-level shared primitive (same exception `workspace.service.ts` already
 // relies on) — not a workflow service, so this stays inside the module boundary.
 import { assertValidBranchName } from '../kb-fs/branch-name.js';
+import { assertInsideRepo } from '../kb-fs/repo-path.js';
 import type { ISessionSink } from './session-sink.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
 import { toKbRelative, resolveReadableMap } from '../access-model/kb-read-filter.js';
@@ -110,6 +111,22 @@ const KB_CONVENTIONS_NOTE =
 const int = (description: string): JsonSchema => ({ type: 'integer', description });
 
 const str = (description: string): JsonSchema => ({ type: 'string', description });
+
+/**
+ * A path input that names the clone folder. The tools are rooted at the
+ * WORKSPACE dir, one level above the git clone, so a path only reaches git
+ * when it starts with that folder; an agent that reads `KnowledgeBase/Foo.md`
+ * in a URL or a doc and passes it verbatim would otherwise write beside the
+ * repository. Saying so in the input itself, not only in prose, is what the
+ * agent actually sees when it fills the argument. `refused` is false for the
+ * inputs that may legitimately name a stray (a source to rescue, a file to
+ * remove).
+ */
+const wsPath = (kbDirName: string, what: string, refused = true): JsonSchema =>
+  str(
+    `${what}: starts with \`${kbDirName}/\` (e.g. \`${kbDirName}/KnowledgeBase/Foo.md\`).` +
+      (refused ? ' A path without that prefix is outside the repository and is refused.' : ''),
+  );
 
 function asText(content: string | Buffer): string {
   return typeof content === 'string' ? content : content.toString('utf8');
@@ -394,7 +411,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative path, or a `__tool_chain_spill__/…` ref from a truncated `call_tool_chain`.'),
+        path: str(`Path to read, starting with \`${kbDirName}/\` (e.g. \`${kbDirName}/KnowledgeBase/Foo.md\`), or a \`__tool_chain_spill__/…\` ref from a truncated \`call_tool_chain\`.`),
         offset: int('Start character index (default 0).'),
         limit: int('Max characters to return from `offset`.'),
         sessionId: SESSION_ID_INPUT,
@@ -453,13 +470,13 @@ export function registerWorkspaceTools(
   mount({
     name: 'list_files',
     description:
-      'List a directory. Returns `{ path, entries: [{ name, type, size? }] }`. Omit `path` for the workspace root.' +
+      `List a directory. Returns \`{ path, entries: [{ name, type, size? }] }\`. Omit \`path\` for the workspace root, which holds the repository as the \`${kbDirName}/\` folder: every content path starts with it (e.g. \`${kbDirName}/KnowledgeBase\`).` +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative directory (default: root).'),
+        path: str(`Directory to list, starting with \`${kbDirName}/\` (default: the workspace root, where the repository is the \`${kbDirName}/\` folder).`),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch'],
@@ -501,7 +518,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative path.'),
+        path: wsPath(kbDirName, 'Path'),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'path'],
@@ -610,7 +627,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative path.'),
+        path: wsPath(kbDirName, 'Path'),
         content: str('Full file content.'),
         sessionId: SESSION_ID_INPUT,
       },
@@ -657,7 +674,7 @@ export function registerWorkspaceTools(
           description: 'Files to write; each created or overwritten.',
           items: {
             type: 'object',
-            properties: { path: str('Workspace-relative path.'), content: str('Full file content.') },
+            properties: { path: wsPath(kbDirName, 'Path'), content: str('Full file content.') },
             required: ['path', 'content'],
             additionalProperties: false,
           },
@@ -705,7 +722,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative path.'),
+        path: wsPath(kbDirName, 'Path'),
         old_string: str('Exact text to replace (include enough context to be unique).'),
         new_string: str('Replacement text.'),
         replace_all: { type: 'boolean', description: 'Replace every occurrence instead of requiring a unique match.' },
@@ -750,7 +767,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative path.'),
+        path: wsPath(kbDirName, 'Path to the file', false),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'path'],
@@ -781,7 +798,7 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative directory.'),
+        path: wsPath(kbDirName, 'Directory to create'),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'path'],
@@ -808,8 +825,8 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        src: str('Source path.'),
-        dest: str('Destination path.'),
+        src: wsPath(kbDirName, 'Source path', false),
+        dest: wsPath(kbDirName, 'Destination path'),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'src', 'dest'],
@@ -842,8 +859,8 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        src: str('Source path.'),
-        dest: str('Destination path.'),
+        src: wsPath(kbDirName, 'Source path', false),
+        dest: wsPath(kbDirName, 'Destination path'),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'src', 'dest'],
@@ -877,8 +894,8 @@ export function registerWorkspaceTools(
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
-        path: str('Workspace-relative .zip path.'),
-        destination: str("Directory to extract into (default: the zip's parent)."),
+        path: wsPath(kbDirName, 'Path to the .zip archive', false),
+        destination: wsPath(kbDirName, "Directory to extract into (default: the zip's parent)"),
         sessionId: SESSION_ID_INPUT,
       },
       required: ['branch', 'path'],
@@ -916,6 +933,9 @@ export function registerWorkspaceTools(
         // extension policy applies per entry too, so a restricted run can't unzip a
         // `.md` into the graph.
         (wsRelPath) => {
+          // An entry that would land beside the repository is skipped with the
+          // corrected-path reason, like any other refused entry.
+          assertInsideRepo(wsRelPath, kbDirName);
           writePolicy.assertPathWritable(ctx.sessionId, wsRelPath);
           return assertOntologyWriteAllowed(sessionOntologyGate, ctx, wsRelPath);
         },


### PR DESCRIPTION
## The bug

The agent filesystem is rooted at the workspace directory, one level above the git clone (`knowledge-base/`). A repo-relative path such as `KnowledgeBase/Reviews/PR-12.html` (the shape every doc and URL shows) was "contained" and so accepted. The bytes landed beside the clone, the release commit found nothing dirty and returned `null`, `write_file` reported `{ path, bytes }` under a description promising "committed + pushed as you", and the explorer, which finds the KB root by looking for a folder named `KnowledgeBase`, re-rooted on the stray and folded the entire clone (including `Plugins/`, `access.md`, `.bevelignore`) into Knowledge.

Reproduced on the live KB over MCP: two `write_file` calls succeeded, the root listing showed `[KnowledgeBase, knowledge-base]`, the file was absent inside the repo, and the branch stayed 0 ahead. Nothing was ever committed.

## The fix, in three layers

1. **Hard guard at the chokepoint.** `LockingFilesystem` refuses every creating or modifying op (`writeFile`, `appendFile`, `writeFiles`, `mkdir`, and the destination of `moveFile`/`copyFile`) whose path does not start with the clone folder, before any plan, validator, lock or byte. Removal stays open so a stray the old behaviour left there can be cleaned up, and moving a stray *into* the repository still works as the rescue path. `kbDirName` is a required field of the lock context so a construction site cannot forget it. `save_file` and each `unzip` entry get the same guard, since they bypass the filesystem.
2. **Tell the agent the prefix where it fills the argument.** Every content tool's `path`/`dest` input and the root listing name `knowledge-base/` with an example. The KB template's `AGENTS.md` says it too.
3. **Make the commit layer loud.** `GitService.commitFile` throws when `git status` is clean but the bytes exist at the workspace-relative location outside the clone, instead of returning "nothing to commit"; the pending-commits ladder then escalates the row rather than dropping it. The honest `null` cases (clean committed path, queued re-apply of a deletion, repo-relative path some internal callers pass) are pinned by tests and unchanged.

The refusal message spells out the corrected path, e.g. `Use "knowledge-base/KnowledgeBase/Reviews/PR-12.html" instead`, so an agent can retry without guessing.

## Tests (written first)

- `kb-fs/__tests__/repo-path.test.ts`: the predicate and the error shape.
- `kb-fs/__tests__/locking-filesystem.test.ts`: existing suite moved onto prefixed paths with `kbDirName` in every context; new block proves each op is refused with no lock, no plan, no validator call and no bytes, that a batch fails atomically, that `knowledge-based/` is not a prefix, and that delete and move-into-repo still work.
- `git/__tests__/git.service.commitFile.strayPath.test.ts` (real git): the stray throws and HEAD is untouched; the three honest `null` cases and a normal commit still pass.
- `workspace.tools.test.ts` / `workflow.tools.test.ts`: every content tool's path input and the root listing mention the prefix; `save_file` refuses a stray with 400 before taking a lock and still schedules a prefixed path.

Backend suite: 155 files, 1843 tests passing. Typecheck clean. The two `no-unused-vars` lint errors on `rmdir`'s underscore params are pre-existing on `main`.

## Follow-ups not in this PR

- `findKbRoot` on the frontend still guesses the root by folder name; descending to the `kbDirName` node the workspace context already provides would make the explorer immune to strays created by any other means.
- Any deployment where this already happened has files at `<WORKSPACES_ROOT>/<branch>/KnowledgeBase/...` outside git; move them into `knowledge-base/` and commit, or delete them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
