### PR TITLE
The file tree's right-click menu stays inside the window

### DIFF
--- a/.changeset/right-click-menu-stays-on-screen.md
+++ b/.changeset/right-click-menu-stays-on-screen.md
@@ -1,0 +1,22 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+The file tree's right-click menu now lands on screen.
+
+Its panel was pinned to the raw pointer position, so a right-click low in the
+sidebar drew the menu downward off the bottom of the window. Nothing brought
+the lost rows back, because the panel is `position: fixed`: the page will not
+scroll to a fixed box, and the wheel scrolls the tree out from under a menu
+that stays where it was. A folder's menu is nine rows and roughly 300px tall,
+which put `Manage access`, `Rename` and `Delete` below the fold for any
+right-click in the lower quarter of the tree. That `Manage access` row matters
+most: for a folder it is the only route to access control in the product, since
+folder sharing was deliberately moved off the file page and onto the folder's
+own row.
+
+The menu is now measured before it paints. It still opens down and to the right
+of the pointer, flips above when it will not fit below, and sits against the
+bottom margin when the window is shorter than the menu itself. `EditorTabs`
+had solved half of this on its own and now shares the placement, so a pointer
+menu's behaviour no longer depends on which surface opened it.

--- a/.changeset/right-click-menu-stays-on-screen.md
+++ b/.changeset/right-click-menu-stays-on-screen.md
@@ -17,6 +17,8 @@ own row.
 
 The menu is now measured before it paints. It still opens down and to the right
 of the pointer, flips above when it will not fit below, and sits against the
-bottom margin when the window is shorter than the menu itself. `EditorTabs`
+bottom margin when the window is shorter than the menu itself. A menu that is
+open when the window resizes is placed again against the new viewport, so
+zooming or entering fullscreen no longer leaves it hanging off the edge. `EditorTabs`
 had solved half of this on its own and now shares the placement, so a pointer
 menu's behaviour no longer depends on which surface opened it.

--- a/packages/core-frontend/src/modules/workspace/components/EditorTabs.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/EditorTabs.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import { MenuPanel, MenuItem } from '../../../shared/components';
-import { useDismissableMenu } from '../../../shared/components';
+import { useDismissableMenu, usePointerMenuPosition } from '../../../shared/components';
 import { useOpenChangeRequests } from '../hooks/useOpenChangeRequests';
 import { useWorkspace } from '../state/workspace.context';
 import { useFileNav } from '../routing/kb-routes';
@@ -339,21 +339,13 @@ function ContextMenu({
   returnFocusTo,
 }: ContextMenuProps) {
   const ref = useDismissableMenu<HTMLDivElement>({ open: true, onClose, returnFocusTo });
-  const [pos, setPos] = useState<{ left: number; top: number }>({ left: state.x, top: state.y });
-
-  // After the menu mounts, measure it and clamp into the viewport so a click
-  // near the right/bottom edge doesn't open a menu that's partially off-screen.
-  useLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const w = el.offsetWidth;
-    const h = el.offsetHeight;
-    const left = Math.max(0, Math.min(state.x, window.innerWidth - w));
-    const top = Math.max(0, Math.min(state.y, window.innerHeight - h));
-    setPos({ left, top });
-    // `ref` comes from `useDismissableMenu` now, so it has to be declared —
-    // it is a stable `useRef` box, so listing it changes nothing at runtime.
-  }, [state.x, state.y, ref]);
+  // This menu measured and clamped itself, which the file tree's did not, and
+  // the two drifting apart is what left a right-click low in the tree with a
+  // menu running off the bottom of the window. One hook now, so a pointer
+  // menu's placement cannot depend on which surface opened it. The tab strip
+  // sits at the top of the window, so what changes here is only the inset from
+  // the right edge: the flip has nothing to flip away from.
+  const pos = usePointerMenuPosition(ref, state.x, state.y);
 
   const targetIdx = openTabs.findIndex((t) => t.path === state.tab.path);
   // If the target tab is gone (closed under us between menu open and click),

