### PR TITLE
A skill's version history is reachable

### DIFF
--- a/.changeset/skill-version-history.md
+++ b/.changeset/skill-version-history.md
@@ -6,6 +6,8 @@ A skill's version history is reachable again. The skill page now carries the sam
 
 It was reachable from nowhere before. The shell routes every default-branch `Plugins/` URL to the library surface, so a skill file's only page is the skill page; the Knowledge tree does not list `Plugins/` at all, so there was no row to right-click either. The log had always been there behind the same endpoint the Knowledge viewer asks, and no screen asked it for a skill.
 
-The menu is withdrawn while the editor is open, because the editor holds the draft in its own state and swapping it out for the log would discard whatever had been typed. It is absent entirely when git cannot answer, since Version history is the whole menu. History follows the file, not the page: switching to another file of the skill lands on that file's content.
+The menu is withdrawn while the editor is open, because the editor holds the draft in its own state and swapping it out for the log would discard whatever had been typed. It is absent entirely when git cannot answer, since Version history is the whole menu.
+
+History follows the file, not the page. Switching to another file of the skill lands on that file's content, and coming back lands on the file rather than reopening the log. Losing git mid-read closes it for good, so a recovered status poll cannot put the log back over the file minutes later.
 
 Managing access is still the plugin's Share panel, unchanged — a skill inherits its plugin folder's `access.md`, and that is the one place those rules are set.

