### PR TITLE
Sign-ins with an owner-registered OAuth app work against MCP servers (PKCE by default, bring-your-own client id)

### DIFF
--- a/.changeset/mcp-oauth-declared-client.md
+++ b/.changeset/mcp-oauth-declared-client.md
@@ -1,0 +1,14 @@
+---
+'@bevel-software/platform-core-backend': minor
+'@bevel-software/platform-core-frontend': minor
+---
+
+Sign-ins with an owner-registered OAuth app now work against MCP servers — HubSpot included.
+
+**PKCE by default.** A hand-declared sign-in provider never sent PKCE, so every MCP-spec server (which requires it) rejected the authorization request; only the zero-config path had it. Declared providers now use PKCE S256 unless the declaration says `pkce: false`. Providers that never implemented PKCE ignore the extra parameters, so nothing that worked stops working. The standalone OAuth secret form on the Secrets page has the same switch, on by default. An existing declared provider picks this up when its owner next saves the client secret.
+
+**Bring your own client id.** A provider that publishes its OAuth metadata but does not allow automatic client registration (HubSpot, Google) used to need every endpoint copied by hand. For an `mcp.json` server the sign-in declaration is now just the client id of the app the owner registered — `oauth: { clientId }` on a user-scoped variable in the plugin.json extensions entry. The endpoints, PKCE, and the resource indicator are discovered from the server's own metadata at scan time and pinned with the client secret. `authorizationUrl`/`tokenUrl` remain available (both or neither) for providers that publish nothing, and `resource` can be declared for the same case. A `.tool` still needs both endpoints: it has no server to ask.
+
+**The server editor shows what the files say.** The tool page's read-only server facts now list everything mcp.json and plugin.json store — headers, auth headers, description, every declared variable, and a sign-in's client id, endpoint source, scopes and PKCE — so what is configured is visible without opening either file. The editor's variables rows gained the same sign-in fields (client id, discovered-or-manual endpoints, scopes, PKCE), and switching a sign-in on pre-fills the `Authorization: Bearer ${VAR}` header where the writer can see it.
+
+**Clearer next steps.** The "sign-in setup needed" banners no longer point every server at "the `.tool` file": an mcp.json server is edited under "Edit server" on its own page, and a declared-but-unfinished sign-in asks only for the client secret. Discovery's `setup.reason` names the redirect URI to register with the provider, and the client-secret route refuses with that same reason while the endpoints are still unknown instead of pinning a provider with none. The knowledge-base `AGENTS.md` documents the `oauth` block, the mcp.json shape, and the walkthrough an agent follows to set a provider up end to end.

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -237,7 +237,7 @@ A `user`-scoped variable can be filled by **signing in** instead of by a typed v
 | `resource` | optional | RFC 8707 resource indicator (the MCP server URL); discovered on an `mcp.json` server |
 | `authParams` | optional | extra static authorize params, e.g. Google's `access_type: offline` |
 
-**Never** a `clientSecret` — a file carrying one fails to load. The secret is pasted once by a tool writer on the tool's page, then every member signs in on the Connect page.
+**Never** a `clientSecret` — a `.tool` carrying one fails to load, and an `mcp.json` server whose plugin.json entry carries one is dropped from the catalog. The secret is pasted once by a tool writer on the tool's page, then every member signs in on the Connect page.
 
 For an `mcp.json` server the declaration lives in `plugin.json`, in the same extensions entry as the auth header that uses it:
 

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -224,6 +224,43 @@ Declare who provisions each variable with an optional top-level `variables` arra
 
 `name` must match `[A-Za-z0-9_]+`. A referenced `${VAR}` that you don't declare defaults to `admin` — and it still SURFACES automatically: the app detects every `${VAR}` the file actually references and shows it in the secrets UI, so the `variables` block is only needed to change a variable's scope to `user`, give it a label, or declare an OAuth sign-in. Values are entered in the Secrets Vault UI (or the `.tool` editor's sidebar), never in the file itself. A malformed `variables` entry makes the whole file fail to load, so it is never silently mis-scoped.
 
+### Declaring an OAuth sign-in — the `oauth` block
+
+A `user`-scoped variable can be filled by **signing in** instead of by a typed value: add an `oauth` block and each member authorizes with the provider; the token then rides in whatever header references `${VAR}`. The block carries PUBLIC config only:
+
+| field | | |
+|---|---|---|
+| `clientId` | required | the OAuth app's client id — the tool owner registers the app with the provider, using the redirect URI `<backend>/api/secrets/oauth/callback` |
+| `authorizationUrl`, `tokenUrl` | **optional on an `mcp.json` server**, required in a `.tool` | leave both out on an MCP server: they are discovered from the server's own OAuth metadata. Give both or neither. |
+| `scopes` | optional | `string[]`, requested at sign-in and required back from the token |
+| `pkce` | optional, default **on** | PKCE S256 — MCP servers require it; providers without it ignore it. Only `false` is meaningful. |
+| `resource` | optional | RFC 8707 resource indicator (the MCP server URL); discovered on an `mcp.json` server |
+| `authParams` | optional | extra static authorize params, e.g. Google's `access_type: offline` |
+
+**Never** a `clientSecret` — a file carrying one fails to load. The secret is pasted once by a tool writer on the tool's page, then every member signs in on the Connect page.
+
+For an `mcp.json` server the declaration lives in `plugin.json`, in the same extensions entry as the auth header that uses it:
+
+```json
+{
+  "extensions": {
+    "software.bevel.hexis": {
+      "mcpServers": {
+        "hubspot": {
+          "headers": { "Authorization": "Bearer ${HUBSPOT_TOKEN}" },
+          "variables": [
+            { "name": "HUBSPOT_TOKEN", "scope": "user", "label": "HubSpot sign-in",
+              "oauth": { "clientId": "<the app's client id>" } }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+That is the whole declaration: endpoints, PKCE and the resource indicator come from the server. Add `authorizationUrl`/`tokenUrl` only when `list_tool_setup` reports in `setup.reason` that they could not be discovered.
+
 ### Examples
 
 An `http` manual that authenticates with a shared org key and a per-user key:
@@ -272,7 +309,7 @@ When asked to add/integrate a product as a tool (e.g. "add Notion", "wire up Lin
 2. **Pick the home from what you found.** An MCP server → an entry in the plugin's `mcp.json` (`type: "streamable-http"` with the official `url` — use the `https://…` URL, **never** `ws://`/`wss://`). A plain REST/HTTP endpoint → a `.tool` with `type: http`. Use `type: inline` only when hand-authoring the individual HTTP calls.
 3. **An OAuth-protected MCP server usually needs NOTHING beyond its `mcp.json` entry.** Write just those two and let the app probe the server: it discovers the sign-in provider (MCP authorization spec), registers itself, and surfaces a per-user sign-in on the Connect page. That is the `oauth-auto` case, and for it you must NOT declare `variables` or `headers`.
 
-   Some providers do not support automatic registration (`oauth-manual` — see the walkthrough below). Those DO need a sign-in variable to hold the client id, and an admin pastes the client secret on the tool's page. You do not have to guess which kind you are facing: write the two lines, then run `list_tool_setup` and read `setup.kind`.
+   Some providers do not support automatic registration (`oauth-manual` — HubSpot, Google; see the walkthrough below). Those DO need a sign-in variable holding the client id of an app the owner registers, and an admin pastes the client secret on the tool's page. You do not have to guess which kind you are facing: write the two lines, then run `list_tool_setup` and read `setup.kind` — and `setup.reason`, which spells out the next step (including the redirect URI to register).
 4. **For key-based auth, wire it as `variables`, never a hard-coded secret.** Reference credentials as `${VAR}` in `headers` (e.g. `Authorization: Bearer ${NOTION_TOKEN}`) and declare each in the `variables` block with a scope (`admin` = one shared value; `user` = per-user). Users fill the values in the Secrets Vault.
 5. **Say so when a tool is reachable ONLY from the user's own machine.** For an MCP server (e.g. one on `localhost`), declare `local: true` on its entry in the plugin.json extensions block — `remote: false` is a `.tool` frontmatter field and means nothing in `mcp.json`. For an `http`/`inline` `.tool`, set `remote: false`. Otherwise leave the tool remote-capable.
 
@@ -280,22 +317,23 @@ When asked to add/integrate a product as a tool (e.g. "add Notion", "wire up Lin
 
 Call the **`list_tool_setup`** tool to see, for every accessible tool — `.tool` manuals and `mcp.json` servers alike — what is configured and what is still missing. Use it whenever a tool isn't working, after adding a tool, or when asked "what do I need to set up?" — then EXPLAIN the remaining steps to the user rather than guessing. Per tool it reports:
 
-- **`setup.kind`** (for MCP servers): `open` = no credentials needed; `oauth-auto` = the platform registered itself with the server automatically and users just authorize on the **Connect page**; `oauth-manual` = the provider does not support automatic registration, so a tool writer must configure it by hand (below).
+- **`setup.kind`** (for MCP servers): `open` = no credentials needed; `oauth-auto` = the platform registered itself with the server automatically and users just authorize on the **Connect page**; `oauth-manual` = the sign-in uses an OAuth app the owner registers (the provider offers no automatic registration, or the declaration already names a client id). `setup.reason` is present only while something still blocks that sign-in — no declaration yet, or endpoints that could not be discovered — and says what to do.
 - **Per variable**: `adminConfigured` (the shared value — or, for a sign-in, the owner-side provider setup — is done), `userConfigured` / `authorized` (the CURRENT user's own value / sign-in), and `canWrite` (whether the current user may set the tool's shared config).
 
 The listing is scoped by the same access controls as everything else: a tool the caller can't READ doesn't appear at all, and `canWrite` means write access **on the file that declares it** — the `.tool` file itself (via its frontmatter `write:`/`owner:` verbs or the `access.md` chain), or the plugin's `mcp.json` for an MCP server (via the plugin's `access.md` chain — `mcp.json` carries no verb list of its own) — NOT any platform role. The people who manage that file are exactly the people who configure its shared secrets. To delegate a `.tool` to someone, add them to that file's `write:`/`owner:` list; to delegate an MCP server, grant them `write` on the plugin in its `access.md` (both are edits you can make via change request). That alone lets them configure it.
 
 **Agents never handle secret VALUES.** Never ask for an API key, token, or client secret in the conversation, and there is no tool to set one. Point the right person at the right surface instead:
 
-- **Shared (admin) values and OAuth client secrets** → a tool writer pastes them into the fields on the tool's page in the app (open the `.tool` file; the setup panel is in its sidebar).
+- **Shared (admin) values and OAuth client secrets** → a tool writer pastes them into the fields on the tool's page in the app (the "Your connection" section; for a `.tool` file, the setup panel is also in its editor sidebar).
 - **Per-user values and sign-ins** → each user enters/authorizes on the **Connect page**.
 
-For **`oauth-manual`** (e.g. Google, GitHub, Slack — no dynamic client registration), walk the admin through the one-time setup:
+For **`oauth-manual`** (e.g. HubSpot, Google, GitHub, Slack — no dynamic client registration), walk the admin through the one-time setup:
 
-1. Register an OAuth app in the provider's console, with redirect URI `<backend>/api/secrets/oauth/callback`.
-2. Put the app's **client id** (public) in the `.tool` file's sign-in variable — you can do this edit for them via a change request.
-3. The admin pastes the app's **client secret** into the "Client secret" field on the tool's page — never into the file, never into the chat.
-4. Every user then authorizes on the Connect page.
+1. Register an OAuth app in the provider's console, with redirect URI `<backend>/api/secrets/oauth/callback` (the exact URI is in `setup.reason`).
+2. Ask for the app's **client id** (public — fine to receive in chat) and write the sign-in declaration yourself: for an `mcp.json` server, the `variables` entry with `oauth: { clientId }` plus the `Authorization: Bearer ${VAR}` header in the plugin.json extensions entry (see "Declaring an OAuth sign-in" above — no URLs needed); for a `.tool`, the same entry with `authorizationUrl` and `tokenUrl` as well. You can do this edit for them via a change request. A human can do the same under "Edit server" on the tool's page — the form's fields are exactly this block.
+3. Run `list_tool_setup` again: `setup.reason` must be gone. If it says the endpoints could not be discovered, add `authorizationUrl`/`tokenUrl` from the provider's docs.
+4. The admin pastes the app's **client secret** into the "Client secret" field on the tool's page — never into the file, never into the chat.
+5. Every user then authorizes on the Connect page.
 
 ## Conventions
 

--- a/packages/core-backend/src/modules/secrets-vault/__tests__/mcp-oauth-discovery.service.test.ts
+++ b/packages/core-backend/src/modules/secrets-vault/__tests__/mcp-oauth-discovery.service.test.ts
@@ -147,7 +147,59 @@ describe('McpOAuthDiscoveryService', () => {
     });
     const res = await makeService(vault, fetchFn).statusFor('notion', MCP_URL);
     expect(res.status).toBe('unsupported');
+    // The reason is the admin's to-do list: it names the redirect URI to
+    // register and where the client id goes, because that is the next step.
+    expect(res).toMatchObject({ reason: expect.stringContaining(REDIRECT_URI) });
+    expect(res).toMatchObject({ reason: expect.stringContaining('client id') });
     expect(vault.putSharedOAuthProvider).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('completes an owner-declared client from the server metadata — no registration, nothing persisted', async () => {
+    const vault = makeVault();
+    const { fetchFn, calls } = makeFetch({
+      [MCP_URL]: () => json({}, 401),
+      [PRM_URL]: () => json(PRM),
+      [AS_META_URL]: () => json({ ...AS_META, registration_endpoint: undefined }),
+    });
+    const svc = makeService(vault, fetchFn);
+    const res = await svc.providerForDeclaredClient('hubspot', MCP_URL, 'owner-app-1');
+    expect(res).toEqual({
+      status: 'oauth',
+      provider: {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        tokenUrl: 'https://auth.example.com/token',
+        clientId: 'owner-app-1',
+        scopes: ['mcp.read'],
+        pkce: true,
+        resource: MCP_URL,
+      },
+    });
+    expect(calls).not.toContain('https://auth.example.com/register');
+    expect(vault.putSharedOAuthProvider).not.toHaveBeenCalled();
+    // The metadata walk is per server, so a second declared client on the
+    // same URL costs no network — and gets ITS client id, not the first one's.
+    const before = calls.length;
+    const again = await svc.providerForDeclaredClient('hubspot_eu', MCP_URL, 'owner-app-2');
+    expect(again).toMatchObject({ status: 'oauth', provider: { clientId: 'owner-app-2' } });
+    expect(calls.length).toBe(before);
+  });
+
+  it('refuses to complete a declared client when the server is open or publishes no metadata', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const open = makeService(makeVault(), makeFetch({ [MCP_URL]: () => json({ ok: true }) }).fetchFn);
+    expect(await open.providerForDeclaredClient('x', MCP_URL, 'c')).toMatchObject({
+      status: 'unsupported',
+      reason: expect.stringContaining('authorizationUrl'),
+    });
+    const noMeta = makeService(
+      makeVault(),
+      makeFetch({ [MCP_URL]: () => json({}, 401), [PRM_URL]: () => json(PRM) }).fetchFn,
+    );
+    expect(await noMeta.providerForDeclaredClient('x', MCP_URL, 'c')).toMatchObject({
+      status: 'unsupported',
+      reason: expect.stringContaining('no authorization-server metadata'),
+    });
     warn.mockRestore();
   });
 

