### PR TITLE
A silent token response grants what was requested (RFC 6749 §5.1)

### DIFF
--- a/.changeset/oauth-silent-scope-grant.md
+++ b/.changeset/oauth-silent-scope-grant.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-backend': patch
+---
+
+A sign-in whose provider echoes no `scope` on the token response is no longer flagged "sign in again" forever. RFC 6749 §5.1 makes `scope` optional when the grant matches the request, and providers such as HubSpot leave it out — the vault used to read that silence as "nothing granted", so every declared scope counted as missing and the tool was blocked at call time. The scopes a consent asks for are now remembered with the pending sign-in and recorded as the grant when the provider stays silent; an echoed `scope` still wins, narrower grants included.

--- a/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
+++ b/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
@@ -194,6 +194,38 @@ describe('DbSecretsVaultService — PKCE + public-client tool OAuth', () => {
     // An echoed `scope` is the provider's word and wins — a narrower grant stays visible.
     const echoed = await complete({ access_token: 'at-2', expires_in: 3600, scope: 'crm.objects.contacts.read' });
     expect(echoed.tokens.scope).toBe('crm.objects.contacts.read');
+    // …and so does an EXPLICIT empty grant: only an absent field means "as requested".
+    const empty = await complete({ access_token: 'at-3', expires_in: 3600, scope: '' });
+    expect(empty.tokens.scope).toBe('');
+  });
+
+  it('beginOAuth never writes a stale blob over tokens a concurrent refresh just rotated', async () => {
+    // The standalone flow stashes the pending verifier/scopes with a
+    // read-modify-write. Between its read and its write a refresh persists
+    // rotated tokens; the guarded update misses (0 rows), the row is re-read,
+    // and the pending fields are merged onto THOSE tokens.
+    const stale = sharedRow({
+      id: 'secret-1',
+      userId: 'user-1',
+      oauthMeta: { ...PUBLIC_META, pkce: false },
+      valueEncrypted: crypto.encrypt(JSON.stringify({ tokens: { access_token: 'old', refresh_token: 'rt-old' } })),
+    });
+    const rotated = {
+      ...stale,
+      valueEncrypted: crypto.encrypt(JSON.stringify({ tokens: { access_token: 'new', refresh_token: 'rt-new' } })),
+    };
+    const { db, captured } = makeFakeDb([
+      [stale], // requireRow
+      [], // guarded update: the ciphertext changed underneath us
+      [rotated], // re-read
+      [{ id: 'secret-1' }], // guarded update against the fresh ciphertext
+    ]);
+    const url = await new DbSecretsVaultService(db, ENC_KEY).beginOAuth('user-1', 'secret-1', 'https://bevel.example.com/cb', 's');
+    expect(new URL(url).searchParams.get('scope')).toBe('mcp.read');
+    expect(captured.set).toHaveLength(2);
+    const persisted = JSON.parse(crypto.decrypt(captured.set[1].valueEncrypted));
+    expect(persisted.tokens).toEqual({ access_token: 'new', refresh_token: 'rt-new' });
+    expect(persisted.pendingScopes).toBe('mcp.read');
   });
 });
 

--- a/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
+++ b/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
@@ -226,6 +226,20 @@ describe('DbSecretsVaultService — PKCE + public-client tool OAuth', () => {
     const persisted = JSON.parse(crypto.decrypt(captured.set[1].valueEncrypted));
     expect(persisted.tokens).toEqual({ access_token: 'new', refresh_token: 'rt-new' });
     expect(persisted.pendingScopes).toBe('mcp.read');
+
+    // Only a token rotation is merge-able: a row that meanwhile became another
+    // provider's sign-in (or a static value) aborts, since the consent URL was
+    // built for the provider we read first.
+    for (const changed of [
+      { ...rotated, oauthMeta: { ...PUBLIC_META, pkce: false, clientId: 'someone-else' } },
+      { ...rotated, kind: 'static' },
+    ]) {
+      const race = makeFakeDb([[stale], [], [changed]]);
+      await expect(
+        new DbSecretsVaultService(race.db, ENC_KEY).beginOAuth('user-1', 'secret-1', 'https://bevel.example.com/cb', 's'),
+      ).rejects.toBeInstanceOf(SecretOAuthError);
+      expect(race.captured.set).toHaveLength(1); // nothing written onto the changed row
+    }
   });
 });
 
