### PR TITLE
A connected sign-in offers Reconnect on the tool page

### DIFF
--- a/.changeset/reconnect-sign-in.md
+++ b/.changeset/reconnect-sign-in.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+A connected sign-in on a tool's page now has a **Reconnect** button beside its Connected chip. Providers can widen what a token needs after the fact (HubSpot's MCP tools answer `REQUIRES_REAUTHORIZATION` until the user consents again) or revoke a grant, and until now the tool page offered no way back into consent while the row still read Connected — only the Secrets page did.

--- a/packages/core-frontend/src/modules/library/__tests__/ToolVarRow.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/ToolVarRow.test.tsx
@@ -166,6 +166,24 @@ describe('ToolVarRow: oauth', () => {
     expect(screen.getByText('Connected')).toBeInTheDocument();
   });
 
+  it('offers Reconnect beside Connected, for everyone, and it re-enters the same sign-in flow', async () => {
+    // A provider can widen what it grants after the fact (HubSpot answers
+    // REQUIRES_REAUTHORIZATION until the user consents again) or revoke a
+    // grant — the caller needs a way back into consent that doesn't wait for
+    // the scope check to notice. Left of the chip, so the chip stays the
+    // row's terminal state at a glance.
+    renderRow(signin({ authorized: true }));
+    const reconnect = screen.getByRole('button', { name: 'Reconnect' });
+    expect(reconnect.compareDocumentPosition(screen.getByText('Connected')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    fireEvent.click(reconnect);
+    await waitFor(() =>
+      expect(connectMock.startToolOAuth).toHaveBeenCalledWith('github', 'SIGNIN', { returnTo: RETURN_TO }),
+    );
+    await waitFor(() =>
+      expect(navMock.navigateExternal).toHaveBeenCalledWith('https://provider.example/authorize'),
+    );
+  });
+
   it('asks for a fresh sign-in when the token is under-scoped', () => {
     renderRow(signin({ authorized: true, needsReauth: true }));
     expect(screen.getByRole('button', { name: 'Sign in again' })).toBeInTheDocument();

--- a/packages/core-frontend/src/modules/library/components/tool-page/ToolVarRow.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/ToolVarRow.tsx
@@ -143,7 +143,15 @@ export function ToolVarRow({
 
     if (variable.authorized && !variable.needsReauth) {
       description = 'Each person sets their own';
+      // Connected is not final: a provider can widen what it grants after the
+      // fact (HubSpot's MCP tools do, and answer REQUIRES_REAUTHORIZATION
+      // until the user consents again), a grant can be revoked provider-side,
+      // or the owner can rotate the client. The caller needs a way back into
+      // consent that doesn't wait for the scope check to notice.
       meta.push(
+        <Button key="reconnect" size="tiny" variant="quiet" disabled={busy} onClick={() => void signIn()}>
+          Reconnect
+        </Button>,
         <Badge key="chip" tone="ok">
           Connected
         </Badge>,


### PR DESCRIPTION
## Why

Found testing HubSpot on staging after #101/#102: a sign-in that HubSpot answers with `REQUIRES_REAUTHORIZATION` still reads **Connected** on the tool page, and the row offered no way back into consent (only "Replace client secret" for writers). The Secrets page row already had Reconnect; the tool page — where the setup banner sends people — did not.

## What changes

`ToolVarRow`: a **Reconnect** button (quiet, tiny) to the left of the Connected chip, for every caller, re-entering the same `startToolOAuth` flow with the row's `returnTo`. The "Sign in again" state (under-scoped token) is unchanged.

## Verification

Typecheck clean; new test asserts the button precedes the chip and starts the flow; ToolVarRow/ToolConnectionSection/ToolPage suites 51/51. Changeset: patch, core-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Reconnect button beside the Connected chip on the tool page's OAuth sign-in row, so a sign-in that a provider now answers with `REQUIRES_REAUTHORIZATION` (HubSpot's MCP tools) or whose grant was revoked can get back into consent. Previously the tool page only showed Connected with no way back; only the Secrets page offered Reconnect.

**Bug Fixes**
- The button re-enters the same `startToolOAuth` flow with the row's `returnTo` for every caller.
- The under-scoped "Sign in again" state is unchanged.

<sup>Written for commit 91bb34ca4cae8b6c2e513ffd4d1878baade077d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