--- a/packages/core-backend/src/modules/secrets-vault/__tests__/tool-owner-gate.route.test.ts
+++ b/packages/core-backend/src/modules/secrets-vault/__tests__/tool-owner-gate.route.test.ts
@@ -25,6 +25,7 @@ const toolManualService = {
       name: 'weather',
       path: TOOL_PATH,
       type: 'mcp' as const,
+      setup: { kind: 'oauth-manual' as const, reason: 'no authorization-server metadata at https://weather.example' },
       variables: [
         { name: 'SHARED_KEY', scope: 'admin' as const, label: 'Org key' },
         {
@@ -37,6 +38,19 @@ const toolManualService = {
             clientId: 'client-1',
           },
         },
+        {
+          name: 'LEGACY',
+          scope: 'user' as const,
+          oauth: {
+            authorizationUrl: 'https://auth.example.com/authorize',
+            tokenUrl: 'https://auth.example.com/token',
+            clientId: 'client-2',
+            pkce: false,
+            resource: 'https://weather.example/mcp',
+          },
+        },
+        // Declared by client id alone, and discovery could NOT fill the endpoints in.
+        { name: 'BYO', scope: 'user' as const, oauth: { clientId: 'owner-app' } },
       ],
     },
   ],
@@ -125,9 +139,42 @@ describe('tool owner gate — shared config requires WRITE on the `.tool` file',
       expect.objectContaining({
         key: 'weather_SIGNIN',
         clientSecret: 'cs-123',
-        provider: expect.objectContaining({ clientId: 'client-1' }),
+        // PKCE rides along by default — the MCP spec requires it and a
+        // provider without it ignores the parameters. No `resource` declared.
+        provider: expect.objectContaining({ clientId: 'client-1', pkce: true, resource: undefined }),
       }),
     );