@@ -284,6 +298,20 @@ describe('DbSecretsVaultService — dead-grant detection on refresh', () => {
 
     await expect(svc.resolve('user-1', KEY)).resolves.toBe('fresh-at');
     expect(onMutation).toHaveBeenCalledWith('user-1');
+  });
+
+  it('a refresh keeps the recorded grant when `scope` is absent, and takes an echoed one — empty included', async () => {
+    // Same rule as the code exchange: only an ABSENT field means "unchanged".
+    const refreshWith = async (body: Record<string, unknown>) => {
+      const { db, captured } = makeFakeDb([[userRow()], undefined]);
+      const svc = new DbSecretsVaultService(db, ENC_KEY, undefined, userScope);
+      vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })));
+      await svc.resolve('user-1', KEY);
+      return JSON.parse(crypto.decrypt(captured.set[0].valueEncrypted)).tokens.scope;
+    };
+    expect(await refreshWith({ access_token: 'a', expires_in: 3600 })).toBe('mcp.read');
+    expect(await refreshWith({ access_token: 'a', expires_in: 3600, scope: 'mcp.read mcp.write' })).toBe('mcp.read mcp.write');
+    expect(await refreshWith({ access_token: 'a', expires_in: 3600, scope: '' })).toBe('');
   });
 
   it('putSharedOAuthProvider notifies mutation listeners with null (shared → everyone)', async () => {

--- a/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
+++ b/packages/core-backend/src/modules/secrets-vault/__tests__/db-secrets-vault.oauth.test.ts
@@ -151,6 +151,50 @@ describe('DbSecretsVaultService — PKCE + public-client tool OAuth', () => {
     expect(stored.tokens.access_token).toBe('at-1');
     expect(stored.pendingVerifier).toBeUndefined();
   });
+
+  it('beginToolOAuthByKey remembers the scopes it asked for, and completeOAuth takes them as granted when the provider echoes none', async () => {
+    // RFC 6749 §5.1: `scope` in the token response is OPTIONAL when identical
+    // to what was requested. A provider that omits it (HubSpot) granted the
+    // request, not nothing — reading it as nothing would flag every declared
+    // scope as missing and block the tool behind a permanent "sign in again".
+    const begin = makeFakeDb([[sharedRow()], [], [{ id: 'user-row-1' }]]);
+    const svc = new DbSecretsVaultService(begin.db, ENC_KEY);
+    const { url } = await svc.beginToolOAuthByKey({
+      userId: 'user-1',
+      key: KEY,
+      redirectUri: 'https://bevel.example.com/cb',
+      state: 's',
+      scopes: ['crm.objects.contacts.read', 'crm.objects.companies.read'],
+    });
+    expect(new URL(url).searchParams.get('scope')).toBe('crm.objects.contacts.read crm.objects.companies.read');
+    const pending = JSON.parse(crypto.decrypt(begin.captured.values[0].valueEncrypted));
+    expect(pending.pendingScopes).toBe('crm.objects.contacts.read crm.objects.companies.read');
+
+    const complete = async (tokenResponse: Record<string, unknown>) => {
+      const userRow = sharedRow({
+        id: 'user-row-1',
+        userId: 'user-1',
+        valueEncrypted: crypto.encrypt(
+          JSON.stringify({ pendingVerifier: 'v', pendingScopes: 'crm.objects.contacts.read crm.objects.companies.read' }),
+        ),
+      });
+      const { db, captured } = makeFakeDb([[userRow], undefined]);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => new Response(JSON.stringify(tokenResponse), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+      );
+      await new DbSecretsVaultService(db, ENC_KEY).completeOAuth('user-1', 'user-row-1', 'code', 'https://bevel.example.com/cb');
+      return JSON.parse(crypto.decrypt(captured.set[0].valueEncrypted));
+    };
+
+    // No `scope` echoed → the requested scopes are the granted ones.
+    const silent = await complete({ access_token: 'at-1', expires_in: 3600 });
+    expect(silent.tokens.scope).toBe('crm.objects.contacts.read crm.objects.companies.read');
+    expect(silent.pendingScopes).toBeUndefined(); // one-time, like the verifier
+    // An echoed `scope` is the provider's word and wins — a narrower grant stays visible.
+    const echoed = await complete({ access_token: 'at-2', expires_in: 3600, scope: 'crm.objects.contacts.read' });
+    expect(echoed.tokens.scope).toBe('crm.objects.contacts.read');
+  });
 });
 
 describe('DbSecretsVaultService — dead-grant detection on refresh', () => {

--- a/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
+++ b/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
@@ -34,10 +34,13 @@ interface OAuthTokenSet {
   expires_at?: number;
   token_type?: string;
   /**
-   * Space-delimited scopes the provider actually granted (echoed on the token
-   * response). The durable record of what this token can do, so a later check can
-   * tell whether it still covers a tool whose required scopes have grown. Absent
-   * on tokens minted before this was captured (treated as "covers nothing").
+   * Space-delimited scopes the provider actually granted. The durable record of
+   * what this token can do, so a later check can tell whether it still covers a
+   * tool whose required scopes have grown. Taken from the token response's
+   * `scope` when echoed; when the provider stays silent, RFC 6749 §5.1 says the
+   * grant is identical to the request, so the scopes asked for at `begin*` time
+   * are recorded instead. Absent only on tokens minted before this was captured
+   * (treated as "covers nothing").
    */
   scope?: string;
 }
@@ -51,6 +54,13 @@ interface OAuthBlob {
    * it's a one-time secret binding the pending consent to this server.
    */
   pendingVerifier?: string;
+  /**
+   * The space-delimited `scope` the pending consent asked for — what the
+   * token is deemed granted when the provider's token response echoes none
+   * (RFC 6749 §5.1: `scope` is optional when identical to the request). One-time
+   * like the verifier: consumed by the exchange it was minted for.
+   */
+  pendingScopes?: string;
 }
 
 /**
@@ -281,12 +291,13 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     // PKCE (S256): same as the tool path — mint the verifier, stash it on the
     // row (so `completeOAuth` echoes it at the token exchange), and put only
     // the derived challenge in the consent URL. A provider registered pkce
-    // would otherwise fail the exchange from this standalone flow.
-    let pendingVerifier: string | undefined;
-    if (meta.pkce) {
-      pendingVerifier = randomBytes(32).toString('base64url');
+    // would otherwise fail the exchange from this standalone flow. The
+    // requested scopes ride along for the same exchange (see `pendingScopes`).
+    const pendingVerifier = meta.pkce ? randomBytes(32).toString('base64url') : undefined;
+    const pendingScopes = meta.scopes && meta.scopes.length ? meta.scopes.join(' ') : undefined;
+    if (pendingVerifier || pendingScopes) {
       const blob = this.readBlob(row.valueEncrypted);
-      const next: OAuthBlob = { ...blob, pendingVerifier };
+      const next: OAuthBlob = { ...blob, pendingVerifier, pendingScopes };
       await this.db
         .update(secrets)
         .set({ valueEncrypted: this.crypto().encrypt(JSON.stringify(next)), updatedAt: new Date() })
@@ -340,7 +351,13 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     if (meta.resource) body.set('resource', meta.resource);
 
     const tokens = await this.tokenRequest(meta.tokenUrl, body);
-    // The verifier is one-time — never carried past the exchange it was minted for.
+    // A silent token response granted what was asked (RFC 6749 §5.1) — record
+    // the request as the grant, or every declared scope would read as missing
+    // and the sign-in would be flagged "again" forever. An echoed `scope` is
+    // the provider's own word and wins, narrower grants included.
+    if (!tokens.scope && blob.pendingScopes) tokens.scope = blob.pendingScopes;
+    // The verifier and the requested scopes are one-time — never carried past
+    // the exchange they were minted for.
     const next: OAuthBlob = { clientSecret: blob.clientSecret, tokens };
     await this.db
       .update(secrets)
@@ -433,11 +450,22 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     // only the derived challenge in the consent URL. `completeOAuth` echoes the
     // verifier at the token exchange and drops it.
     const pendingVerifier = meta.pkce ? randomBytes(32).toString('base64url') : undefined;
+    // The scopes this consent asks for: the caller may override from the live
+    // tool file (`input.scopes`) so an owner adding a permission takes effect
+    // without re-setting the secret. Remembered on the row so a token response
+    // that echoes no `scope` is read as granting exactly this (RFC 6749 §5.1).
+    const requestedScopes = input.scopes && input.scopes.length ? input.scopes : meta.scopes;
+    const pendingScopes = requestedScopes && requestedScopes.length ? requestedScopes.join(' ') : undefined;
 
     // Provision (or reset) the caller's own oauth row for this key from the shared
     // provider meta + secret, preserving any existing tokens. Keyed `<manual>_<VAR>`
     // so `resolve` (scope 'user') returns the token once sign-in completes.
-    const blob: OAuthBlob = { clientSecret: sharedBlob.clientSecret, tokens: existingTokens, pendingVerifier };
+    const blob: OAuthBlob = {
+      clientSecret: sharedBlob.clientSecret,
+      tokens: existingTokens,
+      pendingVerifier,
+      pendingScopes,
+    };
     const valueEncrypted = this.crypto().encrypt(JSON.stringify(blob));
     const [row] = await this.db
       .insert(secrets)
@@ -449,10 +477,8 @@ export class DbSecretsVaultService implements ISecretsVaultService {
       .returning();
 
     // Build the consent URL exactly as beginOAuth does, from the stored meta —
-    // EXCEPT the requested scopes, which the caller may override from the live tool
-    // file (`input.scopes`) so an owner adding a permission takes effect without
-    // re-setting the secret. Client id, addresses, and secret stay owner-pinned.
-    const requestedScopes = input.scopes && input.scopes.length ? input.scopes : meta.scopes;
+    // EXCEPT the requested scopes (above). Client id, addresses, and secret
+    // stay owner-pinned.
     const url = new URL(meta.authorizationUrl);
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', meta.clientId);

--- a/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
+++ b/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
@@ -296,12 +296,27 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     const pendingVerifier = meta.pkce ? randomBytes(32).toString('base64url') : undefined;
     const pendingScopes = meta.scopes && meta.scopes.length ? meta.scopes.join(' ') : undefined;
     if (pendingVerifier || pendingScopes) {
-      const blob = this.readBlob(row.valueEncrypted);
-      const next: OAuthBlob = { ...blob, pendingVerifier, pendingScopes };
-      await this.db
-        .update(secrets)
-        .set({ valueEncrypted: this.crypto().encrypt(JSON.stringify(next)), updatedAt: new Date() })
-        .where(and(eq(secrets.id, id), eq(secrets.userId, userId)));
+      // Read-modify-write on the blob, guarded on the ciphertext we read: a
+      // refresh running concurrently (the row is a live credential) may have
+      // persisted ROTATED tokens in between, and writing our copy over them
+      // would leave the row holding a dead refresh token if this consent is
+      // then abandoned. On a miss (0 rows), re-read and merge onto the fresh
+      // blob; bounded so a row that keeps changing fails loudly, not forever.
+      let current = row;
+      for (let attempt = 0; ; attempt++) {
+        const blob = this.readBlob(current.valueEncrypted);
+        const next: OAuthBlob = { ...blob, pendingVerifier, pendingScopes };
+        const written = await this.db
+          .update(secrets)
+          .set({ valueEncrypted: this.crypto().encrypt(JSON.stringify(next)), updatedAt: new Date() })
+          .where(
+            and(eq(secrets.id, id), eq(secrets.userId, userId), eq(secrets.valueEncrypted, current.valueEncrypted)),
+          )
+          .returning({ id: secrets.id });
+        if (!Array.isArray(written) || written.length > 0) break;
+        if (attempt >= 2) throw new SecretOAuthError('The sign-in changed while starting — try again');
+        current = await this.requireRow(userId, id);
+      }
     }
 
     const url = new URL(meta.authorizationUrl);
@@ -354,8 +369,9 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     // A silent token response granted what was asked (RFC 6749 §5.1) — record
     // the request as the grant, or every declared scope would read as missing
     // and the sign-in would be flagged "again" forever. An echoed `scope` is
-    // the provider's own word and wins, narrower grants included.
-    if (!tokens.scope && blob.pendingScopes) tokens.scope = blob.pendingScopes;
+    // the provider's own word and wins — narrower grants included, and so does
+    // an explicit empty one: only an ABSENT field means "as requested".
+    if (tokens.scope === undefined && blob.pendingScopes) tokens.scope = blob.pendingScopes;
     // The verifier and the requested scopes are one-time — never carried past
     // the exchange they were minted for.
     const next: OAuthBlob = { clientSecret: blob.clientSecret, tokens };

--- a/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
+++ b/packages/core-backend/src/modules/secrets-vault/db-secrets-vault.service.ts
@@ -316,6 +316,13 @@ export class DbSecretsVaultService implements ISecretsVaultService {
         if (!Array.isArray(written) || written.length > 0) break;
         if (attempt >= 2) throw new SecretOAuthError('The sign-in changed while starting — try again');
         current = await this.requireRow(userId, id);
+        // Only a token rotation is merge-able. A row that is no longer this
+        // OAuth secret — re-registered against another provider, or replaced by
+        // a static value — would have the consent URL built above pointing at
+        // one provider and the pending fields stashed for another.
+        if (current.kind !== 'oauth' || JSON.stringify(current.oauthMeta) !== JSON.stringify(row.oauthMeta)) {
+          throw new SecretOAuthError('The sign-in changed while starting — try again');
+        }
       }
     }
 
@@ -614,8 +621,10 @@ export class DbSecretsVaultService implements ISecretsVaultService {
     // Some providers omit the refresh_token on refresh — keep the old one.
     if (!refreshed.refresh_token) refreshed.refresh_token = tokens.refresh_token;
     // Likewise, a refresh response often omits `scope` — keep the granted scopes
-    // recorded at sign-in so coverage checks don't regress to "unknown".
-    if (!refreshed.scope) refreshed.scope = tokens.scope;
+    // recorded at sign-in so coverage checks don't regress to "unknown". Same
+    // rule as the exchange: only an ABSENT field means "unchanged"; an echoed
+    // value, empty included, is the provider's word.
+    if (refreshed.scope === undefined) refreshed.scope = tokens.scope;
     const next: OAuthBlob = { clientSecret: blob.clientSecret, tokens: refreshed };
 
     // Optimistic concurrency: only persist if the stored ciphertext is unchanged,


### PR DESCRIPTION
## Why

Follow-up to #101, found while testing HubSpot on staging. Once a sign-in declares scopes, the vault compares them against the token response's `scope`. RFC 6749 §5.1 makes that field OPTIONAL when the grant matches the request, and HubSpot omits it — the vault read the silence as "nothing granted", so every declared scope counted as missing, the row showed "Needs signing in again" forever, and the call-time gate blocked the tool.

## What changes

`beginOAuth` / `beginToolOAuthByKey` remember the `scope` string they put in the consent URL on the pending row (`pendingScopes`, one-time like the PKCE verifier). `completeOAuth` records it as the grant when the provider echoes none; an echoed `scope` still wins, narrower grants included. No change to refresh (granted scope was already preserved there).

## Verification

Typecheck clean. New test covers both branches (silent response → requested scopes recorded and `pendingScopes` consumed; echoed narrower scope wins). secrets-vault + mcp suites: 207/207. Changeset: patch, core-backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth sign-ins from providers like HubSpot that omit `scope` from the token response, which RFC 6749 §5.1 permits when the grant matches the request. The vault previously read that silence as "nothing granted," so every declared scope counted as missing, the row showed "Needs signing in again" forever, and the call-time gate blocked the tool; now the requested scopes are recorded as the grant.

- `beginOAuth` and `beginToolOAuthByKey` store the consent URL's scopes on the pending row, and `completeOAuth` records them as granted when the provider echoes none.
- An echoed `scope` still wins, including narrower or explicitly empty ones; only an absent field means "as requested."
- `pendingScopes` is one-time and consumed by the exchange, like the PKCE verifier.
- `beginOAuth`'s pending-field write is guarded on the ciphertext it read and retries on a miss, merging only onto a token rotation; a row that became a different provider's or a static value aborts.
- Refresh now honors an echoed `scope` (empty included); only an absent one keeps the stored grant.

<sup>Written for commit 18026f64bf9875e1a06d9dcc8b93a407a2bbb415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