--- a/.changeset/skill-version-history.md
+++ b/.changeset/skill-version-history.md
@@ -1,0 +1,11 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+A skill's version history is reachable again. The skill page now carries the same `⋯` menu a Knowledge page does, and its Version history opens the git log for the file on screen, in place of the reading pane, with a way back.
+
+It was reachable from nowhere before. The shell routes every default-branch `Plugins/` URL to the library surface, so a skill file's only page is the skill page; the Knowledge tree does not list `Plugins/` at all, so there was no row to right-click either. The log had always been there behind the same endpoint the Knowledge viewer asks, and no screen asked it for a skill.
+
+The menu is withdrawn while the editor is open, because the editor holds the draft in its own state and swapping it out for the log would discard whatever had been typed. It is absent entirely when git cannot answer, since Version history is the whole menu. History follows the file, not the page: switching to another file of the skill lands on that file's content.
+
+Managing access is still the plugin's Share panel, unchanged — a skill inherits its plugin folder's `access.md`, and that is the one place those rules are set.

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -240,6 +240,8 @@ function renderPage(
   library?: Partial<LibraryContextValue>,
   /** Props the canonical /workspace mount passes; the legacy route passes none. */
   pageProps?: { provisional?: boolean },
+  /** Git state — overridden to test what the page does when there is no log. */
+  gitValue: GitContextValue = git,
 ) {
   libraryMock.value = { ...libraryValue(owned, crs, mine), ...library };
   return render(
@@ -250,7 +252,7 @@ function renderPage(
     >
       <AuthContext.Provider value={auth}>
         <WorkspaceContext.Provider value={workspace}>
-          <GitContext.Provider value={git}>
+          <GitContext.Provider value={gitValue}>
           <EventBusContext.Provider value={bus}>
             {/* The real toast provider: the success message IS the page's
                 report that the merge landed, so a stubbed-out toast would
@@ -1122,5 +1124,92 @@ describe('SkillPage: deciding on a change', () => {
 
     fireEvent.click(withdraw);
     await waitFor(() => expect(apiMock.cancelPullRequest).toHaveBeenCalledWith(7));
+  });
+
+  /**
+   * A skill is a file in the repository, and this page is the ONLY surface it
+   * has: the shell routes every default-branch `Plugins/` URL here
+   * (`isLibraryLocation`) and the Knowledge tree does not list `Plugins/` at
+   * all, so a `⋯` missing here means the git log for every skill in the
+   * deployment is unreachable — the audit trail the product is sold on,
+   * available for Knowledge pages and for nothing else.
+   */
+  describe('version history', () => {
+    it('opens the log for the file on screen, at its workspace path', async () => {
+      renderPage(false);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'More actions' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Version history' }));
+
+      // The path the panel asks git about is the workspace-relative one the
+      // Knowledge viewer would hand it — kbDirName included. Getting this
+      // wrong asks about a file that does not exist and reports an empty
+      // history for one that does.
+      expect(
+        await screen.findByText('Timeline: knowledge-base/Skills/newsletter/SKILL.md'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Version history: SKILL.md')).toBeInTheDocument();
+
+      // And there is a way back, because history is not in the URL.
+      fireEvent.click(screen.getByRole('button', { name: 'Back to the file' }));
+      expect(await screen.findByTestId('md-view')).toBeInTheDocument();
+    });
+
+    it('does not follow you to another file of the skill', async () => {
+      renderPage(false);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'More actions' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Version history' }));
+      await screen.findByText('Timeline: knowledge-base/Skills/newsletter/SKILL.md');
+
+      // A tab switch is a switch of file, and history is a lens on ONE file.
+      // Carrying it across would show the previous file's log under the new
+      // file's heading.
+      fireEvent.click(screen.getByRole('tab', { name: 'sources.yaml' }));
+      expect(screen.queryByText(/^Timeline:/)).toBeNull();
+
+      // And it does not come BACK on the way home. Keying the open flag to
+      // the file it was opened for is not enough on its own: returning to
+      // that tab then reopens a log nobody asked for a second time, which is
+      // how you land on history when you meant to read the file.
+      fireEvent.click(screen.getByRole('tab', { name: 'SKILL.md' }));
+      expect(screen.queryByText(/^Timeline:/)).toBeNull();
+      expect(await screen.findByTestId('md-view')).toBeInTheDocument();
+    });
+
+    /**
+     * `SkillFileEditor` holds the draft in its own state, so swapping it out
+     * for the history panel throws away whatever was typed, with no warning
+     * and no way back. The menu is withdrawn for exactly as long as that is
+     * true.
+     */
+    it('is withdrawn while the editor is open, so a draft cannot be discarded', async () => {
+      accessMock.result = {
+        canWrite: true,
+        eligible: { roles: [], users: [] },
+        owners: { roles: [], users: [] },
+      };
+      renderPage(true);
+
+      fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+      await screen.findByRole('textbox', { name: /Edit SKILL\.md/ });
+      expect(screen.queryByRole('button', { name: 'More actions' })).toBeNull();
+
+      // It comes back the moment the draft is gone.
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(await screen.findByRole('button', { name: 'More actions' })).toBeInTheDocument();
+    });
+
+    it('has no trigger at all when git cannot answer', async () => {
+      renderPage(false, [], [], makeFakeBus(), undefined, undefined, undefined, {
+        ...git,
+        availability: 'loading',
+      } as GitContextValue);
+
+      // Version history is the whole menu, so no log means no `⋯` — an
+      // overflow opening onto an empty panel is worse than no overflow.
+      expect(await screen.findByRole('heading', { name: 'newsletter' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'More actions' })).toBeNull();
+    });
   });
 });

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -244,7 +244,22 @@ function renderPage(
   gitValue: GitContextValue = git,
 ) {
   libraryMock.value = { ...libraryValue(owned, crs, mine), ...library };
-  return render(
+  return render(harness(bus, gitValue, routerState, pageProps));
+}
+
+/**
+ * The provider tree `renderPage` mounts, as a value — so a test can hand the
+ * SAME tree back to `rerender` with a different git state and watch the page
+ * react WITHOUT remounting it. Remounting would reset the very state
+ * (`historyOpen`) those tests are about, and pass whatever the page did.
+ */
+function harness(
+  bus: EventBusContextValue,
+  gitValue: GitContextValue,
+  routerState?: Record<string, unknown>,
+  pageProps?: { provisional?: boolean },
+) {
+  return (
     <MemoryRouter
       initialEntries={[
         { pathname: '/skills-and-tools/skills/newsletter', state: routerState ?? null },
@@ -269,7 +284,7 @@ function renderPage(
           </GitContext.Provider>
         </WorkspaceContext.Provider>
       </AuthContext.Provider>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -1198,6 +1213,30 @@ describe('SkillPage: deciding on a change', () => {
       // It comes back the moment the draft is gone.
       fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
       expect(await screen.findByRole('button', { name: 'More actions' })).toBeInTheDocument();
+    });
+
+    /**
+     * `availability` is re-derived from a POLLED status call, so one failed
+     * poll flips it to `error` and the next good one flips it back. If the
+     * open flag survived that, the log would reappear over the file minutes
+     * after the reader had gone back to reading.
+     */
+    it('closes for good when git stops answering mid-read', async () => {
+      const bus = makeFakeBus();
+      const { rerender } = renderPage(false, [], [], bus);
+      fireEvent.click(await screen.findByRole('button', { name: 'More actions' }));
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Version history' }));
+      await screen.findByText(/^Timeline:/);
+
+      // A poll fails: the log goes away, and so does its trigger.
+      rerender(harness(bus, { ...git, availability: 'error' } as GitContextValue));
+      expect(screen.queryByText(/^Timeline:/)).toBeNull();
+
+      // The next poll succeeds. The file is still what is on screen.
+      rerender(harness(bus, git));
+      expect(await screen.findByTestId('md-view')).toBeInTheDocument();
+      expect(screen.queryByText(/^Timeline:/)).toBeNull();
+      expect(screen.getByRole('button', { name: 'More actions' })).toBeInTheDocument();
     });
 
     it('has no trigger at all when git cannot answer', async () => {

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -248,6 +248,30 @@ function renderPage(
 }
 
 /**
+ * Wait for the page to stop loading before driving it.
+ *
+ * The reading pane is the LAST thing to arrive: it needs the skill detail
+ * (which is also what puts the second tab on screen) and then the file's bytes
+ * off the default branch. Waiting on a TAB instead can resolve earlier —
+ * `findByRole('tab', …)` is satisfied by the SKILL.md tab, which renders
+ * before either of those lands.
+ *
+ * Why the keyboard tests use it: `jumps to the first and last file with Home
+ * and End` was seen failing in full-suite runs on a loaded machine, never in
+ * isolation (0 in 20 runs). The cause was NOT established — a deliberately
+ * delayed detail load does not reproduce it, and the same runs on the
+ * unmodified file were too few to tell the two versions apart. What is certain
+ * is that both keyboard tests were driving the tablist while several requests
+ * were still in flight, and they are about arrow keys, not about loading. So
+ * they start from a settled page. If the flake outlives this, the cause is
+ * somewhere else and this at least stops the tablist tests from being where it
+ * is hunted.
+ */
+async function settled() {
+  await screen.findByTestId('md-view');
+}
+
+/**
  * The provider tree `renderPage` mounts, as a value — so a test can hand the
  * SAME tree back to `rerender` with a different git state and watch the page
  * react WITHOUT remounting it. Remounting would reset the very state
@@ -388,7 +412,8 @@ describe('SkillPage', () => {
    */
   it('moves selection AND focus with the arrow keys', async () => {
     renderPage(false);
-    const skillTab = await screen.findByRole('tab', { name: /SKILL\.md/ });
+    await settled();
+    const skillTab = screen.getByRole('tab', { name: /SKILL\.md/ });
     const sourcesTab = screen.getByRole('tab', { name: /sources\.yaml/ });
 
     skillTab.focus();
@@ -404,7 +429,8 @@ describe('SkillPage', () => {
 
   it('jumps to the first and last file with Home and End', async () => {
     renderPage(false);
-    const skillTab = await screen.findByRole('tab', { name: /SKILL\.md/ });
+    await settled();
+    const skillTab = screen.getByRole('tab', { name: /SKILL\.md/ });
     const sourcesTab = screen.getByRole('tab', { name: /sources\.yaml/ });
 
     skillTab.focus();

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -1265,6 +1265,56 @@ describe('SkillPage: deciding on a change', () => {
       expect(screen.getByRole('button', { name: 'More actions' })).toBeInTheDocument();
     });
 
+    /**
+     * The MENU flag needs the same treatment as the log's, and it is a
+     * separate flag: the trigger and its panel both live behind
+     * `historyAvailable`, so an open menu unmounts with them and leaves its
+     * flag set behind an element nobody can see. Found by cubic on #103.
+     */
+    it('does not spring the menu back open when git recovers', async () => {
+      const bus = makeFakeBus();
+      const { rerender } = renderPage(false, [], [], bus);
+      const trigger = await screen.findByRole('button', { name: 'More actions' });
+      fireEvent.click(trigger);
+      expect(screen.getByRole('menuitem', { name: 'Version history' })).toBeInTheDocument();
+
+      // A poll fails while the menu is OPEN — trigger and panel go together.
+      rerender(harness(bus, { ...git, availability: 'error' } as GitContextValue));
+      expect(screen.queryByRole('button', { name: 'More actions' })).toBeNull();
+
+      // The next poll succeeds. The trigger is back, and it is CLOSED.
+      rerender(harness(bus, git));
+      const back = await screen.findByRole('button', { name: 'More actions' });
+      expect(back).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('menuitem', { name: 'Version history' })).toBeNull();
+    });
+
+    /**
+     * `editing` is the same state by a second door, and it is reachable
+     * without a mouse: `useDismissableMenu` dismisses on outside POINTERDOWN,
+     * so tabbing from the open menu to Edit and pressing Enter never dismisses
+     * it. Cancel then used to hand the menu back open over the file.
+     */
+    it('does not spring the menu back open when the editor closes', async () => {
+      accessMock.result = {
+        canWrite: true,
+        eligible: { roles: [], users: [] },
+        owners: { roles: [], users: [] },
+      };
+      renderPage(true);
+      fireEvent.click(await screen.findByRole('button', { name: 'More actions' }));
+      expect(screen.getByRole('menuitem', { name: 'Version history' })).toBeInTheDocument();
+
+      // Reached by keyboard, so no outside pointerdown ever dismissed the menu.
+      fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+      await screen.findByRole('textbox', { name: /Edit SKILL\.md/ });
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      const back = await screen.findByRole('button', { name: 'More actions' });
+      expect(back).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('menuitem', { name: 'Version history' })).toBeNull();
+    });
+
     it('has no trigger at all when git cannot answer', async () => {
       renderPage(false, [], [], makeFakeBus(), undefined, undefined, undefined, {
         ...git,

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -283,7 +283,20 @@ export function SkillPage({
   // successful one flips it back. Left open, that second poll would put the
   // log back over the file minutes after the reader returned to reading. Once
   // it is gone they ask for it again, which is one click.
+  //
+  // BOTH flags, for one reason: the trigger and its panel live behind
+  // `historyAvailable` together, so an open menu unmounts with them and its
+  // flag is left set behind an element nobody can see. Closing only the log
+  // fixed the panel and left the menu to spring open by itself on the next
+  // good poll.
+  //
+  // `editing` is the second door into the same state, and it is reachable
+  // without a mouse: `useDismissableMenu` dismisses on outside POINTERDOWN, so
+  // tabbing from the open menu to Edit and pressing Enter never dismisses it.
+  // The editor then withdraws `historyAvailable`, and Cancel used to hand the
+  // menu back open.
   if (historyOpen && !historyAvailable) setHistoryOpen(false);
+  if (menuOpen && !historyAvailable) setMenuOpen(false);
   const viewingHistory = historyAvailable && historyOpen;
   /**
    * Change requests a merge attempt has REFUSED as unmergeable. Git is the only

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -1,14 +1,25 @@
-import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, History } from 'lucide-react';
 import {
   DEFAULT_BRANCH,
   pluginOfPath,
   type PullRequestSummary,
 } from '@bevel-software/platform-shared';
 import '../../library.css';
-import { Badge, Button } from '../../../../shared/components';
+import {
+  Badge,
+  Button,
+  IconButton,
+  MenuItem,
+  MenuPanel,
+  Surface,
+  useDismissableMenu,
+} from '../../../../shared/components';
 import { useAuth } from '../../../auth/state/auth.context';
 import { useWorkspace } from '../../../workspace/state/workspace.context';
+import { useGit } from '../../../git/state/git.context';
+import { FileHistoryPanel } from '../../../git/components/FileHistoryPanel';
 import { kbFileUrl, resolveRelativePath, useNodeIdNav } from '../../../workspace/routing/kb-routes';
 import { cancelPullRequest } from '../../../pr/services/pr-cancel.api';
 import { useFileAccess } from '../../../access/hooks/useFileAccess';
@@ -91,8 +102,27 @@ export function SkillPage({
   const [selectedState, setSelected] = useState('SKILL.md');
   const selected = activeFile ?? selectedState;
   const [compareCr, setCompareCr] = useState<PullRequestSummary | null>(null);
+  /**
+   * The `⋯` menu's one destination: the git log for the file on screen,
+   * rendered in place of the reading pane. Local state rather than a URL,
+   * matching the Knowledge viewer's `activeTab` — a skill's canonical address
+   * names the FILE, and history is a lens on it, not a different file.
+   *
+   * Cleared whenever the file changes; see `historyKey` for why that is not a
+   * matter of taste.
+   */
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  const menuRef = useDismissableMenu<HTMLDivElement>({
+    open: menuOpen,
+    onClose: closeMenu,
+    returnFocusTo: menuTriggerRef,
+  });
   /** Ties the tabs to the panel they control; unique per mounted page. */
   const tabsId = useId();
+  const git = useGit();
 
   // Ownership is a property of the CATALOG entry, not of the skill document —
   // it comes from the per-file ACL the provider already resolved, so the page
@@ -210,6 +240,44 @@ export function SkillPage({
     Boolean((location.state as { startEditing?: boolean } | null)?.startEditing),
   );
   const [busyCr, setBusyCr] = useState<number | null>(null);
+
+  /**
+   * The workspace-relative path `FileHistoryPanel` reads the git log for — the
+   * same string the Knowledge viewer hands it, so a skill file's history is
+   * the file's history, not a second implementation of it. Null until the
+   * workspace and the skill have both resolved: the panel takes a path and
+   * asks immediately, so handing it a half-built one would ask about
+   * `undefined/SKILL.md`.
+   */
+  const historyPath = kbDirName && skillPath ? `${kbDirName}/${fileRepoPath}` : null;
+  /**
+   * Whether `⋯` has anything behind it. Git not ready means there is no log to
+   * show, and an overflow that opens onto an empty panel is worse than no
+   * overflow at all — the same call `KbPageHeader` makes.
+   *
+   * `!editing` is the other half, and it is not cosmetic: `SkillFileEditor`
+   * holds the draft in its own state, so swapping it out for the history panel
+   * would throw away whatever the person had typed with no warning and no way
+   * back. The menu returns the moment they save or cancel.
+   */
+  const historyAvailable = git.availability === 'ready' && historyPath !== null && !editing;
+  /**
+   * History closes when the file changes. It is a lens on ONE file, so a tab
+   * switch must land on that file's CONTENT — and it must stay landed: keying
+   * the open flag to the file it was opened for is not enough, because coming
+   * back to that tab then re-opens the log nobody asked for a second time.
+   *
+   * Adjusted during render rather than in an effect, so the new file's content
+   * paints on the first frame. An effect would show the old file's log under
+   * the new file's heading for one commit, which is the flicker the `active`
+   * derivation a few lines up exists to avoid.
+   */
+  const [historyKey, setHistoryKey] = useState(fileRepoPath);
+  if (historyKey !== fileRepoPath) {
+    setHistoryKey(fileRepoPath);
+    if (historyOpen) setHistoryOpen(false);
+  }
+  const viewingHistory = historyAvailable && historyOpen;
   /**
    * Change requests a merge attempt has REFUSED as unmergeable. Git is the only
    * thing that can answer "does this still apply?", and it answers when asked
@@ -440,11 +508,57 @@ export function SkillPage({
 
       <header className="mt-4">
         <div className="flex items-center gap-3">
-          <h1 className="text-display font-semibold text-ink">{skill?.name ?? name}</h1>
+          <h1 className="min-w-0 text-display font-semibold text-ink">{skill?.name ?? name}</h1>
           {skill && owned && (
             <Badge tone="outline" size="xs" className="shrink-0 uppercase">
               Owner
             </Badge>
+          )}
+
+          {/* The same overflow a Knowledge page carries, for the same reason:
+              a skill is a file in the repository, and "who changed this, when"
+              is answerable about it exactly as it is about any other file. It
+              was unanswerable HERE and nowhere else, because this page is the
+              only surface a `Plugins/` file has — the shell routes those URLs
+              to the Library (`isLibraryLocation`) and the Knowledge tree does
+              not list `Plugins/` at all, so there was no viewer to fall back
+              to and no row to right-click.
+
+              Version history is the whole menu, so the trigger goes where the
+              menu goes — see `historyAvailable`. */}
+          {historyAvailable && (
+            <div className="relative ml-auto flex-none">
+              <IconButton
+                ref={menuTriggerRef}
+                aria-label="More actions"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                active={menuOpen}
+                onClick={() => setMenuOpen((v) => !v)}
+              >
+                <span aria-hidden className="text-strong leading-none">
+                  ⋯
+                </span>
+              </IconButton>
+              {menuOpen && (
+                <div ref={menuRef} className="absolute right-0 top-[calc(100%+5px)] z-40">
+                  <MenuPanel role="menu" aria-label="More actions" className="min-w-[212px]">
+                    <MenuItem
+                      role="menuitem"
+                      onClick={() => {
+                        closeMenu();
+                        setHistoryOpen(true);
+                      }}
+                    >
+                      <span className="flex items-center gap-2.5">
+                        <History size={14} />
+                        Version history
+                      </span>
+                    </MenuItem>
+                  </MenuPanel>
+                </div>
+              )}
+            </div>
           )}
         </div>
         {/* No description line here — the file pane renders the raw SKILL.md,
@@ -476,16 +590,47 @@ export function SkillPage({
         }}
       />
 
-      {/* The panel the tabs control. It wraps BOTH the reading pane and the
-          editor that replaces it, so `aria-controls` resolves in either state
-          rather than pointing at an element that exists only half the time. */}
+      {/* The panel the tabs control. It wraps the reading pane, the editor
+          that replaces it and the history that replaces both, so
+          `aria-controls` resolves in every state rather than pointing at an
+          element that exists only some of the time. */}
       <div
         role="tabpanel"
         id={skillPanelId(tabsId)}
         aria-labelledby={skillTabId(tabsId, active)}
-        aria-busy={detail.loading || raw === null || undefined}
+        aria-busy={(!viewingHistory && (detail.loading || raw === null)) || undefined}
       >
-      {detail.loading ? (
+      {viewingHistory && historyPath !== null ? (
+        <>
+          {/* An explicit way back. Without it the only route to the file would
+              be reopening it, since history is not in the URL. */}
+          <div className="mb-3 mt-4 flex items-center gap-2">
+            <Button
+              variant="quiet"
+              size="sm"
+              leadingIcon={<ArrowLeft size={13} />}
+              onClick={() => setHistoryOpen(false)}
+            >
+              Back to the file
+            </Button>
+            <span className="text-detail text-ink-faint">{`Version history: ${active}`}</span>
+          </div>
+          {/* A DEFINITE height, and a flex column to hold it. The panel is
+              built for the Knowledge viewer's full-height pane: its list and
+              its diff both scroll inside themselves, which needs a parent
+              whose height does not come from them. Dropped straight into this
+              reading column it would size to its own content instead, so a
+              long diff would stretch the page rather than scroll in place and
+              the empty state would collapse to a line. The measure matches the
+              editor's textarea, which is the same trade in the same column. */}
+          <Surface
+            radius="lg"
+            className="flex h-[60vh] min-h-80 flex-col overflow-hidden"
+          >
+            <FileHistoryPanel filePath={historyPath} />
+          </Surface>
+        </>
+      ) : detail.loading ? (
         <SkillFilePane
           file={active}
           raw={null}
@@ -568,8 +713,12 @@ export function SkillPage({
       )}
 
       {/* Every open proposal on this file, under the file it is about. The
-          owner decides here; the author can take theirs back. */}
+          owner decides here; the author can take theirs back. Not under the
+          history panel: a box asking "approve this?" needs the text it would
+          change above it, and the log is not that text. The dock below still
+          reaches every open request from either view. */}
       {!editing &&
+        !viewingHistory &&
         boxes.map((cr) => {
           const mine = data.myCrNumbers.has(cr.number);
           // `[]` is the hook's "overtaken" answer — the proposal and the file

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -277,6 +277,13 @@ export function SkillPage({
     setHistoryKey(fileRepoPath);
     if (historyOpen) setHistoryOpen(false);
   }
+  // Losing the log CLOSES it, rather than parking it behind a flag. Git
+  // availability is re-derived from a polled status call, so a single failed
+  // poll flips it to `error` — which takes the panel off screen — and the next
+  // successful one flips it back. Left open, that second poll would put the
+  // log back over the file minutes after the reader returned to reading. Once
+  // it is gone they ask for it again, which is one click.
+  if (historyOpen && !historyAvailable) setHistoryOpen(false);
   const viewingHistory = historyAvailable && historyOpen;
   /**
    * Change requests a merge attempt has REFUSED as unmergeable. Git is the only


### PR DESCRIPTION
## What this does

The skill page gets the `⋯` menu a Knowledge page already has, with **Version history** behind it, opening the git log for the file on screen in place of the reading pane, with a way back.

It was reachable from nowhere before. The shell routes every default-branch `Plugins/` URL to the library surface (`isLibraryLocation`), so a skill file's only page is the skill page; the Knowledge tree deliberately does not list `Plugins/` at all, so there was no row to right-click either. The log had always been there behind the same endpoint the Knowledge viewer calls — no screen ever asked it for a skill.

That gap sat directly on the README's enterprise claim: *"the audit trail is the storage layer: who changed what, when, who approved it, and how to undo it."* True for every `KnowledgeBase/` page, and for no skill.

## Three gates, each earning its place

- **No git, no menu.** Version history is the whole menu, and an overflow that opens onto an empty panel is worse than no overflow. Same call `KbPageHeader` makes.
- **No menu while the editor is open.** `SkillFileEditor` holds the draft in its own state, so replacing it with the log would discard whatever had been typed, silently and with no way back.
- **History is keyed to the file**, so a tab switch lands on that file's content on the same render, and coming back lands on the file rather than reopening the log.

## Review finding, fixed in `dcbb43b`

`git.availability` is re-derived from a **polled** status call, so one failed poll flips it to `error` and the next good one flips it back. Gating only the render on that left the open flag set underneath: the panel vanished on the bad poll, the reader went back to reading, and the next good poll dropped the log back over the file minutes later. It now closes outright.

The test drives it through `rerender` rather than a fresh `render` — a remount would reset the very flag under test and pass regardless — and was verified to fail without the fix.

## One commit a reviewer should decide on

`526b12d` makes two **pre-existing** tablist tests start from a settled page. It is hardening, **not** a fix, and the commit message says so.

`jumps to the first and last file with Home and End` was seen failing under full-suite load and never in isolation. The cause was never established: a deliberately delayed detail load does not reproduce it, and 20 consecutive clean full-suite runs cleared this branch's changes. What is certain is only that both keyboard tests were driving the tablist while several requests were still in flight, and that they are about arrow keys rather than loading.

It is the one commit touching tests not written for this change. Drop it if you would rather keep the branch to its own scope.

## Verification

Checked in a running instance, not only in unit tests: a hermetic deployment with three seeded revisions on a real `SKILL.md` — the menu opening, the log listing all three, the rendered before/after diff, the tab-switch reset, and the editor gating. That live pass is where a reappearance bug surfaced that the unit tests had missed.

| | |
|---|---|
| Tests | core-frontend 1507/1507, core-backend 1877/1877, hexis-mcp 133/133, mcp-core 85/85 — three consecutive full-monorepo runs |
| Typecheck | clean, all 7 packages |
| Lint | clean on all changed files |
| Changeset | `patch` on `@bevel-software/platform-core-frontend` |

Managing access is unchanged and deliberately still the plugin's Share panel: a skill inherits its plugin folder's `access.md`, and that is the one place those rules are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Version history to the skill page's `⋯` menu, opening the git log for the file on screen in place of the reading pane. Before, a skill's history was reachable from nowhere; the log was always there, but no surface asked for a skill.

- The menu is hidden while the editor is open and when git is unavailable, since Version history is the whole menu.
- History follows the file: a tab switch lands on that file's content, and coming back stays on the file rather than reopening the log.
- Losing git mid-read now closes both the panel and its menu, so a recovered poll cannot drop either back over the file; the same closure covers the editor being opened by keyboard and canceled.
- Two pre-existing tablist tests now wait for the reading pane before driving the tablist; this hardening is separable and can be dropped.
- Managing access is unchanged; skills still inherit their plugin folder's rules via the Share panel.

<sup>Written for commit 8d87b0cd83c3e9153cfb806083d69410d47de87a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