+  });
+
+  it('pins the declaration\'s PKCE opt-out and resource indicator with the secret', async () => {
+    const base = await baseUrlAs(WRITER);
+    const res = await fetch(`${base}/api/secrets/tools/weather/vars/LEGACY/oauth/admin`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientSecret: 'cs-456' }),
+    });
+    expect(res.status).toBe(201);
+    expect(putSharedOAuthClientSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'weather_LEGACY',
+        provider: expect.objectContaining({ clientId: 'client-2', pkce: false, resource: 'https://weather.example/mcp' }),
+      }),
+    );
+  });
+
+  it('refuses the secret while the sign-in endpoints are still unknown, naming why (422)', async () => {
+    const base = await baseUrlAs(WRITER);
+    const res = await fetch(`${base}/api/secrets/tools/weather/vars/BYO/oauth/admin`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientSecret: 'cs-789' }),
+    });
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('no authorization-server metadata at https://weather.example');
+    // Pinning a provider with no endpoints would make every later sign-in
+    // fail with a far vaguer error than this one.
+    expect(putSharedOAuthClientSecret).not.toHaveBeenCalled();
   });
 
   it('a non-writer cannot set the client secret (403)', async () => {

--- a/packages/core-backend/src/modules/secrets-vault/mcp-oauth-discovery.service.ts
+++ b/packages/core-backend/src/modules/secrets-vault/mcp-oauth-discovery.service.ts
@@ -10,6 +10,22 @@ export type McpAuthDiscovery =
   /** The server wants auth but the spec chain didn't complete — leave the tool as-is. */
   | { status: 'unsupported'; reason: string };
 
+/** Where a server's sign-in lives — the spec chain's answer before any client exists. */
+interface AuthorizationServerInfo {
+  authorizationUrl: string;
+  tokenUrl: string;
+  /** RFC 7591 endpoint, when the AS offers dynamic registration. */
+  registrationUrl?: string;
+  /** RFC 8707 resource indicator: the PRM's `resource`, else the MCP URL itself. */
+  resource: string;
+  scopes?: string[];
+}
+
+type AuthorizationServerResolution =
+  | { status: 'open' }
+  | { status: 'found'; as: AuthorizationServerInfo }
+  | { status: 'unsupported'; reason: string };
+
 const FETCH_TIMEOUT_MS = 5_000;
 /** Re-probe an open/unsupported server after this long (it may grow/lose auth). */
 const NEGATIVE_TTL_MS = 5 * 60_000;
@@ -37,12 +53,21 @@ const OAUTH_TTL_MS = 60 * 60_000;
  * row from the shared one, and the UTCP variable loader injects the fresh
  * access token into the manual's `Authorization` header at call time.
  *
+ * Providers without dynamic registration (HubSpot, Google) stop at step 3.
+ * For those, `providerForDeclaredClient` runs steps 1–3 for a client id the
+ * OWNER registered by hand and declared on the manual — same endpoints, same
+ * PKCE, same resource indicator, nothing persisted (the owner's client-secret
+ * save pins the completed provider).
+ *
  * Every fetch is SSRF-guarded (https-only, no redirects, bounded) — these URLs
  * originate from user-authored `.tool` files and remote servers' own metadata.
  */
 export class McpOAuthDiscoveryService {
   private readonly cache = new Map<string, { result: McpAuthDiscovery; expiresAt: number }>();
   private readonly inflight = new Map<string, Promise<McpAuthDiscovery>>();
+  /** The metadata walk alone, per MCP URL — shared by every declared client on that server. */
+  private readonly asCache = new Map<string, { result: AuthorizationServerResolution; expiresAt: number }>();
+  private readonly asInflight = new Map<string, Promise<AuthorizationServerResolution>>();
 
   constructor(
     private readonly deps: {
@@ -73,6 +98,30 @@ export class McpOAuthDiscoveryService {
       this.inflight.set(key, pending);
     }
     return pending;
+  }
+
+  /**
+   * The provider for a client the OWNER registered: the server's discovered
+   * endpoints + resource indicator around the declared `clientId`, PKCE on (the
+   * MCP spec requires it; a provider without it ignores the parameters). No
+   * registration call, no vault write — the metadata is cached per URL so a
+   * re-scan or a second declared client on the same server costs no network.
+   */
+  async providerForDeclaredClient(manualName: string, mcpUrl: string, clientId: string): Promise<McpAuthDiscovery> {
+    const resolved = await this.resolveAuthorizationServer(manualName, mcpUrl);
+    if (resolved.status === 'open') {
+      return {
+        status: 'unsupported',
+        reason:
+          'the server did not ask for a sign-in and publishes no OAuth metadata — declare `authorizationUrl` and `tokenUrl` on the sign-in variable if it needs one',
+      };
+    }
+    if (resolved.status === 'unsupported') return resolved;
+    const { authorizationUrl, tokenUrl, resource, scopes } = resolved.as;
+    return {
+      status: 'oauth',
+      provider: { authorizationUrl, tokenUrl, clientId, scopes, pkce: true, resource },
+    };
   }
 
   private remember(key: string, result: McpAuthDiscovery): McpAuthDiscovery {
@@ -114,6 +163,89 @@ export class McpOAuthDiscoveryService {
   }
 
   private async discoverFresh(manualName: string, key: string, mcpUrl: string): Promise<McpAuthDiscovery> {
+    const resolved = await this.resolveAuthorizationServer(manualName, mcpUrl);
+    if (resolved.status !== 'found') return resolved;
+    const { authorizationUrl, tokenUrl, registrationUrl, resource, scopes } = resolved.as;
+    if (!registrationUrl) {
+      return {
+        status: 'unsupported',
+        reason:
+          'the server requires sign-in but does not allow automatic client registration — register an OAuth app ' +
+          `with the provider (redirect URI: ${this.deps.redirectUri}), declare its client id on a user-scoped ` +
+          'sign-in variable (the server editor on the tool\'s page, or the plugin.json extensions entry), then set its client secret',
+      };
+    }
+
+    // 4. Dynamic client registration (RFC 7591), as a PUBLIC client: PKCE
+    //    carries the proof, no secret to store or leak.
+    assertSafeFetchUrl(registrationUrl, { requireHttps: true, label: 'registration_endpoint' });
+    const regRes = await this.fetchRaw(registrationUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        client_name: 'Bevel Knowledge Base',
+        redirect_uris: [this.deps.redirectUri],
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      }),
+    });
+    if (!regRes.ok) {
+      return { status: 'unsupported', reason: `client registration failed: HTTP ${regRes.status}` };
+    }
+    const reg = (await regRes.json().catch(() => null)) as Record<string, unknown> | null;
+    const clientId = typeof reg?.client_id === 'string' ? reg.client_id : '';
+    if (!clientId) {
+      return { status: 'unsupported', reason: 'client registration returned no client_id' };
+    }
+    const clientSecret = typeof reg?.client_secret === 'string' && reg.client_secret ? reg.client_secret : undefined;
+
+    const provider: OAuthProviderConfig = {
+      authorizationUrl,
+      tokenUrl,
+      clientId,
+      clientSecret,
+      scopes,
+      pkce: true,
+      publicClient: !clientSecret,
+      resource,
+    };
+    await this.deps.secretsVault.putSharedOAuthProvider({
+      key,
+      label: `${manualName} sign-in`,
+      provider,
+    });
+    // Return the stored (public) shape — no secret rides in cache entries.
+    const publicProvider = { ...provider };
+    delete publicProvider.clientSecret;
+    return { status: 'oauth', provider: publicProvider };
+  }
+
+  /** Steps 1–3, memoised per MCP URL (positive and negative alike, short TTL). */
+  private async resolveAuthorizationServer(manualName: string, mcpUrl: string): Promise<AuthorizationServerResolution> {
+    const cached = this.asCache.get(mcpUrl);
+    if (cached && cached.expiresAt > this.now()) return cached.result;
+    let pending = this.asInflight.get(mcpUrl);
+    if (!pending) {
+      pending = this.resolveAuthorizationServerFresh(mcpUrl)
+        .catch((err: unknown): AuthorizationServerResolution => ({
+          status: 'unsupported',
+          reason: err instanceof Error ? err.message : String(err),
+        }))
+        .then((result) => {
+          if (result.status === 'unsupported') {
+            console.warn(`[mcp-oauth-discovery] "${manualName}" (${mcpUrl}): ${result.reason}`);
+          }
+          this.asCache.set(mcpUrl, { result, expiresAt: this.now() + NEGATIVE_TTL_MS });
+          return result;
+        })
+        .finally(() => this.asInflight.delete(mcpUrl));
+      this.asInflight.set(mcpUrl, pending);
+    }
+    return pending;
+  }
+
+  private async resolveAuthorizationServerFresh(mcpUrl: string): Promise<AuthorizationServerResolution> {
     // 1. Probe: an unauthenticated initialize. A 401/403, or ANY response
     //    carrying a `WWW-Authenticate` challenge, means the server wants OAuth;
     //    a redirect to a login page (fetch throws under `redirect:'error'`)
@@ -205,57 +337,16 @@ export class McpOAuthDiscoveryService {
     if (!authorizationUrl || !tokenUrl) {
       return { status: 'unsupported', reason: 'authorization-server metadata is missing endpoints' };
     }
-    if (!registrationUrl) {
-      return {
-        status: 'unsupported',
-        reason:
-          'server requires sign-in but does not support automatic client registration — declare the oauth provider in the .tool file instead',
-      };
-    }
-
-    // 4. Dynamic client registration (RFC 7591), as a PUBLIC client: PKCE
-    //    carries the proof, no secret to store or leak.
-    assertSafeFetchUrl(registrationUrl, { requireHttps: true, label: 'registration_endpoint' });
-    const regRes = await this.fetchRaw(registrationUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({
-        client_name: 'Bevel Knowledge Base',
-        redirect_uris: [this.deps.redirectUri],
-        grant_types: ['authorization_code', 'refresh_token'],
-        response_types: ['code'],
-        token_endpoint_auth_method: 'none',
-      }),
-    });
-    if (!regRes.ok) {
-      return { status: 'unsupported', reason: `client registration failed: HTTP ${regRes.status}` };
-    }
-    const reg = (await regRes.json().catch(() => null)) as Record<string, unknown> | null;
-    const clientId = typeof reg?.client_id === 'string' ? reg.client_id : '';
-    if (!clientId) {
-      return { status: 'unsupported', reason: 'client registration returned no client_id' };
-    }
-    const clientSecret = typeof reg?.client_secret === 'string' && reg.client_secret ? reg.client_secret : undefined;
-
-    const provider: OAuthProviderConfig = {
-      authorizationUrl,
-      tokenUrl,
-      clientId,
-      clientSecret,
-      scopes,
-      pkce: true,
-      publicClient: !clientSecret,
-      resource,
+    return {
+      status: 'found',
+      as: {
+        authorizationUrl,
+        tokenUrl,
+        ...(registrationUrl ? { registrationUrl } : {}),
+        resource,
+        ...(scopes ? { scopes } : {}),
+      },
     };
-    await this.deps.secretsVault.putSharedOAuthProvider({
-      key,
-      label: `${manualName} sign-in`,
-      provider,
-    });
-    // Return the stored (public) shape — no secret rides in cache entries.
-    const publicProvider = { ...provider };
-    delete publicProvider.clientSecret;
-    return { status: 'oauth', provider: publicProvider };
   }
 
   private async fetchRaw(url: string, init: RequestInit): Promise<Response> {

--- a/packages/core-backend/src/modules/secrets-vault/secrets-vault.routes.ts
+++ b/packages/core-backend/src/modules/secrets-vault/secrets-vault.routes.ts
@@ -384,19 +384,37 @@ export function createSecretsVaultRoutes(deps: SecretsVaultRoutesDeps): express.
       if (!(await accessControl.canWrite(defaultWs(), email, found.manual.path))) {
         return void res.status(403).json({ error: 'You need write access to this tool to set its client secret.' });
       }
+      const { authorizationUrl, tokenUrl } = found.variable.oauth;
+      // A declaration that names only its client id is completed from the
+      // server's OAuth metadata at scan time. When that didn't happen, pinning
+      // the secret to a provider with no endpoints would leave every sign-in
+      // failing later with a far less specific error than the catalog's own.
+      if (!authorizationUrl || !tokenUrl) {
+        const why = found.manual.setup?.reason;
+        return void res.status(422).json({
+          error: why
+            ? `The sign-in endpoints for this server aren't known yet: ${why}.`
+            : "The sign-in endpoints for this server aren't known yet — declare `authorizationUrl` and `tokenUrl` on the sign-in variable.",
+        });
+      }
       const clientSecret = (req.body ?? {}).clientSecret;
       await secretsVault.putSharedOAuthClientSecret({
         key: varKey(found.manual.name, found.variable.name),
         clientSecret,
         provider: {
-          authorizationUrl: found.variable.oauth.authorizationUrl,
-          tokenUrl: found.variable.oauth.tokenUrl,
+          authorizationUrl,
+          tokenUrl,
           clientId: found.variable.oauth.clientId,
           scopes: found.variable.oauth.scopes,
           // Static authorize params (e.g. Google's `access_type=offline`) so the
           // provider returns a refresh token — stored with the secret so a later
           // `.tool` edit can't redirect the flow.
           authParams: found.variable.oauth.authParams,
+          // PKCE unless the declaration opted out; the resource indicator when
+          // the server (or the declaration) names one. Both pinned here for the
+          // same reason as the rest: the flow runs from the stored row.
+          pkce: found.variable.oauth.pkce !== false,
+          resource: found.variable.oauth.resource,
         },
       });
       res.status(201).json({ ok: true });

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-json-discovery.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-json-discovery.test.ts
@@ -188,6 +188,39 @@ describe('descriptorsFromMcpJson', () => {
     expect(out[0]?.variables?.[0]?.oauth?.clientId).toBe('c-1');
   });
 
+  it('accepts a client-id-only sign-in (endpoints discovered later), refuses half a pair, carries pkce/resource', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const declare = (oauth: unknown) =>
+      descriptorsFromMcpJson(
+        'GTM',
+        JSON.stringify({ mcpServers: { vendor: { type: 'streamable-http', url: 'https://v.example/mcp' } } }),
+        JSON.stringify({
+          name: 'gtm',
+          extensions: {
+            'software.bevel.hexis': { mcpServers: { vendor: { variables: [{ name: 'T', scope: 'user', oauth }] } } },
+          },
+        }),
+      )[0]?.variables?.[0]?.oauth;
+    // An MCP server publishes its endpoints — the client id alone is a complete declaration here.
+    expect(declare({ clientId: 'c' })).toEqual({ clientId: 'c' });
+    // …but half a pair is a broken declaration, not a discoverable one.
+    expect(declare({ clientId: 'c', authorizationUrl: 'https://v.example/auth' })).toBeUndefined();
+    expect(declare({ clientId: 'c', tokenUrl: 'https://v.example/token' })).toBeUndefined();
+    // An emptied editor field reads as absent, not as a malformed URL.
+    expect(declare({ clientId: 'c', authorizationUrl: '', tokenUrl: ' ' })).toEqual({ clientId: 'c' });
+    // PKCE is on by default: only the opt-out is stored, and it must be a boolean.
+    expect(declare({ clientId: 'c', pkce: true })).toEqual({ clientId: 'c' });
+    expect(declare({ clientId: 'c', pkce: false })).toEqual({ clientId: 'c', pkce: false });
+    expect(declare({ clientId: 'c', pkce: 'no' })).toBeUndefined();
+    // The resource indicator names the remote server — same https/SSRF bar as the endpoints.
+    expect(declare({ clientId: 'c', resource: 'https://v.example/mcp' })).toEqual({
+      clientId: 'c',
+      resource: 'https://v.example/mcp',
+    });
+    expect(declare({ clientId: 'c', resource: 'http://v.example/mcp' })).toBeUndefined();
+    expect(declare({ clientId: 'c', resource: 'https://169.254.169.254/mcp' })).toBeUndefined();
+  });
+
   it('yields nothing for an unparsable file, quietly for an absent extensions block', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(descriptorsFromMcpJson('GTM', '{ not json', null)).toEqual([]);

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-json-discovery.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-json-discovery.test.ts
@@ -219,6 +219,11 @@ describe('descriptorsFromMcpJson', () => {
     });
     expect(declare({ clientId: 'c', resource: 'http://v.example/mcp' })).toBeUndefined();
     expect(declare({ clientId: 'c', resource: 'https://169.254.169.254/mcp' })).toBeUndefined();
+    // A secret in a portable file never loads — same keys the `.tool` parser
+    // refuses, and the whole server is dropped rather than the key ignored.
+    expect(declare({ clientId: 'c', clientSecret: 'shh' })).toBeUndefined();
+    expect(declare({ clientId: 'c', client_secret: 'shh' })).toBeUndefined();
+    expect(declare({ clientId: 'c', secret: 'shh' })).toBeUndefined();
   });
 
   it('yields nothing for an unparsable file, quietly for an absent extensions block', () => {

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/mcp-server-edit.service.test.ts
@@ -290,6 +290,8 @@ describe('putServer', () => {
           oauth: { authorizationUrl: 'https://v.example/auth', tokenUrl: 'https://v.example/token', clientId: '   ' },
         },
       ],
+      [{ name: 'K', scope: 'user', oauth: { clientId: 'c', clientSecret: 'shh' } }], // a secret never lands in a file
+      [{ name: 'K', scope: 'user', oauth: { clientId: 'c', authorizationUrl: 'https://v.example/auth' } }], // half a pair
     ];
     const before = await readJson('Plugins/GTM/plugin.json');
     for (const variables of bad) {

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.mcp-oauth.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.mcp-oauth.test.ts
@@ -197,4 +197,99 @@ describe('ToolManualService — MCP OAuth auto-discovery decoration', () => {
     expect(survived.map((m) => m.name).sort()).toEqual(['jira', 'notion']);
     warn.mockRestore();
   });
+
+  /** An mcp.json server whose plugin.json declares a sign-in by client id alone. */
+  async function writeDeclaredServer(oauth: Record<string, unknown>) {
+    const pluginDir = join(root, wsId, KB_DIR, 'Plugins', 'GTM');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, 'mcp.json'),
+      JSON.stringify({ mcpServers: { hubspot: { type: 'streamable-http', url: 'https://mcp.hubspot.example/mcp' } } }),
+    );
+    await writeFile(
+      join(pluginDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'gtm',
+        extensions: {
+          'software.bevel.hexis': {
+            mcpServers: {
+              hubspot: {
+                headers: { Authorization: 'Bearer ${HUBSPOT_TOKEN}' },
+                variables: [{ name: 'HUBSPOT_TOKEN', scope: 'user', oauth }],
+              },
+            },
+          },
+        },
+      }),
+    );
+  }
+
+  test('a declared client id without endpoints is completed from the server metadata; a miss lands in setup.reason', async () => {
+    await writeDeclaredServer({ clientId: 'owner-app' });
+    const statusFor = vi.fn(async () => ({ status: 'open' as const }));
+    const providerForDeclaredClient = vi.fn(async () => ({
+      status: 'oauth' as const,
+      provider: {
+        authorizationUrl: 'https://auth.hubspot.example/authorize',
+        tokenUrl: 'https://auth.hubspot.example/token',
+        clientId: 'owner-app',
+        pkce: true,
+        resource: 'https://mcp.hubspot.example/mcp',
+      },
+    }));
+    const svc = svcWith({ statusFor, providerForDeclaredClient });
+    const hubspot = (await svc.listAccessible('user@example.com')).find((m) => m.name === 'hubspot')!;
+    // Explicit wins: a declared server is never probed for registration…
+    expect(statusFor).not.toHaveBeenCalledWith('hubspot', expect.anything());
+    expect(providerForDeclaredClient).toHaveBeenCalledWith('hubspot', 'https://mcp.hubspot.example/mcp', 'owner-app');
+    // …its declaration is completed in place — an owner-registered sign-in
+    // with nothing left to explain, so no `reason`.
+    expect(hubspot.setup).toEqual({ kind: 'oauth-manual' });
+    expect(hubspot.variables?.[0].oauth).toEqual({
+      clientId: 'owner-app',
+      authorizationUrl: 'https://auth.hubspot.example/authorize',
+      tokenUrl: 'https://auth.hubspot.example/token',
+      resource: 'https://mcp.hubspot.example/mcp',
+    });
+
+    // When the metadata can't be had, the declaration stays incomplete and the
+    // reason travels with the tool — to the UI banner and to `list_tool_setup`.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const missing = svcWith({
+      statusFor,
+      providerForDeclaredClient: async () => ({
+        status: 'unsupported' as const,
+        reason: 'no authorization-server metadata at https://mcp.hubspot.example',
+      }),
+    });
+    const stuck = (await missing.listAccessible('user@example.com')).find((m) => m.name === 'hubspot')!;
+    expect(stuck.setup).toEqual({
+      kind: 'oauth-manual',
+      reason: 'no authorization-server metadata at https://mcp.hubspot.example',
+    });
+    expect(stuck.variables?.[0].oauth).toEqual({ clientId: 'owner-app' });
+    // A port without the declared-client path says so rather than pretending.
+    const legacy = svcWith({ statusFor });
+    const unsupported = (await legacy.listAccessible('user@example.com')).find((m) => m.name === 'hubspot')!;
+    expect(unsupported.setup?.reason).toContain('discovery is unavailable');
+    warn.mockRestore();
+  });
+
+  test('a fully declared sign-in is oauth-manual with no reason, and is never probed', async () => {
+    await writeDeclaredServer({
+      clientId: 'owner-app',
+      authorizationUrl: 'https://auth.hubspot.example/authorize',
+      tokenUrl: 'https://auth.hubspot.example/token',
+      pkce: false,
+    });
+    const statusFor = vi.fn(async () => ({ status: 'open' as const }));
+    const providerForDeclaredClient = vi.fn();
+    const svc = svcWith({ statusFor, providerForDeclaredClient });
+    const hubspot = (await svc.listAccessible('user@example.com')).find((m) => m.name === 'hubspot')!;
+    expect(hubspot.setup).toEqual({ kind: 'oauth-manual' });
+    expect(providerForDeclaredClient).not.toHaveBeenCalled();
+    expect(statusFor).not.toHaveBeenCalledWith('hubspot', expect.anything());
+    // The declaration is carried verbatim, opt-out included.
+    expect(hubspot.variables?.[0].oauth).toMatchObject({ clientId: 'owner-app', pkce: false });
+  });
 });

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.service.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.service.test.ts
@@ -266,6 +266,22 @@ describe('ToolManualService', () => {
     expect(await svc().listAccessible('user@x.eu')).toHaveLength(0);
   });
 