--- a/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
@@ -34,7 +34,7 @@ import { useFileNav } from '../routing/kb-routes';
 import { downloadViaBlob } from './renderers/downloadFile';
 import { cn } from '../../../lib/utils';
 import { MenuPanel, MenuItem, TextField, IconButton } from '../../../shared/components';
-import { useDismissableMenu } from '../../../shared/components';
+import { useDismissableMenu, usePointerMenuPosition } from '../../../shared/components';
 import { useOpenChangeRequests } from '../hooks/useOpenChangeRequests';
 import { PullRequestsForMe } from '../../git/components/PullRequestsForMe';
 import { ManageAccessDialog } from '../../access/components/ManageAccessDialog';
@@ -180,6 +180,12 @@ function ContextMenu({
   // Outside-click, Escape, and focus return — none of which `MenuPanel`
   // provides (it is presentation only, by design).
   const ref = useDismissableMenu<HTMLDivElement>({ open: true, onClose, returnFocusTo });
+  // Measured placement, because the pointer is not a safe place to paint from.
+  // A folder's menu is nine rows, and a right-click low in the sidebar used to
+  // draw it straight off the bottom of the window with no way to reach what
+  // fell below: `Manage access`, `Rename` and `Delete` among them, and for a
+  // folder that `Manage access` row is the product's only route to it.
+  const pos = usePointerMenuPosition(ref, x, y);
 
   // Only files whose name ends with `.zip` (case-insensitive) get the
   // extraction affordance — matches the OS shell-extension behavior users
@@ -245,12 +251,12 @@ function ContextMenu({
 
   return (
     // Positioning stays with the caller — `MenuPanel` is presentation only, so
-    // the fixed-to-the-pointer wrapper is ours and the panel inside is the
-    // shared one.
+    // the fixed wrapper and its measured placement are ours, and the panel
+    // inside is the shared one.
     <div
       ref={ref}
       className="fixed z-50"
-      style={{ left: x, top: y }}
+      style={{ left: pos.left, top: pos.top }}
       onMouseDown={(e) => e.stopPropagation()}
     >
     <MenuPanel role="menu" aria-label={`Actions for ${entry.name}`} className="min-w-[180px]">

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -918,5 +918,133 @@ describe('FileExplorer rows: the prototype tree', () => {
     // A normal row opens the FILE, never the dialog.
     fireEvent.click(row);
     expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+// ── The right-click menu has to land on screen ──
+//
+// The panel is `position: fixed`, so whatever falls past the bottom edge of
+// the window is unreachable: the page will not scroll to a fixed box, and the
+// wheel scrolls the tree out from under a menu that stays where it was. A
+// folder's menu is nine rows, so pinning it to the raw pointer put `Manage
+// access`, `Rename` and `Delete` below the fold for any right-click in the
+// lower quarter of the sidebar.
+describe('FileExplorer right-click: the menu stays inside the window', () => {
+  const TREE: FileTreeEntry = {
+    name: '.',
+    relativePath: '.',
+    type: 'directory',
+    children: [
+      { name: 'reports', relativePath: 'reports', type: 'directory', children: [] },
+      { name: 'brief.md', relativePath: 'brief.md', type: 'file' },
+    ],
+  };
+
+  const MENU_W = 200;
+  const MENU_H = 300;
+
+  // jsdom lays nothing out, so every `offsetWidth`/`offsetHeight` is 0 and the
+  // placement would have nothing to react to. Give a size to the one element
+  // the hook measures: the fixed wrapper, identified by the `role="menu"`
+  // panel it holds.
+  const isMenuBox = (el: HTMLElement) => el.firstElementChild?.getAttribute('role') === 'menu';
+  let restoreLayout: (() => void) | null = null;
+
+  function stubViewport(width: number, height: number) {
+    const w = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')!;
+    const h = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')!;
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return isMenuBox(this) ? MENU_W : 0;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return isMenuBox(this) ? MENU_H : 0;
+      },
+    });
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width });
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: height });
+    restoreLayout = () => {
+      Object.defineProperty(HTMLElement.prototype, 'offsetWidth', w);
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', h);
+    };
+  }
+
+  /** The fixed wrapper the placement writes to: the `role="menu"` panel's parent. */
+  const menuBox = () => screen.getByRole('menu').parentElement as HTMLElement;
+
+  beforeEach(() => {
+    cleanup();
+    mockAuthFetch.mockReset();
+  });
+
+  afterEach(() => {
+    restoreLayout?.();
+    restoreLayout = null;
+  });
+
+  it('flips a folder menu above the pointer when it would run off the bottom', () => {
+    stubViewport(1280, 800);
+    renderExplorer({ fileTree: TREE });
+
+    fireEvent.contextMenu(screen.getByText('reports'), { clientX: 120, clientY: 760 });
+
+    // Above the pointer, with the 4px gap that keeps the cursor off the last
+    // row: 760 - 4 - 300. Without the gap the pointer would come to rest on
+    // `Delete`, which is exactly the row it should not be resting on.
+    const box = menuBox();
+    expect(box.style.top).toBe('456px');
+    expect(parseInt(box.style.top, 10) + MENU_H).toBeLessThanOrEqual(window.innerHeight);
+  });
+
+  it('keeps every row of a folder menu reachable, Manage access included', () => {
+    stubViewport(1280, 800);
+    renderExplorer({ fileTree: TREE });
+
+    fireEvent.contextMenu(screen.getByText('reports'), { clientX: 120, clientY: 780 });
+
+    // The impact line, asserted: the row that is the only route to a folder's
+    // access control has to be inside the window, not merely rendered.
+    expect(screen.getByRole('menuitem', { name: /Manage access/i })).toBeInTheDocument();
+    const top = parseInt(menuBox().style.top, 10);
+    expect(top).toBeGreaterThanOrEqual(8);
+    expect(top + MENU_H).toBeLessThanOrEqual(window.innerHeight - 8);
+  });
+
+  it('leaves a menu that already fits where the pointer put it', () => {
+    stubViewport(1280, 800);
+    renderExplorer({ fileTree: TREE });
+
+    fireEvent.contextMenu(screen.getByText('brief.md'), { clientX: 120, clientY: 100 });
+
+    // Down and to the right of the pointer is what every desktop shell does,
+    // and it leaves the cursor on the first row, which is never destructive.
+    const box = menuBox();
+    expect(box.style.top).toBe('100px');
+    expect(box.style.left).toBe('120px');
+  });
+
+  it('clamps to the top margin when the window is shorter than the menu', () => {
+    stubViewport(1280, 250);
+    renderExplorer({ fileTree: TREE });
+
+    fireEvent.contextMenu(screen.getByText('reports'), { clientX: 120, clientY: 200 });
+
+    // Neither side fits, so the panel keeps its top rows rather than losing
+    // both ends.
+    expect(menuBox().style.top).toBe('8px');
+  });
+
+  it('pulls the menu back from the right edge of the window', () => {
+    stubViewport(300, 800);
+    renderExplorer({ fileTree: TREE });
+
+    fireEvent.contextMenu(screen.getByText('brief.md'), { clientX: 250, clientY: 100 });
+
+    // 300 - 200 - 8: the whole panel, not just its left edge, is on screen.
+    expect(menuBox().style.left).toBe('92px');
   });
 });

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
@@ -929,6 +929,9 @@ describe('FileExplorer rows: the prototype tree', () => {
 // folder's menu is nine rows, so pinning it to the raw pointer put `Manage
 // access`, `Rename` and `Delete` below the fold for any right-click in the
 // lower quarter of the sidebar.
+/** jsdom's own viewport, read at import before any test has stubbed it. */
+const REAL_VIEWPORT = { width: window.innerWidth, height: window.innerHeight };
+
 describe('FileExplorer right-click: the menu stays inside the window', () => {
   const TREE: FileTreeEntry = {
     name: '.',
@@ -953,6 +956,11 @@ describe('FileExplorer right-click: the menu stays inside the window', () => {
   function stubViewport(width: number, height: number) {
     const w = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')!;
     const h = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')!;
+    // jsdom defines these as own accessors on `window`, so the descriptor is
+    // real and putting it back restores the getter rather than freezing a
+    // number in its place.
+    const iw = Object.getOwnPropertyDescriptor(window, 'innerWidth')!;
+    const ih = Object.getOwnPropertyDescriptor(window, 'innerHeight')!;
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       configurable: true,
       get(this: HTMLElement) {
@@ -970,6 +978,8 @@ describe('FileExplorer right-click: the menu stays inside the window', () => {
     restoreLayout = () => {
       Object.defineProperty(HTMLElement.prototype, 'offsetWidth', w);
       Object.defineProperty(HTMLElement.prototype, 'offsetHeight', h);
+      Object.defineProperty(window, 'innerWidth', iw);
+      Object.defineProperty(window, 'innerHeight', ih);
     };
   }
 
@@ -1046,5 +1056,15 @@ describe('FileExplorer right-click: the menu stays inside the window', () => {
 
     // 300 - 200 - 8: the whole panel, not just its left edge, is on screen.
     expect(menuBox().style.left).toBe('92px');
+  });
+});
+
+// The stub above is only safe if it puts the window back. A viewport left at
+// the last case's 300px would silently narrow whatever runs next, including a
+// block someone appends below this one.
+describe('FileExplorer right-click: the viewport stub cleans up after itself', () => {
+  it('leaves window.innerWidth and innerHeight as it found them', () => {
+    expect(window.innerWidth).toBe(REAL_VIEWPORT.width);
+    expect(window.innerHeight).toBe(REAL_VIEWPORT.height);
   });
 });

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileExplorer.test.tsx
@@ -1048,6 +1048,27 @@ describe('FileExplorer right-click: the menu stays inside the window', () => {
     expect(menuBox().style.top).toBe('8px');
   });
 
+  it('re-places an open menu when the window is resized under it', () => {
+    stubViewport(1280, 800);
+    renderExplorer({ fileTree: TREE });
+
+    // Opens with room to spare, so the menu sits at the pointer.
+    fireEvent.contextMenu(screen.getByText('reports'), { clientX: 120, clientY: 400 });
+    expect(menuBox().style.top).toBe('400px');
+
+    // Shrink the window with the menu still open. Dragging a window edge would
+    // have closed it, since that is a mousedown outside the panel, but zoom,
+    // fullscreen and OS window snapping resize without one.
+    act(() => {
+      Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 500 });
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    // 400 + 300 no longer fits under 500, and 400 - 4 - 300 clears the margin,
+    // so it flips rather than hanging off the bottom of the new viewport.
+    expect(menuBox().style.top).toBe('96px');
+  });
+
   it('pulls the menu back from the right edge of the window', () => {
     stubViewport(300, 800);
     renderExplorer({ fileTree: TREE });

--- a/packages/core-frontend/src/shared/components/index.ts
+++ b/packages/core-frontend/src/shared/components/index.ts
@@ -46,3 +46,5 @@ export type { PageShellWidth } from './PageShell';
 export { useModalLayer } from './useModalLayer';
 export { useDismissableMenu } from './useDismissableMenu';
 export type { DismissableMenuOptions } from './useDismissableMenu';
+export { usePointerMenuPosition } from './usePointerMenuPosition';
+export type { PointerMenuPosition } from './usePointerMenuPosition';

--- a/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
+++ b/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
@@ -1,0 +1,75 @@
+import { useLayoutEffect, useState, type RefObject } from 'react';
+
+/** Minimum inset from a viewport edge, and the gap left when a menu flips above the pointer. */
+const MENU_MARGIN = 8;
+const MENU_GAP = 4;
+
+/** Where a pointer-anchored panel should paint, in viewport coordinates. */
+export interface PointerMenuPosition {
+  left: number;
+  top: number;
+}
+
+/**
+ * Places a pointer-anchored menu so the whole panel stays on screen.
+ *
+ * `MenuPanel` is presentation only and leaves positioning to its caller, which
+ * is the right call for a primitive but leaves every pointer-anchored menu to
+ * solve the same geometry. Three of them solved it three ways:
+ * `ManageAccessDialog`'s `AnchoredMenu` measures and flips, `EditorTabs`
+ * clamped, and the file tree pinned its panel straight to `clientX/clientY`.
+ *
+ * The tree is the one that hurt. A folder's menu is nine rows and about 300px
+ * tall, so a right-click anywhere in the lower quarter of the sidebar drew it
+ * downward off the bottom of the window, and being `position: fixed` there was
+ * no way back to the rows below the fold: the page will not scroll to a fixed
+ * box, and the wheel scrolls the tree out from under a menu that stays put.
+ * `Manage access` is one of those rows, and for a folder it is the only route
+ * to access control in the product.
+ *
+ * Down and to the right of the pointer stays the default, because that is what
+ * every desktop shell does and it leaves the pointer on the first row, which is
+ * never destructive. A panel that will not fit below flips above the pointer
+ * instead, keeping a small gap: the gap is not cosmetic, since a flip that put
+ * the panel's bottom edge exactly on the pointer would park the cursor on the
+ * last row, and in the tree's menu that row is `Delete`. Fitting neither way
+ * means the window is shorter than the menu, and the panel then sits against
+ * the bottom margin, which keeps its top rows reachable and loses only the
+ * bottom ones it could not have shown anyway.
+ *
+ * Pass the ref the panel already carries, the one from `useDismissableMenu`, so
+ * both hooks share a single box. Measuring in a layout effect means the browser
+ * paints the placed position once instead of flashing the unplaced one.
+ */
+export function usePointerMenuPosition<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  x: number,
+  y: number,
+): PointerMenuPosition {
+  // The pre-measurement value is the pointer itself, so the first render is
+  // exactly where these menus used to open and the layout effect corrects it
+  // before paint.
+  const [pos, setPos] = useState<PointerMenuPosition>({ left: x, top: y });
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+    const left = Math.max(MENU_MARGIN, Math.min(x, window.innerWidth - w - MENU_MARGIN));
+    let top: number;
+    if (y + h <= window.innerHeight - MENU_MARGIN) {
+      top = y;
+    } else if (y - MENU_GAP - h >= MENU_MARGIN) {
+      top = y - MENU_GAP - h;
+    } else {
+      top = Math.max(MENU_MARGIN, window.innerHeight - MENU_MARGIN - h);
+    }
+    setPos({ left, top });
+    // Moving the panel cannot change its size, so one measurement per open is
+    // enough and this never feeds itself. `ref` is a stable `useRef` box, so
+    // listing it changes nothing at runtime.
+  }, [x, y, ref]);
+
+  return pos;
+}

--- a/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
+++ b/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
@@ -52,23 +52,35 @@ export function usePointerMenuPosition<T extends HTMLElement>(
   const [pos, setPos] = useState<PointerMenuPosition>({ left: x, top: y });
 
   useLayoutEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const w = el.offsetWidth;
-    const h = el.offsetHeight;
-    const left = Math.max(MENU_MARGIN, Math.min(x, window.innerWidth - w - MENU_MARGIN));
-    let top: number;
-    if (y + h <= window.innerHeight - MENU_MARGIN) {
-      top = y;
-    } else if (y - MENU_GAP - h >= MENU_MARGIN) {
-      top = y - MENU_GAP - h;
-    } else {
-      top = Math.max(MENU_MARGIN, window.innerHeight - MENU_MARGIN - h);
-    }
-    setPos({ left, top });
-    // Moving the panel cannot change its size, so one measurement per open is
-    // enough and this never feeds itself. `ref` is a stable `useRef` box, so
-    // listing it changes nothing at runtime.
+    const place = () => {
+      const el = ref.current;
+      if (!el) return;
+      const w = el.offsetWidth;
+      const h = el.offsetHeight;
+      const left = Math.max(MENU_MARGIN, Math.min(x, window.innerWidth - w - MENU_MARGIN));
+      let top: number;
+      if (y + h <= window.innerHeight - MENU_MARGIN) {
+        top = y;
+      } else if (y - MENU_GAP - h >= MENU_MARGIN) {
+        top = y - MENU_GAP - h;
+      } else {
+        top = Math.max(MENU_MARGIN, window.innerHeight - MENU_MARGIN - h);
+      }
+      // Keep the previous object when nothing moved. `place` runs again on
+      // every resize, and a fresh object each time would re-render for nothing.
+      setPos((prev) => (prev.left === left && prev.top === top ? prev : { left, top }));
+    };
+    place();
+    // A menu still open across a resize would otherwise keep a placement
+    // measured against a window that no longer exists. Dragging a window edge
+    // closes it first, because that is a mousedown outside the panel, but
+    // zooming, entering fullscreen and OS window snapping all resize without
+    // one, and the panel would be left hanging off the new viewport.
+    //
+    // `ref` is in the deps because it is read here. It is a stable `useRef`
+    // box, so listing it changes nothing at runtime.
+    window.addEventListener('resize', place);
+    return () => window.removeEventListener('resize', place);
   }, [x, y, ref]);
 
   return pos;


### PR DESCRIPTION
## The bug

The file tree's context menu was pinned to the raw pointer position and never measured against the viewport. A right-click low in the sidebar drew the menu downward off the bottom of the window.

Nothing brought the lost rows back. The panel is `position: fixed`, so the page will not scroll to it, and the wheel scrolls the tree out from under a menu that stays where it was. A folder's menu is nine rows and roughly 300px tall, which put `Manage access`, `Rename` and `Delete` below the fold for any right-click in the lower quarter of the tree.

`Manage access` is the row that matters. Folder sharing was deliberately moved off the file page and onto the folder's own row, so for a folder that menu item is the only route to access control in the product.

## What changed

`usePointerMenuPosition` measures the panel in a layout effect and places it:

- down and to the right of the pointer by default, which is what every desktop shell does and leaves the cursor on the first row, never a destructive one;
- flipped above the pointer when it will not fit below, keeping a 4px gap so the cursor does not come to rest on the last row, which in this menu is `Delete`;
- against the bottom margin when the window is shorter than the menu, keeping the top rows reachable.

Both axes are clamped with an 8px inset.

This was already solved twice elsewhere and never here. `ManageAccessDialog`'s `AnchoredMenu` measures and flips, with a comment describing this exact failure. `EditorTabs` clamped. The tree did neither. `EditorTabs` now drops its own copy for the shared hook, so where a pointer menu lands no longer depends on which surface opened it. The tab strip sits at the top of the window, so the flip never engages there and the only change is the inset from the right edge.

## Testing

`core-frontend`: 1507 tests pass across 121 files.

Five new cases cover the placement. Reverting just the one-line style change fails four of them; the fifth is the control case asserting a menu that already fits does not move, which correctly passes both ways. jsdom lays nothing out, so the suite stubs `offsetWidth`/`offsetHeight` for the one element the hook measures.

Typecheck and lint are clean for every file touched.

## Note for the reviewer

Menus close on outside-click and Escape, but not on scroll, so a menu left open while the tree scrolls ends up floating beside a row it does not act on. That is pre-existing and adjacent to this fix rather than part of it, and closing on scroll would change behaviour for all six menus in the app, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the file tree's right-click menu so it no longer draws off the bottom of the window when you right-click low in the sidebar. The menu was pinned to the raw pointer position and is `position: fixed`, so the rows that fell below the fold were unreachable; it is now measured before paint and flips above the pointer or clamps to the nearest window edge with an 8px inset.

**Bug Fixes**
- A folder's `Manage access`, `Rename`, and `Delete` rows are now reachable from any right-click; `Manage access` is the only route to access control for a folder.
- The flip keeps a 4px gap above the pointer so the cursor doesn't land on `Delete`, and a menu taller than the window sits against the bottom margin.
- An open menu is placed again when the window resizes, so zooming or entering fullscreen doesn't leave it hanging off the edge.
- The placement test's viewport stub now restores the window size it patches, so one case's dimensions can't leak into later tests.
- Menus still don't close on scroll, which is pre-existing and out of scope.

**Refactors**
- `EditorTabs` now uses the shared `usePointerMenuPosition` hook, so placement no longer depends on which surface opened it; the tab strip's only change is the right-edge inset.

<sup>Written for commit 95da3a651325c4eb2a516e0379afb6b2e91bde85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