+  test('carries oauth.pkce:false and a gated oauth.resource; a `.tool` still needs both endpoints', async () => {
+    await writeOAuthTool(oauthVar({ pkce: false, resource: 'https://api.example.com/mcp' }));
+    const [manual] = await svc().listAccessible('user@x.eu');
+    expect(manual.variables?.[0].oauth).toMatchObject({ pkce: false, resource: 'https://api.example.com/mcp' });
+    // PKCE is the default and is not echoed; only the opt-out is stored.
+    await writeOAuthTool(oauthVar({ pkce: true }));
+    expect((await svc().listAccessible('user@x.eu'))[0].variables?.[0].oauth).not.toHaveProperty('pkce');
+    await writeOAuthTool(oauthVar({ pkce: 'yes' }));
+    expect(await svc().listAccessible('user@x.eu')).toHaveLength(0);
+    await writeOAuthTool(oauthVar({ resource: 'http://localhost/mcp' }));
+    expect(await svc().listAccessible('user@x.eu')).toHaveLength(0);
+    // A `.tool` has no server whose metadata could fill the endpoints in.
+    await writeOAuthTool(oauthVar({ authorizationUrl: undefined }));
+    expect(await svc().listAccessible('user@x.eu')).toHaveLength(0);
+  });
+
   test('parses `remote`: default true, explicit false, rejects non-boolean', async () => {
     root = await mkdtemp(join(tmpdir(), 'toolsrem-'));
     const tools = join(root, wsId, KB_DIR, 'Plugins');

--- a/packages/core-backend/src/modules/tool-manuals/mcp-json-discovery.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-json-discovery.ts
@@ -109,6 +109,12 @@ export function validatedVariables(raw: unknown): ToolVariable[] | null {
       // to all callers.
       if (!isRecord(entry.oauth) || scope !== 'user') return null;
       const o = entry.oauth;
+      // Confidential material never loads from a file, on either declaration
+      // surface: the `.tool` parser throws on these keys, and silently
+      // dropping one here would leave a plugin.json carrying a secret that
+      // "worked" — the file is portable package data, readable by every
+      // client that loads the plugin.
+      if (o.clientSecret !== undefined || o.client_secret !== undefined || o.secret !== undefined) return null;
       // `clientId` is trimmed and must be non-empty, exactly as the `.tool`
       // parser requires: a whitespace-only value would pass discovery and
       // then fail the owner's client-secret setup with "clientId is

--- a/packages/core-backend/src/modules/tool-manuals/mcp-json-discovery.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-json-discovery.ts
@@ -106,28 +106,42 @@ export function validatedVariables(raw: unknown): ToolVariable[] | null {
     if (entry.oauth !== undefined) {
       // OAuth is inherently per-caller (same rule the `.tool` parser
       // enforces): an admin-shared OAuth token would leak one user's token
-      // to all callers. The provider config's required halves must be there
-      // — a sign-in wired to a missing URL is a declaration, not a feature.
+      // to all callers.
       if (!isRecord(entry.oauth) || scope !== 'user') return null;
       const o = entry.oauth;
       // `clientId` is trimmed and must be non-empty, exactly as the `.tool`
       // parser requires: a whitespace-only value would pass discovery and
       // then fail the owner's client-secret setup with "clientId is
       // required" — an error at the wrong surface, long after the save.
-      if (
-        typeof o.authorizationUrl !== 'string' ||
-        typeof o.tokenUrl !== 'string' ||
-        typeof o.clientId !== 'string' ||
-        !o.clientId.trim()
-      ) {
-        return null;
-      }
+      if (typeof o.clientId !== 'string' || !o.clientId.trim()) return null;
+      // The endpoints are OPTIONAL here, unlike in a `.tool`: an MCP server
+      // publishes its authorization-server metadata, so a declaration that
+      // names only the client id is completed at scan time. Both or neither
+      // — one URL without the other is a half-declaration, not a feature.
+      // An empty string counts as absent (the editor's cleared field).
+      const optionalUrl = (v: unknown): string | undefined | null => {
+        if (v === undefined || v === null) return undefined;
+        if (typeof v !== 'string') return null;
+        const trimmed = v.trim();
+        return trimmed ? trimmed : undefined;
+      };
+      const authorizationUrl = optionalUrl(o.authorizationUrl);
+      const tokenUrl = optionalUrl(o.tokenUrl);
+      const resource = optionalUrl(o.resource);
+      if (authorizationUrl === null || tokenUrl === null || resource === null) return null;
+      if ((authorizationUrl === undefined) !== (tokenUrl === undefined)) return null;
       // The same https + SSRF gate the `.tool` parser runs on these URLs: a
       // sign-in or token exchange aimed at an internal host is a declaration
-      // this surface must refuse exactly like the other one does.
+      // this surface must refuse exactly like the other one does. `resource`
+      // is never fetched, but it names the remote server — same bar.
       try {
-        assertSafeFetchUrl(o.authorizationUrl, { requireHttps: true, label: `${entry.name} oauth.authorizationUrl` });
-        assertSafeFetchUrl(o.tokenUrl, { requireHttps: true, label: `${entry.name} oauth.tokenUrl` });
+        if (authorizationUrl !== undefined) {
+          assertSafeFetchUrl(authorizationUrl, { requireHttps: true, label: `${entry.name} oauth.authorizationUrl` });
+          assertSafeFetchUrl(tokenUrl!, { requireHttps: true, label: `${entry.name} oauth.tokenUrl` });
+        }
+        if (resource !== undefined) {
+          assertSafeFetchUrl(resource, { requireHttps: true, label: `${entry.name} oauth.resource` });
+        }
       } catch {
         return null;
       }
@@ -138,14 +152,18 @@ export function validatedVariables(raw: unknown): ToolVariable[] | null {
           return null;
         }
       }
+      // PKCE is on unless the declaration says `false`; anything else there is
+      // a malformed flag, not a preference.
+      if (o.pkce !== undefined && typeof o.pkce !== 'boolean') return null;
       oauth = {
-        authorizationUrl: o.authorizationUrl,
-        tokenUrl: o.tokenUrl,
+        ...(authorizationUrl !== undefined ? { authorizationUrl, tokenUrl: tokenUrl! } : {}),
         clientId: o.clientId.trim(),
         ...(Array.isArray(o.scopes) && o.scopes.every((s) => typeof s === 'string')
           ? { scopes: o.scopes as string[] }
           : {}),
         ...(o.authParams !== undefined ? { authParams: o.authParams as Record<string, string> } : {}),
+        ...(o.pkce === false ? { pkce: false } : {}),
+        ...(resource !== undefined ? { resource } : {}),
       };
     }
     out.push({

--- a/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
@@ -209,7 +209,8 @@ export class McpServerEditService {
       throw new McpServerEditError(
         'The `variables` declaration is malformed — each entry needs a unique, non-reserved ' +
           'alphanumeric/underscore name, a scope of `admin` or `user`, and any `oauth` block must sit ' +
-          'on a `user`-scoped variable with valid https provider URLs and a client id.',
+          'on a `user`-scoped variable with a client id; its provider URLs are optional (discovered from ' +
+          'the server) but must be valid https URLs, both or neither, when given.',
         422,
       );
     }

--- a/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/mcp-server-edit.service.ts
@@ -209,8 +209,8 @@ export class McpServerEditService {
       throw new McpServerEditError(
         'The `variables` declaration is malformed — each entry needs a unique, non-reserved ' +
           'alphanumeric/underscore name, a scope of `admin` or `user`, and any `oauth` block must sit ' +
-          'on a `user`-scoped variable with a client id; its provider URLs are optional (discovered from ' +
-          'the server) but must be valid https URLs, both or neither, when given.',
+          'on a `user`-scoped variable with a client id and never a client secret; its provider URLs are ' +
+          'optional (discovered from the server) but must be valid https URLs, both or neither, when given.',
         422,
       );
     }

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.contract.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.contract.ts
@@ -30,10 +30,17 @@ export type ToolVariableScope = 'admin' | 'user';
  * present, the variable's value is obtained by signing in with this provider
  * (the per-user secret row is `kind:'oauth'`), rather than being typed. The
  * confidential client secret is provisioned separately by a tool writer.
+ *
+ * The endpoints are OPTIONAL for an `mcp.json` server: an MCP-spec server
+ * publishes its authorization-server metadata, so a declaration carrying only
+ * the `clientId` of an owner-registered app is completed at scan time
+ * (`authorizationUrl`/`tokenUrl`/`resource` filled in from that metadata). A
+ * `.tool` manual has no server to ask, so there both URLs are required.
  */
 export interface ToolVariableOAuth {
-  authorizationUrl: string;
-  tokenUrl: string;
+  /** Absent on an mcp.json server ⇒ discovered from the server's OAuth metadata. */
+  authorizationUrl?: string;
+  tokenUrl?: string;
   clientId: string;
   scopes?: string[];
   /**
@@ -45,6 +52,20 @@ export interface ToolVariableOAuth {
    * secret is still provisioned only through the protected route.
    */
   authParams?: Record<string, string>;
+  /**
+   * PKCE (S256) on the authorization-code flow. ON unless explicitly `false`:
+   * the MCP authorization spec requires it, and a provider that doesn't
+   * implement it ignores the extra parameters (RFC 6749 §3.1). Only `false` is
+   * ever stored — absent means the default.
+   */
+  pkce?: boolean;
+  /**
+   * RFC 8707 resource indicator — the MCP server's canonical URL, so the token
+   * is audience-bound. Filled in from the server's metadata for an mcp.json
+   * server; declare it by hand only when the provider demands it and the
+   * endpoints are declared by hand too.
+   */
+  resource?: string;
 }
 
 /**
@@ -74,14 +95,18 @@ export interface ToolVariable {
  *  - `open`         — the server needs no auth; nothing to configure.
  *  - `oauth-auto`   — OAuth was auto-configured; the sign-in appears as a
  *                     `user`-scoped variable, so users just authorize.
- *  - `oauth-manual` — the server needs OAuth but auto-discovery couldn't set it
- *                     up (typically no dynamic client registration, e.g. Google);
- *                     a tool writer must declare the provider in the `.tool` file
- *                     and set its client secret. `reason` says exactly why.
+ *  - `oauth-manual` — the server needs OAuth with an OWNER-REGISTERED client:
+ *                     auto-discovery couldn't register one (typically no dynamic
+ *                     client registration — Google, HubSpot), or the declaration
+ *                     already names a client id. A tool writer declares the
+ *                     sign-in on a `user`-scoped variable (the server editor for
+ *                     an `mcp.json` server; the `variables` block of a `.tool`)
+ *                     and sets its client secret. `reason` is present only while
+ *                     something is still missing, and says exactly what.
  */
 export interface ToolManualSetup {
   kind: 'open' | 'oauth-auto' | 'oauth-manual';
-  /** Why auto-setup didn't complete — present for `oauth-manual`. */
+  /** What still blocks the sign-in — present for an unfinished `oauth-manual`. */
   reason?: string;
 }
 

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
@@ -106,18 +106,31 @@ const variableSubstitutor = new DefaultVariableSubstitutor();
  * the vault applies in the other direction with `VariableScopeResolver`.
  */
 export interface McpAuthDiscoveryPort {
-  statusFor(
-    manualName: string,
-    mcpUrl: string,
-  ): Promise<
-    | { status: 'open' }
-    | {
-        status: 'oauth';
-        provider: { authorizationUrl: string; tokenUrl: string; clientId: string; scopes?: string[] };
-      }
-    | { status: 'unsupported'; reason: string }
-  >;
+  statusFor(manualName: string, mcpUrl: string): Promise<McpAuthDiscoveryResult>;
+  /**
+   * The sign-in endpoints for an OWNER-REGISTERED client: the same metadata
+   * walk as `statusFor`, stopping short of dynamic registration — the manual
+   * already names its `clientId`. Nothing is persisted; the owner's
+   * client-secret save pins the completed provider. Optional so a port that
+   * only knows the zero-config path still satisfies the interface.
+   */
+  providerForDeclaredClient?(manualName: string, mcpUrl: string, clientId: string): Promise<McpAuthDiscoveryResult>;
 }
+
+export type McpAuthDiscoveryResult =
+  | { status: 'open' }
+  | {
+      status: 'oauth';
+      provider: {
+        authorizationUrl: string;
+        tokenUrl: string;
+        clientId: string;
+        scopes?: string[];
+        resource?: string;
+        pkce?: boolean;
+      };
+    }
+  | { status: 'unsupported'; reason: string };
 
 /**
  * Reads `*.tool` manuals from the DEFAULT-branch workspace (never the caller's
@@ -429,21 +442,35 @@ export class ToolManualService implements IToolManualService {
   private async decorateMcpOAuth(manuals: ToolManualDescriptor[]): Promise<void> {
     const discovery = this.mcpAuthDiscovery;
     if (!discovery) return;
-    const eligible = manuals.filter((m) => {
-      if (m.type !== 'mcp' || !m.url) return false;
-      // Local-only servers aren't probeable from here; templated URLs aren't
-      // resolvable without a caller. Both keep their file-declared behavior.
-      if (m.remote === false || m.url.includes('${')) return false;
+    // Local-only servers aren't probeable from here; templated URLs aren't
+    // resolvable without a caller. Both keep their file-declared behavior.
+    const probeable = (m: ToolManualDescriptor): boolean =>
+      !!m.url && m.remote !== false && !m.url.includes('${');
+    const bare: ToolManualDescriptor[] = [];
+    const declared: { m: ToolManualDescriptor; v: ToolVariable }[] = [];
+    for (const m of manuals) {
+      if (m.type !== 'mcp') continue;
+      const oauthVar = (m.variables ?? []).find((v) => v.oauth != null);
+      if (oauthVar) {
+        // An owner-registered client is `oauth-manual` by definition — whether
+        // the declaration is complete or still needs its endpoints discovered.
+        // Explicit wins over discovery: never registered over, never probed
+        // for anything but the endpoints the declaration left out.
+        m.setup = { kind: 'oauth-manual' };
+        const o = oauthVar.oauth!;
+        if (!o.authorizationUrl || !o.tokenUrl) declared.push({ m, v: oauthVar });
+        continue;
+      }
       // The file configures auth itself — explicit wins over discovery.
       const hasAuthHeader = Object.keys(m.headers ?? {}).some((h) => h.toLowerCase() === 'authorization');
-      const hasOAuthVar = (m.variables ?? []).some((v) => v.oauth != null);
-      return !hasAuthHeader && !hasOAuthVar;
-    });
+      if (!hasAuthHeader && probeable(m)) bare.push(m);
+    }
     // Probe every eligible server CONCURRENTLY — a cold scan with several bare
     // mcp tools shouldn't pay one network round-trip per tool in series. The
     // mutation still happens per-manual after its own probe settles.
-    await Promise.all(
-      eligible.map(async (m) => {
+    await Promise.all([
+      ...declared.map(({ m, v }) => this.completeDeclaredOAuth(discovery, m, v)),
+      ...bare.map(async (m) => {
         try {
           const found = await discovery.statusFor(m.name, m.url!);
           // Record the setup requirement so the secrets UI can tell an admin
@@ -488,7 +515,62 @@ export class ToolManualService implements IToolManualService {
           );
         }
       }),
-    );
+    ]);
+  }
+
+  /**
+   * "Bring your own client": a declared sign-in that names only its `clientId`
+   * (the owner registered an app with a provider that offers no dynamic
+   * registration — HubSpot, Google) gets its endpoints, PKCE and resource
+   * indicator from the server's own OAuth metadata, exactly as the zero-config
+   * path would. The descriptor is completed IN MEMORY: the client-secret route
+   * reads the completed declaration and pins it with the secret, so nothing
+   * here persists. When the metadata can't be had, the declaration stays
+   * incomplete and `setup.reason` says so — the secret route then refuses
+   * with the same reason instead of pinning a provider with no endpoints.
+   */
+  private async completeDeclaredOAuth(
+    discovery: McpAuthDiscoveryPort,
+    m: ToolManualDescriptor,
+    v: ToolVariable,
+  ): Promise<void> {
+    const declaredByHand = 'declare `authorizationUrl` and `tokenUrl` on the sign-in variable';
+    if (!m.url || m.remote === false || m.url.includes('${')) {
+      m.setup = {
+        kind: 'oauth-manual',
+        reason: `the sign-in endpoints can't be discovered for a local-only or templated server URL — ${declaredByHand}`,
+      };
+      return;
+    }
+    if (!discovery.providerForDeclaredClient) {
+      m.setup = { kind: 'oauth-manual', reason: `sign-in endpoint discovery is unavailable — ${declaredByHand}` };
+      return;
+    }
+    try {
+      const found = await discovery.providerForDeclaredClient(m.name, m.url, v.oauth!.clientId);
+      if (found.status !== 'oauth') {
+        m.setup = {
+          kind: 'oauth-manual',
+          reason:
+            found.status === 'unsupported'
+              ? found.reason
+              : `the server did not ask for a sign-in and publishes no OAuth metadata — ${declaredByHand} if it needs one`,
+        };
+        return;
+      }
+      v.oauth = {
+        ...v.oauth!,
+        authorizationUrl: found.provider.authorizationUrl,
+        tokenUrl: found.provider.tokenUrl,
+        // A hand-declared resource wins; otherwise the server's own canonical URL.
+        ...(!v.oauth!.resource && found.provider.resource ? { resource: found.provider.resource } : {}),
+      };
+    } catch (err) {
+      // Never break the catalog — the sign-in just isn't ready yet.
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[tool-manuals] sign-in endpoint discovery failed for "${m.path}": ${msg}`);
+      m.setup = { kind: 'oauth-manual', reason: `sign-in endpoint discovery failed: ${msg}` };
+    }
   }
 
   private async scanDisk(): Promise<ToolManualDescriptor[]> {
@@ -845,7 +927,9 @@ function normalizeVariables(raw: unknown): ToolVariable[] {
  * Parse a variable's optional OAuth provider config. Carries PUBLIC config only —
  * never a client secret. Both URLs are validated with the SAME SSRF-safe check the
  * vault uses for OAuth endpoints (`assertSafeFetchUrl` with https required), so a
- * `.tool` author can't aim a sign-in/token exchange at an internal host.
+ * `.tool` author can't aim a sign-in/token exchange at an internal host. Both
+ * URLs are REQUIRED here: a `.tool` (http/inline) has no server whose OAuth
+ * metadata could fill them in — that convenience belongs to mcp.json servers.
  */
 function normalizeVariableOAuth(name: string, raw: unknown): ToolVariableOAuth | undefined {
   if (raw === undefined || raw === null) return undefined;
@@ -891,12 +975,21 @@ function normalizeVariableOAuth(name: string, raw: unknown): ToolVariableOAuth |
     }
     authParams = Object.fromEntries(entries) as Record<string, string>;
   }
+  // PKCE is on unless the file says `false`; only the opt-out is ever stored.
+  if (o.pkce !== undefined && typeof o.pkce !== 'boolean') {
+    throw new Error(`variable "${name}" oauth.pkce must be a boolean`);
+  }
+  // Never fetched (it rides as a request param), but it names the remote
+  // server — same https/SSRF bar as the endpoints.
+  const resource = o.resource !== undefined ? safeUrl(o.resource, 'resource') : undefined;
   return {
     authorizationUrl,
     tokenUrl,
     clientId,
     ...(scopes ? { scopes } : {}),
     ...(authParams ? { authParams } : {}),
+    ...(o.pkce === false ? { pkce: false } : {}),
+    ...(resource ? { resource } : {}),
   };
 }
 

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
@@ -442,10 +442,6 @@ export class ToolManualService implements IToolManualService {
   private async decorateMcpOAuth(manuals: ToolManualDescriptor[]): Promise<void> {
     const discovery = this.mcpAuthDiscovery;
     if (!discovery) return;
-    // Local-only servers aren't probeable from here; templated URLs aren't
-    // resolvable without a caller. Both keep their file-declared behavior.
-    const probeable = (m: ToolManualDescriptor): boolean =>
-      !!m.url && m.remote !== false && !m.url.includes('${');
     const bare: ToolManualDescriptor[] = [];
     const declared: { m: ToolManualDescriptor; v: ToolVariable }[] = [];
     for (const m of manuals) {
@@ -463,7 +459,7 @@ export class ToolManualService implements IToolManualService {
       }
       // The file configures auth itself — explicit wins over discovery.
       const hasAuthHeader = Object.keys(m.headers ?? {}).some((h) => h.toLowerCase() === 'authorization');
-      if (!hasAuthHeader && probeable(m)) bare.push(m);
+      if (!hasAuthHeader && isProbeableMcpServer(m)) bare.push(m);
     }
     // Probe every eligible server CONCURRENTLY — a cold scan with several bare
     // mcp tools shouldn't pay one network round-trip per tool in series. The
@@ -535,7 +531,7 @@ export class ToolManualService implements IToolManualService {
     v: ToolVariable,
   ): Promise<void> {
     const declaredByHand = 'declare `authorizationUrl` and `tokenUrl` on the sign-in variable';
-    if (!m.url || m.remote === false || m.url.includes('${')) {
+    if (!isProbeableMcpServer(m)) {
       m.setup = {
         kind: 'oauth-manual',
         reason: `the sign-in endpoints can't be discovered for a local-only or templated server URL — ${declaredByHand}`,
@@ -547,7 +543,7 @@ export class ToolManualService implements IToolManualService {
       return;
     }
     try {
-      const found = await discovery.providerForDeclaredClient(m.name, m.url, v.oauth!.clientId);
+      const found = await discovery.providerForDeclaredClient(m.name, m.url!, v.oauth!.clientId);
       if (found.status !== 'oauth') {
         m.setup = {
           kind: 'oauth-manual',
@@ -921,6 +917,16 @@ function normalizeVariables(raw: unknown): ToolVariable[] {
       ...(oauth ? { oauth } : {}),
     };
   });
+}
+
+/**
+ * Whether the platform can reach an MCP server's URL for OAuth discovery.
+ * Local-only servers aren't probeable from here; templated URLs aren't
+ * resolvable without a caller. Both keep their file-declared behavior — the
+ * one rule for the zero-config probe and for completing a declared client.
+ */
+function isProbeableMcpServer(m: ToolManualDescriptor): boolean {
+  return !!m.url && m.remote !== false && !m.url.includes('${');
 }
 
 /**

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.tools.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.tools.ts
@@ -69,9 +69,12 @@ export function registerToolManualsTools(
       'what is already configured. Results are scoped to the caller — a `.tool` the caller cannot READ is ' +
       'absent entirely, and all status flags reflect the caller\'s own state. Per tool: `setup` describes ' +
       'an MCP server\'s sign-in requirement (`open` = none; `oauth-auto` = sign-in was configured ' +
-      'automatically; `oauth-manual` = the provider does not support automatic registration, so a writer ' +
-      'must declare the OAuth provider in the `.tool` file and paste its client secret into the tool ' +
-      'editor). Per variable: whether the shared (admin) value is set, whether the CURRENT user has ' +
+      'automatically; `oauth-manual` = the sign-in needs an OAuth app the owner registers with the provider: ' +
+      'a writer declares its client id on a `user`-scoped variable with an `oauth` block — in the plugin.json ' +
+      'extensions entry for an mcp.json server (endpoints are discovered from the server; PKCE is on by ' +
+      'default), or in the `.tool` file with explicit URLs — and pastes the client secret on the tool\'s page. ' +
+      '`setup.reason` is present only while something still blocks the sign-in and says what). ' +
+      'Per variable: whether the shared (admin) value is set, whether the CURRENT user has ' +
       'set/authorized their own, and whether it is an OAuth sign-in (users authorize those on the /connect ' +
       'page, never by typing a value). `canWrite` = the caller may write THAT `.tool` FILE (per-file access ' +
       'from its frontmatter `write:`/`owner:` verbs and the access.md chain — NOT a platform role), which ' +

--- a/packages/core-frontend/src/modules/library/__tests__/McpServerSection.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/McpServerSection.test.tsx
@@ -135,4 +135,99 @@ describe('McpServerSection', () => {
     await waitFor(() => expect(apiMock.putMcpServer).toHaveBeenCalledTimes(1));
     expect(apiMock.putMcpServer.mock.calls[0]![1]).toMatchObject({ newName: 'vendor_eu' });
   });
+
+  it('shows everything the two files store: headers, variables, and a declared sign-in', async () => {
+    // What mcp.json + plugin.json say is what the reader sees — no opening
+    // either file to learn what is configured.
+    apiMock.getMcpServer.mockResolvedValue({
+      ...VIEW,
+      canWrite: false,
+      description: 'Vendor CRM',
+      variables: [
+        { name: 'VENDOR_KEY', scope: 'user' },
+        {
+          name: 'SIGNIN',
+          scope: 'user',
+          label: 'Vendor sign-in',
+          oauth: { clientId: 'app-1', scopes: ['crm.read'], pkce: false },
+        },
+      ],
+    });
+    renderSection();
+    expect(await screen.findByText('X-V: 2')).toBeInTheDocument();
+    expect(screen.getByText('Authorization: Bearer ${VENDOR_KEY}')).toBeInTheDocument();
+    expect(screen.getByText('Vendor CRM')).toBeInTheDocument();
+    expect(screen.getByText('${SIGNIN}')).toBeInTheDocument();
+    expect(screen.getByText('app-1')).toBeInTheDocument();
+    expect(screen.getByText('Endpoints: discovered from the server')).toBeInTheDocument();
+    expect(screen.getByText('Scopes: crm.read')).toBeInTheDocument();
+    expect(screen.getByText('PKCE: off')).toBeInTheDocument();
+  });
+
+  it('declares a sign-in on a user variable: client id only, endpoints discovered, header pre-filled', async () => {
+    apiMock.getMcpServer.mockResolvedValue({
+      ...VIEW,
+      authHeaders: {},
+      variables: [{ name: 'HUBSPOT_TOKEN', scope: 'user' }],
+    });
+    renderSection();
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit server' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Variable 1 OAuth sign-in' }));
+    // The header the token needs appears where the writer can see and change it.
+    expect(screen.getByRole('textbox', { name: /Auth headers/ })).toHaveValue(
+      'Authorization: Bearer ${HUBSPOT_TOKEN}',
+    );
+    fireEvent.change(screen.getByRole('textbox', { name: 'Variable 1 client id' }), {
+      target: { value: ' app-1 ' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Variable 1 scopes' }), {
+      target: { value: 'crm.read crm.write' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(apiMock.putMcpServer).toHaveBeenCalledTimes(1));
+    const write = apiMock.putMcpServer.mock.calls[0]![1];
+    expect(write).toMatchObject({
+      authHeaders: { Authorization: 'Bearer ${HUBSPOT_TOKEN}' },
+      variables: [
+        { name: 'HUBSPOT_TOKEN', scope: 'user', oauth: { clientId: 'app-1', scopes: ['crm.read', 'crm.write'] } },
+      ],
+    });
+    // Exactly what the file will store: no endpoints (discovered), no
+    // `pkce` (on is the default — only an opt-out is written).
+    expect(write.variables[0].oauth).not.toHaveProperty('authorizationUrl');
+    expect(write.variables[0].oauth).not.toHaveProperty('pkce');
+  });
+
+  it('sends hand-entered endpoints and the PKCE opt-out exactly as the file will store them', async () => {
+    apiMock.getMcpServer.mockResolvedValue({
+      ...VIEW,
+      variables: [{ name: 'SIGNIN', scope: 'user', oauth: { clientId: 'app-1' } }],
+    });
+    renderSection();
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit server' }));
+    // An Authorization header already exists — nothing is pre-filled over it.
+    expect(screen.getByRole('textbox', { name: /Auth headers/ })).toHaveValue('Authorization: Bearer ${VENDOR_KEY}');
+    fireEvent.click(screen.getByRole('radio', { name: 'Variable 1 endpoints by hand' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Variable 1 authorization URL' }), {
+      target: { value: 'https://p.example/auth' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Variable 1 token URL' }), {
+      target: { value: 'https://p.example/token' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Variable 1 PKCE' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(apiMock.putMcpServer).toHaveBeenCalledTimes(1));
+    expect(apiMock.putMcpServer.mock.calls[0]![1].variables).toEqual([
+      {
+        name: 'SIGNIN',
+        scope: 'user',
+        oauth: {
+          authorizationUrl: 'https://p.example/auth',
+          tokenUrl: 'https://p.example/token',
+          clientId: 'app-1',
+          pkce: false,
+        },
+      },
+    ]);
+  });
 });

--- a/packages/core-frontend/src/modules/library/__tests__/ToolConnectionSection.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/ToolConnectionSection.test.tsx
@@ -122,6 +122,37 @@ describe('ToolConnectionSection', () => {
     expect(screen.queryByRole('button', { name: 'Edit the tool file' })).toBeNull();
   });
 
+  it('sends the owner of an mcp.json server to "Edit server" on this page, not to a file', () => {
+    renderSection(tool({ path: 'Plugins/GTM/mcp.json', setup: OAUTH_MANUAL, canWrite: true }));
+    expect(screen.getByRole('status')).toHaveTextContent(/under "Edit server" below/);
+    expect(screen.queryByRole('button', { name: 'Edit the tool file' })).toBeNull();
+  });
+
+  it('once the sign-in is declared, asks the owner only for the client secret', () => {
+    renderSection(
+      tool({
+        setup: { kind: 'oauth-manual' },
+        canWrite: true,
+        variables: [
+          {
+            name: 'SIGNIN',
+            scope: 'user',
+            label: null,
+            key: 'github_SIGNIN',
+            adminConfigured: false,
+            userConfigured: false,
+            oauth: true,
+            authorized: false,
+          },
+        ],
+      }),
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'the sign-in is declared — set its client secret below to finish',
+    );
+    expect(screen.queryByRole('button', { name: 'Edit the tool file' })).toBeNull();
+  });
+
   it('omits the edit link while the workspace has no kb directory yet', () => {
     renderSection(tool({ setup: OAUTH_MANUAL, canWrite: true }), null);
     expect(screen.getByRole('status')).toBeInTheDocument();

--- a/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/McpServerSection.tsx
@@ -4,6 +4,7 @@ import { Badge, Banner, Button, Dialog } from '../../../../shared/components';
 import {
   getMcpServer,
   putMcpServer,
+  type McpServerVariable,
   type McpServerView,
   type McpTransport,
 } from '../../services/tools.api';
@@ -14,6 +15,13 @@ import { pathForTool } from '../../routes/library-paths';
  * replaces dropping a writer into raw JSON. It shows nothing for `.tool`
  * manuals (the GET 404s: those edit as files) and renders read-only facts for
  * non-writers, whose editing surface this page has never been.
+ *
+ * WHAT THE FILES SAY IS WHAT THE PAGE SHOWS. One server's truth spans two
+ * files (mcp.json for the portable half, plugin.json's extensions block for
+ * ours), and the reader should not have to open either to know what is
+ * configured: the read-only view lists every stored fact — headers, declared
+ * variables, a sign-in's client id and endpoints — and the editor edits
+ * exactly those, so a save changes nothing the view didn't show.
  *
  * RENAME CONFIRMS, WITH THE COST NAMED. The server's name is the namespace
  * its vault secrets bind to (`<name>_<VAR>`), so renaming disconnects every
@@ -49,7 +57,7 @@ export function McpServerSection({
   const [literalHeaders, setLiteralHeaders] = useState('');
   const [authHeaders, setAuthHeaders] = useState('');
   const [local, setLocal] = useState(false);
-  const [variables, setVariables] = useState<McpServerView['variables']>([]);
+  const [variables, setVariables] = useState<McpServerVariable[]>([]);
 
   useEffect(() => {
     let live = true;
@@ -83,6 +91,20 @@ export function McpServerSection({
     setEditing(true);
   };
 
+  /**
+   * A sign-in's token has to reach the server somehow — turning one on
+   * pre-fills the `Authorization` header the variable loader will fill,
+   * VISIBLY, in the auth-headers field the writer is already looking at.
+   * Never over an Authorization header that's already there.
+   */
+  const suggestAuthHeader = (varName: string) => {
+    if (!varName) return;
+    const has = Object.keys(linesToHeaders(authHeaders)).some((h) => h.toLowerCase() === 'authorization');
+    if (has) return;
+    const line = `Authorization: Bearer \${${varName}}`;
+    setAuthHeaders((prev) => (prev.trim() ? `${prev.replace(/\n+$/, '')}\n${line}` : line));
+  };
+
   const save = async () => {
     const renaming = name.trim() !== server.name;
     // EVERY rename confirms: this caller's page only knows their own and the
@@ -111,9 +133,7 @@ export function McpServerSection({
           : { url: url.trim() }),
         literalHeaders: linesToHeaders(literalHeaders),
         authHeaders: linesToHeaders(authHeaders),
-        variables: variables
-          .map((v) => ({ ...v, name: v.name.trim(), label: v.label?.trim() || undefined }))
-          .filter((v) => v.name.length > 0),
+        variables: variables.map(normalizeVariable).filter((v) => v.name.length > 0),
         ...(server.description ? { description: server.description } : {}),
         local,
       });
@@ -144,31 +164,7 @@ export function McpServerSection({
 
       {!editing && (
         <div className="flex items-start justify-between gap-4 rounded-md border border-line px-3.5 py-2.5">
-          <dl className="min-w-0 text-detail text-ink-muted">
-            <div className="flex gap-2">
-              <dt className="shrink-0 font-semibold">Transport</dt>
-              <dd>{server.transport}</dd>
-            </div>
-            {server.url && (
-              <div className="flex gap-2">
-                <dt className="shrink-0 font-semibold">URL</dt>
-                <dd className="truncate">{server.url}</dd>
-              </div>
-            )}
-            {server.command && (
-              <div className="flex gap-2">
-                <dt className="shrink-0 font-semibold">Command</dt>
-                <dd className="truncate">
-                  {server.command} {(server.args ?? []).join(' ')}
-                </dd>
-              </div>
-            )}
-            {server.local && (
-              <div className="mt-1 text-ink-faint">
-                Runs locally — served by the local knowledge server on each member's machine, never by the workspace.
-              </div>
-            )}
-          </dl>
+          <ServerFacts server={server} />
           {server.canWrite && (
             <Button variant="outline" size="sm" onClick={openEditor}>
               Edit server
@@ -207,7 +203,7 @@ export function McpServerSection({
             hint="One `Header: value` per line. Visible package data — no secrets here." />
           <LabeledTextarea label="Auth headers" value={authHeaders} onChange={setAuthHeaders}
             hint="One per line; values may use ${VAR} vault references, e.g. `Authorization: Bearer ${API_KEY}`." />
-          <VariablesEditor variables={variables} onChange={setVariables} />
+          <VariablesEditor variables={variables} onChange={setVariables} onSignInEnabled={suggestAuthHeader} />
           {transport !== 'stdio' && (
             <label className="flex items-center gap-2 text-detail text-ink-muted">
               <input type="checkbox" checked={local} onChange={(e) => setLocal(e.target.checked)} />
@@ -245,6 +241,109 @@ export function McpServerSection({
         </Dialog>
       )}
     </section>
+  );
+}
+
+/**
+ * Everything the two files store about this server, read-only. Facts are
+ * grouped the way the files split them — portable (mcp.json) first, then
+ * ours (plugin.json) — so a reader can tell where an edit by hand would land.
+ * Nothing is elided: a header, a declared variable, a sign-in's endpoints all
+ * appear here exactly as saved, or the editor would be changing invisible state.
+ */
+function ServerFacts({ server }: { server: McpServerView }) {
+  const literal = Object.entries(server.literalHeaders);
+  const auth = Object.entries(server.authHeaders);
+  return (
+    <dl className="min-w-0 flex-1 text-detail text-ink-muted" aria-label="Server configuration">
+      <Fact label="Transport">{server.transport}</Fact>
+      {server.url && <Fact label="URL" mono>{server.url}</Fact>}
+      {server.command && (
+        <Fact label="Command" mono>
+          {server.command} {(server.args ?? []).join(' ')}
+        </Fact>
+      )}
+      {server.description && <Fact label="Description">{server.description}</Fact>}
+      {literal.length > 0 && (
+        <Fact label="Headers">
+          <HeaderList entries={literal} />
+        </Fact>
+      )}
+      {auth.length > 0 && (
+        <Fact label="Auth headers">
+          <HeaderList entries={auth} />
+        </Fact>
+      )}
+      {server.variables.length > 0 && (
+        <Fact label="Variables">
+          <ul className="flex flex-col gap-1">
+            {server.variables.map((v) => (
+              <li key={v.name}>
+                <code className="rounded-sm bg-sunken px-1 py-0.5 font-mono text-meta text-ink">{`\${${v.name}}`}</code>{' '}
+                <span>{v.scope === 'user' ? 'each member their own' : 'one shared value'}</span>
+                {v.label && <span className="text-ink-faint"> — {v.label}</span>}
+                {v.oauth && <SignInFacts oauth={v.oauth} />}
+              </li>
+            ))}
+          </ul>
+        </Fact>
+      )}
+      {server.local && (
+        <div className="mt-1 text-ink-faint">
+          Runs locally — served by the local knowledge server on each member's machine, never by the workspace.
+        </div>
+      )}
+    </dl>
+  );
+}
+
+/** A declared sign-in, as stored: client id, where the endpoints come from, scopes, PKCE. */
+function SignInFacts({ oauth }: { oauth: NonNullable<McpServerVariable['oauth']> }) {
+  const discovered = !oauth.authorizationUrl || !oauth.tokenUrl;
+  return (
+    <ul className="ml-4 mt-0.5 flex list-disc flex-col gap-0.5 text-ink-faint">
+      <li>
+        OAuth sign-in · client id <code className="font-mono text-ink-muted">{oauth.clientId}</code>
+      </li>
+      <li>
+        {discovered ? (
+          <>Endpoints: discovered from the server</>
+        ) : (
+          <>
+            Authorize <code className="font-mono">{oauth.authorizationUrl}</code> · Token{' '}
+            <code className="font-mono">{oauth.tokenUrl}</code>
+          </>
+        )}
+      </li>
+      {oauth.scopes && oauth.scopes.length > 0 && <li>Scopes: {oauth.scopes.join(' ')}</li>}
+      <li>PKCE: {oauth.pkce === false ? 'off' : 'on'}</li>
+      {oauth.resource && (
+        <li>
+          Resource <code className="font-mono">{oauth.resource}</code>
+        </li>
+      )}
+    </ul>
+  );
+}
+
+function Fact({ label, mono, children }: { label: string; mono?: boolean; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="shrink-0 font-semibold">{label}</dt>
+      <dd className={`min-w-0 ${mono ? 'truncate font-mono' : ''}`}>{children}</dd>
+    </div>
+  );
+}
+
+function HeaderList({ entries }: { entries: [string, string][] }) {
+  return (
+    <ul className="flex flex-col">
+      {entries.map(([k, v]) => (
+        <li key={k} className="truncate font-mono">
+          {k}: {v}
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -303,51 +402,198 @@ function LabeledTextarea({
  * by a tool writer) or `user` (each member their own, on the Connect page).
  * The names must match the `${VAR}` references in the auth headers — the vault
  * key is `<server>_<VAR>`, derived from exactly these names.
+ *
+ * A user-scoped variable can be an OAuth SIGN-IN instead of a typed value:
+ * the owner's OAuth app's client id, endpoints discovered from the server
+ * (or entered by hand for a provider that publishes none), scopes, PKCE. The
+ * fields mirror the `oauth` block plugin.json stores, one to one — what an
+ * agent would write into the file is what this form writes.
  */
 function VariablesEditor({
   variables,
   onChange,
+  onSignInEnabled,
 }: {
-  variables: McpServerView['variables'];
-  onChange(next: McpServerView['variables']): void;
+  variables: McpServerVariable[];
+  onChange(next: McpServerVariable[]): void;
+  /** A sign-in was just switched on for this variable name — the parent may wire its header. */
+  onSignInEnabled(varName: string): void;
 }) {
-  const update = (i: number, patch: Partial<McpServerView['variables'][number]>) =>
+  const update = (i: number, patch: Partial<McpServerVariable>) =>
     onChange(variables.map((v, j) => (j === i ? { ...v, ...patch } : v)));
+  const updateOAuth = (i: number, patch: Partial<NonNullable<McpServerVariable['oauth']>>) =>
+    onChange(
+      variables.map((v, j) =>
+        j === i && v.oauth ? { ...v, oauth: { ...v.oauth, ...patch } } : v,
+      ),
+    );
   return (
     <div className="flex flex-col gap-1 text-detail">
       <span className="font-semibold text-ink">Variables</span>
-      {variables.map((v, i) => (
-        // Index keys are correct here: rows are edited in place and have no
-        // identity beyond their position until saved.
-        // eslint-disable-next-line react/no-array-index-key
-        <div key={i} className="flex items-center gap-2">
-          <input
-            aria-label={`Variable ${i + 1} name`}
-            className="w-40 rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
-            value={v.name}
-            onChange={(e) => update(i, { name: e.target.value })}
-          />
-          <select
-            aria-label={`Variable ${i + 1} scope`}
-            className="rounded-md border border-line bg-white px-2 py-1 text-ui"
-            value={v.scope}
-            onChange={(e) => update(i, { scope: e.target.value as 'admin' | 'user' })}
-          >
-            <option value="admin">admin — one shared value</option>
-            <option value="user">user — each member their own</option>
-          </select>
-          <input
-            aria-label={`Variable ${i + 1} label`}
-            className="min-w-0 flex-1 rounded-md border border-line bg-white px-2 py-1 text-ui"
-            placeholder="Label shown in the secrets UI"
-            value={v.label ?? ''}
-            onChange={(e) => update(i, { label: e.target.value || undefined })}
-          />
-          <Button variant="quiet" size="sm" onClick={() => onChange(variables.filter((_, j) => j !== i))}>
-            Remove
-          </Button>
-        </div>
-      ))}
+      {variables.map((v, i) => {
+        const n = i + 1;
+        const oauth = v.oauth;
+        const manualEndpoints = oauth !== undefined && oauth.authorizationUrl !== undefined;
+        return (
+          // Index keys are correct here: rows are edited in place and have no
+          // identity beyond their position until saved.
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={i} className="flex flex-col gap-1.5 rounded-md border border-line px-2.5 py-2">
+            <div className="flex items-center gap-2">
+              <input
+                aria-label={`Variable ${n} name`}
+                className="w-40 rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+                value={v.name}
+                onChange={(e) => update(i, { name: e.target.value })}
+              />
+              <select
+                aria-label={`Variable ${n} scope`}
+                className="rounded-md border border-line bg-white px-2 py-1 text-ui"
+                value={v.scope}
+                onChange={(e) => {
+                  const scope = e.target.value as 'admin' | 'user';
+                  // A sign-in is per-caller by nature; a shared token would
+                  // hand one member's grant to everyone. Dropping it here is
+                  // the same rule the save enforces, made visible early.
+                  const next: McpServerVariable = { ...v, scope };
+                  if (scope !== 'user') delete next.oauth;
+                  onChange(variables.map((x, j) => (j === i ? next : x)));
+                }}
+              >
+                <option value="admin">admin — one shared value</option>
+                <option value="user">user — each member their own</option>
+              </select>
+              <input
+                aria-label={`Variable ${n} label`}
+                className="min-w-0 flex-1 rounded-md border border-line bg-white px-2 py-1 text-ui"
+                placeholder="Label shown in the secrets UI"
+                value={v.label ?? ''}
+                onChange={(e) => update(i, { label: e.target.value || undefined })}
+              />
+              <Button variant="quiet" size="sm" onClick={() => onChange(variables.filter((_, j) => j !== i))}>
+                Remove
+              </Button>
+            </div>
+            {v.scope === 'user' && (
+              <label className="flex items-center gap-2 text-ink-muted">
+                <input
+                  type="checkbox"
+                  aria-label={`Variable ${n} OAuth sign-in`}
+                  checked={oauth !== undefined}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      update(i, { oauth: { clientId: '' } });
+                      onSignInEnabled(v.name.trim());
+                    } else {
+                      const next = { ...v };
+                      delete next.oauth;
+                      onChange(variables.map((x, j) => (j === i ? next : x)));
+                    }
+                  }}
+                />
+                OAuth sign-in — members sign in with the provider instead of pasting a value
+              </label>
+            )}
+            {oauth && (
+              <div className="ml-5 flex flex-col gap-1.5 border-l-2 border-line pl-3">
+                <label className="flex flex-col gap-1">
+                  <span className="font-semibold text-ink">Client ID</span>
+                  <input
+                    aria-label={`Variable ${n} client id`}
+                    className="rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+                    value={oauth.clientId}
+                    onChange={(e) => updateOAuth(i, { clientId: e.target.value })}
+                  />
+                  <span className="text-ink-faint">
+                    From the OAuth app you registered with the provider. Its client secret is
+                    pasted on this page after saving — never in a file.
+                  </span>
+                </label>
+                <div className="flex flex-col gap-1">
+                  <span className="font-semibold text-ink">Endpoints</span>
+                  <label className="flex items-center gap-2 text-ink-muted">
+                    <input
+                      type="radio"
+                      name={`variable-${n}-endpoints`}
+                      aria-label={`Variable ${n} endpoints discovered`}
+                      checked={!manualEndpoints}
+                      onChange={() => {
+                        const next = { ...oauth };
+                        delete next.authorizationUrl;
+                        delete next.tokenUrl;
+                        update(i, { oauth: next });
+                      }}
+                    />
+                    Discover from the server (MCP servers publish them)
+                  </label>
+                  <label className="flex items-center gap-2 text-ink-muted">
+                    <input
+                      type="radio"
+                      name={`variable-${n}-endpoints`}
+                      aria-label={`Variable ${n} endpoints by hand`}
+                      checked={manualEndpoints}
+                      onChange={() =>
+                        updateOAuth(i, {
+                          authorizationUrl: oauth.authorizationUrl ?? '',
+                          tokenUrl: oauth.tokenUrl ?? '',
+                        })
+                      }
+                    />
+                    Enter by hand (the provider publishes no OAuth metadata)
+                  </label>
+                  {manualEndpoints && (
+                    <div className="ml-5 flex flex-col gap-1.5">
+                      <input
+                        aria-label={`Variable ${n} authorization URL`}
+                        className="rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+                        placeholder="https://provider.example/oauth/authorize"
+                        value={oauth.authorizationUrl ?? ''}
+                        onChange={(e) => updateOAuth(i, { authorizationUrl: e.target.value })}
+                      />
+                      <input
+                        aria-label={`Variable ${n} token URL`}
+                        className="rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+                        placeholder="https://provider.example/oauth/token"
+                        value={oauth.tokenUrl ?? ''}
+                        onChange={(e) => updateOAuth(i, { tokenUrl: e.target.value })}
+                      />
+                    </div>
+                  )}
+                </div>
+                <label className="flex flex-col gap-1">
+                  <span className="font-semibold text-ink">Scopes</span>
+                  <input
+                    aria-label={`Variable ${n} scopes`}
+                    className="rounded-md border border-line bg-white px-2 py-1 font-mono text-ui"
+                    placeholder="space-separated, e.g. crm.objects.contacts.read"
+                    value={(oauth.scopes ?? []).join(' ')}
+                    onChange={(e) => {
+                      // Split on save-shaped boundaries but keep the field
+                      // typeable: a trailing space is a scope being started.
+                      const scopes = e.target.value.split(/[\s,]+/);
+                      updateOAuth(i, { scopes: scopes.length === 1 && scopes[0] === '' ? undefined : scopes });
+                    }}
+                  />
+                </label>
+                <label className="flex items-center gap-2 text-ink-muted">
+                  <input
+                    type="checkbox"
+                    aria-label={`Variable ${n} PKCE`}
+                    checked={oauth.pkce !== false}
+                    onChange={(e) => {
+                      const next = { ...oauth };
+                      if (e.target.checked) delete next.pkce;
+                      else next.pkce = false;
+                      update(i, { oauth: next });
+                    }}
+                  />
+                  PKCE (S256) — required by MCP servers; harmless for providers that ignore it
+                </label>
+              </div>
+            )}
+          </div>
+        );
+      })}
       <div>
         <Button variant="outline" size="sm" onClick={() => onChange([...variables, { name: '', scope: 'admin' }])}>
           Add variable
@@ -359,6 +605,33 @@ function VariablesEditor({
       </span>
     </div>
   );
+}
+
+/**
+ * The stored shape of one row: trimmed, empties dropped, the sign-in's
+ * endpoints sent as typed (a half pair is the backend's 422 to give, not
+ * something to silently complete or discard here).
+ */
+function normalizeVariable(v: McpServerVariable): McpServerVariable {
+  const label = v.label?.trim();
+  const base: McpServerVariable = { name: v.name.trim(), scope: v.scope, ...(label ? { label } : {}) };
+  if (!v.oauth || v.scope !== 'user') return base;
+  const o = v.oauth;
+  const authorizationUrl = o.authorizationUrl?.trim();
+  const tokenUrl = o.tokenUrl?.trim();
+  const scopes = (o.scopes ?? []).map((s) => s.trim()).filter(Boolean);
+  return {
+    ...base,
+    oauth: {
+      ...(authorizationUrl ? { authorizationUrl } : {}),
+      ...(tokenUrl ? { tokenUrl } : {}),
+      clientId: o.clientId.trim(),
+      ...(scopes.length > 0 ? { scopes } : {}),
+      ...(o.authParams ? { authParams: o.authParams } : {}),
+      ...(o.pkce === false ? { pkce: false } : {}),
+      ...(o.resource ? { resource: o.resource } : {}),
+    },
+  };
 }
 
 function headersToLines(headers: Record<string, string>): string {

--- a/packages/core-frontend/src/modules/library/components/tool-page/ToolConnectionSection.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/ToolConnectionSection.tsx
@@ -14,11 +14,12 @@ import { ToolVarRow } from './ToolVarRow';
  * from you on everyone's behalf.
  *
  * The setup banner above the rows exists because `oauth-manual` is the one
- * state the rows CANNOT explain on their own: auto-discovery found that the
- * remote server wants a sign-in but couldn't register a client for it, so every
- * row underneath is stuck through no fault of the person reading them. The
- * banner names whose move it is — the owner's — and for the owner it links
- * straight at the file they have to edit.
+ * state the rows CANNOT explain on their own: the remote server wants a sign-in
+ * through an app the OWNER registers, so every row underneath is stuck through
+ * no fault of the person reading them. The banner names whose move it is — the
+ * owner's — and what the move is: declare the sign-in (the server editor on
+ * this page for an mcp.json server, the file itself for a `.tool`), then set
+ * its client secret. Once declared, only the secret remains and it says so.
  */
 
 export interface ToolConnectionSectionProps {
@@ -40,6 +41,12 @@ export function ToolConnectionSection({ tool, onChanged, onError }: ToolConnecti
   // No oauth variable at all is the un-started case, so it counts as unfinished.
   const setupUnfinished =
     setupKind === 'oauth-manual' && !tool.variables.some((v) => v.oauth && v.adminConfigured);
+  // Declared but not yet finished: the client id is in the file, the secret
+  // isn't in the vault. Different sentence — "set the secret", not "declare".
+  const signInDeclared = tool.variables.some((v) => v.oauth);
+  // An mcp.json server is edited in the server section of THIS page; only a
+  // `.tool` manual sends the owner to a file.
+  const isMcpJsonServer = tool.path.endsWith('/mcp.json');
 
   /**
    * The CONFIGURATION this tool is still missing, named.
@@ -96,13 +103,22 @@ export function ToolConnectionSection({ tool, onChanged, onError }: ToolConnecti
 
       {setupUnfinished && (
         <Banner tone="wait" role="status" className="mb-2.5">
-          {tool.canWrite ? (
+          {tool.canWrite && signInDeclared ? (
+            <>
+              Sign-in setup needed: the sign-in is declared — set its client secret below to
+              finish.
+              {tool.setup?.reason && <em className="mt-1 block">{tool.setup.reason}</em>}
+            </>
+          ) : tool.canWrite ? (
             <>
               Sign-in setup needed: this server needs users to sign in, but Bevel couldn't set
-              that up automatically. Declare the OAuth provider in the tool file, then set its
-              client secret below.
+              that up automatically. Register an OAuth app with the provider, then{' '}
+              {isMcpJsonServer
+                ? 'add a user-scoped variable with an OAuth sign-in under "Edit server" below'
+                : 'declare the sign-in on a user-scoped variable in the tool file'}
+              , and set its client secret here.
               {tool.setup?.reason && <em className="mt-1 block">{tool.setup.reason}</em>}
-              {kbDirName && (
+              {kbDirName && !isMcpJsonServer && (
                 <Button
                   variant="quiet"
                   size="tiny"

--- a/packages/core-frontend/src/modules/library/services/tools.api.ts
+++ b/packages/core-frontend/src/modules/library/services/tools.api.ts
@@ -67,6 +67,28 @@ export async function getToolDetail(slug: string): Promise<ToolManualDetail> {
  */
 export type McpTransport = 'streamable-http' | 'sse' | 'stdio';
 
+/**
+ * A declared `${VAR}` of an mcp.json server, exactly as plugin.json stores it.
+ * `oauth` makes it a sign-in (user-scoped only): the owner's OAuth app's client
+ * id, and optionally the provider endpoints — absent, they are discovered from
+ * the server's own OAuth metadata. PKCE is on unless `pkce: false`. The client
+ * SECRET is never here; it lives in the vault, set on the tool's page.
+ */
+export interface McpServerVariable {
+  name: string;
+  scope: 'admin' | 'user';
+  label?: string;
+  oauth?: {
+    authorizationUrl?: string;
+    tokenUrl?: string;
+    clientId: string;
+    scopes?: string[];
+    authParams?: Record<string, string>;
+    pkce?: boolean;
+    resource?: string;
+  };
+}
+
 export interface McpServerView {
   name: string;
   transport: McpTransport;
@@ -77,7 +99,7 @@ export interface McpServerView {
   env?: Record<string, string>;
   literalHeaders: Record<string, string>;
   authHeaders: Record<string, string>;
-  variables: { name: string; scope: 'admin' | 'user'; label?: string }[];
+  variables: McpServerVariable[];
   description?: string;
   local: boolean;
   canWrite: boolean;

--- a/packages/core-frontend/src/modules/secrets-vault/components/SecretsPage.tsx
+++ b/packages/core-frontend/src/modules/secrets-vault/components/SecretsPage.tsx
@@ -233,6 +233,9 @@ function OAuthSecretForm({ onSaved, onError }: { onSaved: () => void; onError: (
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
   const [scopes, setScopes] = useState('');
+  // On by default: MCP-spec providers require PKCE, and one that doesn't
+  // implement it ignores the extra parameters — off is the rare exception.
+  const [pkce, setPkce] = useState(true);
   const [busy, setBusy] = useState(false);
 
   const submit = async () => {
@@ -246,6 +249,7 @@ function OAuthSecretForm({ onSaved, onError }: { onSaved: () => void; onError: (
           clientId: clientId.trim(),
           clientSecret: clientSecret.trim() || undefined,
           scopes: scopes.split(/[\s,]+/).filter(Boolean),
+          pkce,
         },
       });
       onSaved();
@@ -286,6 +290,10 @@ function OAuthSecretForm({ onSaved, onError }: { onSaved: () => void; onError: (
       <Field label="Scopes (space or comma separated)">
         <TextField className="w-full" value={scopes} onChange={(e) => setScopes(e.target.value)} />
       </Field>
+      <label className="flex items-center gap-2 text-detail text-ink-muted">
+        <input type="checkbox" checked={pkce} onChange={(e) => setPkce(e.target.checked)} />
+        PKCE (S256) — required by MCP servers; harmless for providers that ignore it
+      </label>
       <p className="text-detail text-ink-muted">
         Save first, then click “Sign in” on the secret to complete the flow.
       </p>

--- a/packages/core-frontend/src/modules/secrets-vault/components/ToolSecretsPanel.tsx
+++ b/packages/core-frontend/src/modules/secrets-vault/components/ToolSecretsPanel.tsx
@@ -31,7 +31,7 @@ export function ToolSecretsPanel({ tool, onChanged }: { tool: ToolSecrets; onCha
   if (tool.variables.length === 0) {
     return (
       <div className="flex flex-col gap-3">
-        <SetupBanner setup={tool.setup} />
+        <SetupBanner setup={tool.setup} declared={tool.variables.some((v) => v.oauth)} />
         {tool.setup?.kind !== 'oauth-manual' && (
           <p className="text-detail text-ink-muted">
             {tool.setup?.kind === 'open' ? (
@@ -51,7 +51,7 @@ export function ToolSecretsPanel({ tool, onChanged }: { tool: ToolSecrets; onCha
 
   return (
     <div className="flex flex-col gap-3.5">
-      <SetupBanner setup={tool.setup} />
+      <SetupBanner setup={tool.setup} declared={tool.variables.some((v) => v.oauth)} />
       {adminVars.length > 0 && (
         <VarPlugin
           title="Set by the tool owner"
@@ -95,21 +95,30 @@ function Chip({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * When a `type: mcp` server needs sign-in that auto-discovery COULDN'T set up
- * (typically the provider has no dynamic client registration — e.g. Google),
- * the tool would otherwise look like it needs nothing. Make the required manual
- * setup explicit, and surface the discovery `reason` so the admin knows why.
+ * When a `type: mcp` server needs a sign-in with an owner-registered OAuth app
+ * (auto-discovery couldn't register one — Google, HubSpot — or the declaration
+ * already names a client id), the tool would otherwise look like it needs
+ * nothing until the owner finishes. Make the remaining step explicit, and
+ * surface the discovery `reason` so the admin knows what still blocks it.
  * The `open` / `oauth-auto` cases need no banner — they're either self-evident
  * (a sign-in variable appears below) or nothing-to-do.
  */
-function SetupBanner({ setup }: { setup: ToolSetup | null }) {
+function SetupBanner({ setup, declared }: { setup: ToolSetup | null; declared: boolean }) {
   if (setup?.kind !== 'oauth-manual') return null;
   return (
     <Banner tone="wait" role="status">
-      <span className="font-semibold">Sign-in setup needed.</span> This server needs users to sign
-      in, but Bevel couldn&apos;t set that up automatically. A tool writer must register an OAuth
-      client with the provider, declare it in the <Chip>.tool</Chip> file&apos;s{' '}
-      <Chip>variables</Chip> block, then set its client secret here.
+      <span className="font-semibold">Sign-in setup needed.</span>{' '}
+      {declared ? (
+        <>The sign-in is declared — a tool writer sets its client secret here to finish.</>
+      ) : (
+        <>
+          This server needs users to sign in, but Bevel couldn&apos;t set that up automatically. A
+          tool writer must register an OAuth app with the provider and declare its client id on a
+          user-scoped sign-in variable — under <Chip>Edit server</Chip> on the tool&apos;s page for
+          an MCP server, or in the <Chip>.tool</Chip> file&apos;s <Chip>variables</Chip> block —
+          then set its client secret here.
+        </>
+      )}
       {setup.reason && <em className="mt-1 block text-detail">{setup.reason}</em>}
     </Banner>
   );

--- a/packages/core-frontend/src/modules/secrets-vault/services/secrets.api.ts
+++ b/packages/core-frontend/src/modules/secrets-vault/services/secrets.api.ts
@@ -22,6 +22,8 @@ export interface OAuthProviderConfig {
   scopes?: string[];
   /** Extra static params appended to the authorization request (e.g. `audience`). */
   authParams?: Record<string, string>;
+  /** PKCE (S256) on the authorization-code flow — what MCP-spec providers require. */
+  pkce?: boolean;
 }
 
 async function unwrap(res: Response, fallback: string): Promise<never> {

--- a/packages/core-frontend/src/modules/secrets-vault/services/tool-secrets.api.ts
+++ b/packages/core-frontend/src/modules/secrets-vault/services/tool-secrets.api.ts
@@ -33,9 +33,12 @@ export interface ToolVarStatus {
  * For a `type: mcp` tool, the setup requirement auto-discovery found:
  *  - `open`         — no auth; nothing to configure.
  *  - `oauth-auto`   — sign-in was set up automatically (appears as a user var).
- *  - `oauth-manual` — the server needs sign-in but couldn't be set up
- *                     automatically; a tool writer must declare the provider in
- *                     the `.tool` file and set its client secret. `reason` says why.
+ *  - `oauth-manual` — the sign-in needs an OAuth app the owner registers with
+ *                     the provider: a tool writer declares its client id on a
+ *                     user-scoped variable (the server editor for an mcp.json
+ *                     server; the `.tool` file otherwise) and sets its client
+ *                     secret. `reason` is present only while something still
+ *                     blocks the sign-in, and says what.
  */
 export interface ToolSetup {
   kind: 'open' | 'oauth-auto' | 'oauth-manual';


### PR DESCRIPTION
## Why

A customer's HubSpot MCP sign-in failed with `PKCE is required for this authorization request`. Hand-declared sign-in providers never sent PKCE — only the zero-config (dynamically-registered) path did — so every MCP-spec server that offers no dynamic client registration was unusable through the manual path. The setup banner also pointed mcp.json servers at "the `.tool` file", which no longer exists for them.

## What changes

**PKCE by default.** Declared providers use PKCE S256 unless `pkce: false`. Providers without PKCE ignore the parameters (RFC 6749 §3.1). The client-secret route pins `pkce` and `resource` alongside the secret. The standalone OAuth form on the Secrets page has the same switch, on by default. Existing declared providers pick this up when the owner next saves the client secret (their users sign in once more).

**Bring your own client id.** On an `mcp.json` server, `oauth: { clientId }` on a user-scoped variable is a complete declaration: `McpOAuthDiscoveryService.providerForDeclaredClient` reuses the RFC 9728/8414 metadata walk (memoised per URL, no registration, nothing persisted) and `ToolManualService.completeDeclaredOAuth` fills endpoints/resource into the descriptor. Endpoints stay declarable (both or neither); a `.tool` still requires them. While they can't be discovered, `setup.reason` says so and the secret route 422s with that reason instead of pinning a provider with no endpoints. Discovery's no-DCR reason now names the redirect URI and the next step.

**The server editor mirrors the files.** The read-only server facts list everything `mcp.json` + `plugin.json` store (headers, auth headers, description, variables, a sign-in's client id / endpoint source / scopes / PKCE / resource). The variables editor gained the sign-in fields one-to-one with the `oauth` block, and switching a sign-in on pre-fills `Authorization: Bearer ${VAR}` visibly in the auth-headers field.

**Clearer next steps.** Banners send mcp.json owners to "Edit server" on the same page, and a declared-but-unfinished sign-in asks only for the client secret. `list_tool_setup`'s description and the KB `AGENTS.md` (new "Declaring an OAuth sign-in" section + rewritten `oauth-manual` walkthrough) describe the shape an agent writes.

## Verification

- `pnpm typecheck` clean in core-backend and core-frontend.
- 17 new/extended tests: discovery (`providerForDeclaredClient` happy/unsupported/cached), mcp.json declaration rules (client-id-only, half pair refused, `pkce`/`resource`), `.tool` parser (`pkce:false`, gated `resource`, endpoints still required), catalog completion + `setup.reason`, client-secret route (PKCE default, opt-out, 422 while endpoints unknown), server section (facts view, declare sign-in, hand-entered endpoints), connection banners.
- Full suites: backend 1880/1885, frontend 1503/1507 — the 7 failures are pre-existing timing/perf tests (git post-merge pull, doc-extract/xlsx caps, SetupScreen timeouts), untouched by this change.
- Lint on changed files reports only pre-existing findings.

Changeset: `.changeset/mcp-oauth-declared-client.md` (minor, backend + frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hand-declared OAuth providers never sent PKCE, so MCP-spec servers like HubSpot rejected their authorization requests ("PKCE is required"). Declared providers now use PKCE S256 unless the declaration sets `pkce: false`, and an mcp.json server's sign-in can be declared with just the owner-registered client id — the endpoints and resource are discovered from the server's own metadata.

**PKCE by default**
- Providers without PKCE ignore the extra parameters, so nothing that worked stops working; the standalone OAuth secret form has the same switch, on by default.
- Existing declared providers pick this up when the owner next saves the client secret; their users sign in once more.

**Client-id-only declarations on mcp.json servers**
- `oauth: { clientId }` on a user-scoped variable completes from the server's OAuth metadata at scan time — no registration, nothing persisted; endpoints stay declarable (both or neither) and a `.tool` still requires them.
- A client secret never belongs in the `oauth` block — one in plugin.json drops the server from the catalog, and the server editor's save refuses the same shapes.
- While endpoints remain undiscovered, `setup.reason` names the redirect URI and the client-secret route refuses (422) with that reason instead of pinning a provider with none.
- The server editor shows everything mcp.json and plugin.json store and gained the sign-in fields; switching a sign-in on pre-fills `Authorization: Bearer ${VAR}`.
- Banners point an mcp.json server at "Edit server" on the same page, a declared-but-unfinished sign-in asks only for the client secret, and `AGENTS.md` documents the `oauth` block.

<sup>Written for commit 2aa0265c7d4c2dca2fcf372173832717269ddcd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

