### PR TITLE
An expired MCP session answers 404, the code clients re-initialize on

### DIFF
--- a/.changeset/mcp-session-not-found-status.md
+++ b/.changeset/mcp-session-not-found-status.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-backend': patch
+---
+
+`/api/mcp` now answers a request naming a session it no longer holds with HTTP 404 and JSON-RPC `-32001 Session not found`, instead of a 400 that read as "malformed request". Streamable HTTP makes that 404 the signal a client re-initializes on, so every connected agent used to strand itself whenever the server restarted (the session map is in-process) or the idle sweep evicted its session — a person had to reconnect each client by hand. A request that carries no session id at all is still a 400, now `-32000` and distinguishable from the miss above; both bodies are real JSON-RPC error objects, since these answers are produced before the request reaches an SDK transport. An `initialize` is no longer refused for still carrying a stale session id, which is exactly the shape the recovering client sends.

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -122,8 +122,10 @@ export async function createCoreServer(
   // `exposedHeaders` lets a BROWSER-based MCP client (e.g. MCP Inspector) read
   // the Streamable-HTTP session header off the `initialize` response — custom
   // response headers are hidden from browser JS unless exposed, so without this
-  // the client can't send `Mcp-Session-Id` back and every follow-up 400s with
-  // "session id does not match any active session". `WWW-Authenticate` is
+  // the client can't send `Mcp-Session-Id` back at all, and every follow-up
+  // 400s with "Bad Request: Mcp-Session-Id header is required" — the
+  // missing-header case, not the unknown-session one (that answers 404
+  // "Session not found"). `WWW-Authenticate` is
   // exposed so a browser client can read the 401 challenge and start the OAuth
   // discovery flow. (Native clients like Claude Code aren't subject to CORS.)
   app.use(

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp-routes-harness.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp-routes-harness.ts
@@ -1,0 +1,89 @@
+import type { Server as HttpServer } from 'node:http';
+import type { RequestHandler } from 'express';
+import express from 'express';
+import { createMcpRoutes } from '../mcp.routes.js';
+
+/**
+ * The shared mount for every `createMcpRoutes` suite.
+ *
+ * Three suites exercise different slices of this router — the transport's
+ * session routing, the connection-key routes, the local-token exchange — and
+ * each had grown its own copy of the same scaffolding: a `fakeAuth` stand-in,
+ * an `app.listen(0)` plus `afterEach` close, and the eight-argument
+ * `createMcpRoutes` call with stubs in every position the suite does not care
+ * about. Three copies meant a signature change had three places to patch, and
+ * they had already drifted from one another.
+ *
+ * Not collected by vitest: the include pattern is `**\/*.test.ts`, and this is
+ * not a test file.
+ */
+
+/**
+ * Auth stand-in binding the user named by `x-test-user`, defaulting to user-A.
+ *
+ * The header lets a suite act as a second user (the cross-user checks need
+ * one); suites that never send it see the single fixed user their assertions
+ * were written against.
+ */
+export const fakeAuth: RequestHandler = (req, _res, next) => {
+  req.userId = (req.headers['x-test-user'] as string | undefined) ?? 'user-A';
+  next();
+};
+
+/**
+ * The collaborators a suite actually cares about. Anything omitted is stubbed:
+ * `createMcpRoutes` only dereferences a dependency inside the handler that
+ * needs it, so a suite that never calls that route never touches the stub.
+ */
+export interface McpRoutesDeps {
+  mcpService?: unknown;
+  externalApiKeyService?: unknown;
+  llmUsageService?: unknown;
+  internalTokens?: unknown;
+  oauthProvider?: unknown;
+  resourceMetadataUrl?: string;
+}
+
+/** Servers opened by `mountMcpRoutes`, closed together by `closeMountedRoutes`. */
+const openServers = new Set<HttpServer>();
+
+/**
+ * Mount the router on an ephemeral port; returns its base URL. Every mount is
+ * tracked, so a suite's teardown is one `closeMountedRoutes()` regardless of
+ * how many it opened.
+ */
+export async function mountMcpRoutes(deps: McpRoutesDeps = {}): Promise<string> {
+  const stub = {} as never;
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api',
+    createMcpRoutes(
+      // `createMcpRoutes` calls `onSessionEvicted` at CONSTRUCTION, so unlike
+      // the others this one needs a real function even when unused.
+      (deps.mcpService ?? { onSessionEvicted: () => {} }) as never,
+      (deps.externalApiKeyService ?? stub) as never,
+      fakeAuth,
+      fakeAuth,
+      (deps.llmUsageService ?? stub) as never,
+      (deps.internalTokens ?? stub) as never,
+      (deps.oauthProvider ?? stub) as never,
+      deps.resourceMetadataUrl ?? '',
+    ),
+  );
+  const server = await new Promise<HttpServer>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  openServers.add(server);
+  const { port } = server.address() as { port: number };
+  return `http://127.0.0.1:${port}`;
+}
+
+/** Close every server this harness opened. Safe to call when none are open. */
+export async function closeMountedRoutes(): Promise<void> {
+  const servers = [...openServers];
+  openServers.clear();
+  await Promise.all(
+    servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+  );
+}

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.delete.test.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.delete.test.ts
@@ -1,10 +1,7 @@
-import type { Server as HttpServer } from 'node:http';
-import type { RequestHandler } from 'express';
-import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMcpRoutes } from '../mcp.routes.js';
 import { TokenNotFoundError, TokenStillActiveError } from '../../tool-auth/external-api-key.errors.js';
 import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.interface.js';
+import { closeMountedRoutes, mountMcpRoutes } from './mcp-routes-harness.js';
 
 /**
  * Focused coverage for the status mapping of
@@ -14,19 +11,8 @@ import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.in
  * HTTP status codes (404 / 409 / 500) and the success shape.
  */
 
-// Stand-in auth: bind a user like the real jwtAuthMiddleware does.
-const fakeAuth: RequestHandler = (req, _res, next) => {
-  req.userId = 'user-A';
-  next();
-};
-
-let httpServer: HttpServer | undefined;
-
 afterEach(async () => {
-  if (httpServer) {
-    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
-    httpServer = undefined;
-  }
+  await closeMountedRoutes();
   vi.restoreAllMocks();
 });
 
@@ -35,24 +21,10 @@ async function mountWithRemove(
 ): Promise<{ baseUrl: string; remove: ReturnType<typeof vi.fn> }> {
   const spy = vi.fn(remove);
   const externalApiKeyService = { remove: spy } as unknown as IExternalApiKeyService;
-  // createMcpRoutes only touches mcpService.onSessionEvicted at construction.
-  const mcpService = { onSessionEvicted: () => {} } as never;
-  const stub = {} as never;
-
-  const app = express();
-  app.use(express.json());
-  // local-token deps (internal tokens / OAuth provider / metadata URL) are only
-  // dereferenced by that route's handler — stubs suffice here.
-  app.use(
-    '/api',
-    createMcpRoutes(mcpService, externalApiKeyService, fakeAuth, fakeAuth, stub, stub, stub, ''),
-  );
-
-  httpServer = await new Promise<HttpServer>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
-  });
-  const port = (httpServer.address() as { port: number }).port;
-  return { baseUrl: `http://127.0.0.1:${port}`, remove: spy };
+  // The local-token deps (internal tokens / OAuth provider / metadata URL) are
+  // only dereferenced by that route's handler, so the harness's stubs suffice.
+  const baseUrl = await mountMcpRoutes({ externalApiKeyService });
+  return { baseUrl, remove: spy };
 }
 
 async function del(baseUrl: string, id: string): Promise<Response> {

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.local-token.test.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.local-token.test.ts
@@ -1,14 +1,11 @@
-import type { Server as HttpServer } from 'node:http';
-import type { RequestHandler } from 'express';
-import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
-import { createMcpRoutes } from '../mcp.routes.js';
 import { MCP_LOOPBACK_TOKEN_TTL_MS } from '../mcp.service.js';
 import { InternalTokenService } from '../../tool-auth/internal-token.service.js';
 import { createTokenVerifier } from '../../tool-auth/tool-auth.middleware.js';
 import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.interface.js';
 import type { BevelOAuthProvider } from '../oauth/bevel-oauth-provider.js';
+import { closeMountedRoutes, mountMcpRoutes } from './mcp-routes-harness.js';
 
 /**
  * Coverage for POST /api/mcp/local-token — the OAuth-access-token → internal
@@ -31,19 +28,8 @@ import type { BevelOAuthProvider } from '../oauth/bevel-oauth-provider.js';
 
 const RESOURCE_METADATA_URL = 'https://bevel.example/.well-known/oauth-protected-resource/api/mcp';
 
-// Stand-in for routes this suite never exercises.
-const fakeAuth: RequestHandler = (req, _res, next) => {
-  req.userId = 'user-A';
-  next();
-};
-
-let httpServer: HttpServer | undefined;
-
 afterEach(async () => {
-  if (httpServer) {
-    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
-    httpServer = undefined;
-  }
+  await closeMountedRoutes();
   vi.restoreAllMocks();
 });
 
@@ -69,31 +55,13 @@ async function mount(oauth: BevelOAuthProvider): Promise<{
   const externalApiKeyService = {
     looksLikeExternalApiKey: (t: string) => typeof t === 'string' && t.startsWith('bevel_'),
   } as unknown as IExternalApiKeyService;
-  // createMcpRoutes only touches mcpService.onSessionEvicted at construction.
-  const mcpService = { onSessionEvicted: () => {} } as never;
-  const stub = {} as never;
-
-  const app = express();
-  app.use(express.json());
-  app.use(
-    '/api',
-    createMcpRoutes(
-      mcpService,
-      externalApiKeyService,
-      fakeAuth,
-      fakeAuth,
-      stub,
-      internalTokens,
-      oauth,
-      RESOURCE_METADATA_URL,
-    ),
-  );
-
-  httpServer = await new Promise<HttpServer>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
+  const baseUrl = await mountMcpRoutes({
+    externalApiKeyService,
+    internalTokens,
+    oauthProvider: oauth,
+    resourceMetadataUrl: RESOURCE_METADATA_URL,
   });
-  const port = (httpServer.address() as { port: number }).port;
-  return { baseUrl: `http://127.0.0.1:${port}`, internalTokens };
+  return { baseUrl, internalTokens };
 }
 
 async function exchange(baseUrl: string, authorization?: string): Promise<Response> {

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
@@ -1,9 +1,6 @@
-import type { Server as HttpServer } from 'node:http';
-import type { Request, RequestHandler, Response } from 'express';
-import express from 'express';
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMcpRoutes } from '../mcp.routes.js';
-import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.interface.js';
+import { closeMountedRoutes, mountMcpRoutes } from './mcp-routes-harness.js';
 
 /**
  * Session routing on the MCP transport routes — how `/api/mcp` answers a
@@ -29,19 +26,8 @@ import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.in
 /** The id the FIRST session minted in a test gets; `openSession` establishes it. */
 const SESSION_ID = 'sess-1';
 
-/** Auth stand-in: binds the user named by `x-test-user`, defaulting to user-A. */
-const fakeAuth: RequestHandler = (req, _res, next) => {
-  req.userId = (req.headers['x-test-user'] as string | undefined) ?? 'user-A';
-  next();
-};
-
-let httpServer: HttpServer | undefined;
-
 afterEach(async () => {
-  if (httpServer) {
-    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
-    httpServer = undefined;
-  }
+  await closeMountedRoutes();
   vi.restoreAllMocks();
 });
 
@@ -73,7 +59,7 @@ function makeMcpService() {
       const transport = {
         sessionId,
         onclose: undefined as undefined | (() => void),
-        handleRequest: vi.fn(async (_req: Request, res: Response) => {
+        handleRequest: vi.fn(async (_req: ExpressRequest, res: ExpressResponse) => {
           if (!announced) {
             announced = true;
             onSessionInitialized(sessionId);
@@ -91,27 +77,8 @@ function makeMcpService() {
 
 async function mount(): Promise<{ baseUrl: string; createSession: ReturnType<typeof vi.fn> }> {
   const mcpService = makeMcpService();
-  const stub = {} as never;
-  const app = express();
-  app.use(express.json());
-  app.use(
-    '/api',
-    createMcpRoutes(
-      mcpService as never,
-      {} as unknown as IExternalApiKeyService,
-      fakeAuth,
-      fakeAuth,
-      stub,
-      stub,
-      stub,
-      '',
-    ),
-  );
-  httpServer = await new Promise<HttpServer>((resolve) => {
-    const s = app.listen(0, () => resolve(s));
-  });
-  const port = (httpServer.address() as { port: number }).port;
-  return { baseUrl: `http://127.0.0.1:${port}`, createSession: mcpService.createSession };
+  const baseUrl = await mountMcpRoutes({ mcpService });
+  return { baseUrl, createSession: mcpService.createSession };
 }
 
 const INITIALIZE = {
@@ -223,7 +190,14 @@ describe('POST /mcp session routing', () => {
     await openSession(baseUrl); // owned by user-A
     const res = await send(baseUrl, { sessionId: SESSION_ID, body: TOOL_CALL, user: 'user-B' });
     expect(res.status).toBe(403);
-    await expect(res.json()).resolves.toEqual({ error: 'Session does not belong to this user' });
+    // JSON-RPC like every other answer this router gives before the SDK
+    // transport — a client parsing /api/mcp bodies as JSON-RPC must not hit a
+    // bare `{ error }` on this one branch.
+    await expect(res.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Session does not belong to this user' },
+      id: null,
+    });
   });
 });
 

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
@@ -26,6 +26,7 @@ import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.in
  *   - the live-session and cross-user branches are untouched.
  */
 
+/** The id the FIRST session minted in a test gets; `openSession` establishes it. */
 const SESSION_ID = 'sess-1';
 
 /** Auth stand-in: binds the user named by `x-test-user`, defaulting to user-A. */
@@ -50,8 +51,15 @@ afterEach(async () => {
  * session through `onSessionInitialized` from INSIDE that first call — which
  * is when the SDK transport really fires it, and the only ordering the route's
  * `active.set` closure can observe without a TDZ error.
+ *
+ * Each call mints a DISTINCT id (`sess-1`, `sess-2`, …) rather than a constant.
+ * With a constant, a route that wrongly minted a second session answered with
+ * a body identical to the correct one, so "no second session" could only ever
+ * be asserted through the call count. Numbering them puts the mistake in the
+ * response itself: a reply naming `sess-2` IS the extra session.
  */
 function makeMcpService() {
+  let minted = 0;
   const createSession = vi.fn(
     async (
       userId: string,
@@ -59,16 +67,18 @@ function makeMcpService() {
       _bearer: string,
       onSessionInitialized: (sessionId: string) => void,
     ) => {
+      minted += 1;
+      const sessionId = `sess-${minted}`;
       let announced = false;
       const transport = {
-        sessionId: SESSION_ID,
+        sessionId,
         onclose: undefined as undefined | (() => void),
         handleRequest: vi.fn(async (_req: Request, res: Response) => {
           if (!announced) {
             announced = true;
-            onSessionInitialized(SESSION_ID);
+            onSessionInitialized(sessionId);
           }
-          res.status(200).json({ forwarded: true, sessionId: SESSION_ID, userId });
+          res.status(200).json({ forwarded: true, sessionId, userId });
         }),
         close: vi.fn(async () => {}),
       };
@@ -182,6 +192,29 @@ describe('POST /mcp session routing', () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ forwarded: true, sessionId: SESSION_ID });
     // No second session: the live branch was taken, not the initialize branch.
+    expect(createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes an initialize over a LIVE session to that session, minting no second one', async () => {
+    // The guard this pins is branch ORDER, and only this change made it
+    // load-bearing: `initialize` used to be gated on `!sessionIdHeader`, so
+    // the live-session branch and the initialize branch were mutually
+    // exclusive and their order did not matter. Without that gate, an
+    // initialize check placed first would match here too — and silently mint
+    // a second session over a working one, which is the failure the route
+    // comment and the PR both promise cannot happen.
+    //
+    // What is asserted is what this ROUTER owes: the request reached the
+    // existing transport and no new session was created. Rejecting a
+    // re-initialize is the SDK transport's own job (`-32600 Server already
+    // initialized`), and asserting that here would be asserting against the
+    // stub rather than against the code under test.
+    const { baseUrl, createSession } = await mount();
+    await openSession(baseUrl); // mints sess-1
+    const res = await send(baseUrl, { sessionId: SESSION_ID, body: INITIALIZE });
+    expect(res.status).toBe(200);
+    // sess-1, not sess-2: the live transport answered, not a fresh one.
+    await expect(res.json()).resolves.toMatchObject({ forwarded: true, sessionId: SESSION_ID });
     expect(createSession).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
+++ b/packages/core-backend/src/modules/mcp/__tests__/mcp.routes.session.test.ts
@@ -1,0 +1,219 @@
+import type { Server as HttpServer } from 'node:http';
+import type { Request, RequestHandler, Response } from 'express';
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMcpRoutes } from '../mcp.routes.js';
+import type { IExternalApiKeyService } from '../../tool-auth/external-api-key.interface.js';
+
+/**
+ * Session routing on the MCP transport routes — how `/api/mcp` answers a
+ * request whose `Mcp-Session-Id` it cannot resolve.
+ *
+ * The distinction is load-bearing rather than cosmetic. Streamable HTTP makes
+ * HTTP 404 on a request bearing a session id the signal a client re-initializes
+ * on; 400 means "you sent something malformed", which has no recovery. These
+ * routes used to answer both misses — no session id, and a session id from a
+ * session that no longer exists — with one 400 on POST and one 404 on
+ * GET/DELETE, so a client whose session died with the server (a restart wipes
+ * the in-process map) was told its request was malformed and stayed stranded.
+ *
+ * Locked down here:
+ *   - the two misses map to distinct, spec-correct codes on every verb;
+ *   - both bodies are real JSON-RPC error objects, since this router answers
+ *     before the SDK transport that would otherwise have shaped them;
+ *   - an `initialize` carrying a STALE session id still opens a new session —
+ *     the recovery path itself, which the old "no session id" guard blocked;
+ *   - the live-session and cross-user branches are untouched.
+ */
+
+const SESSION_ID = 'sess-1';
+
+/** Auth stand-in: binds the user named by `x-test-user`, defaulting to user-A. */
+const fakeAuth: RequestHandler = (req, _res, next) => {
+  req.userId = (req.headers['x-test-user'] as string | undefined) ?? 'user-A';
+  next();
+};
+
+let httpServer: HttpServer | undefined;
+
+afterEach(async () => {
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+    httpServer = undefined;
+  }
+  vi.restoreAllMocks();
+});
+
+/**
+ * A createSession stub shaped like the real one: it hands back a transport
+ * whose `handleRequest` reports the session id it served, and announces the
+ * session through `onSessionInitialized` from INSIDE that first call — which
+ * is when the SDK transport really fires it, and the only ordering the route's
+ * `active.set` closure can observe without a TDZ error.
+ */
+function makeMcpService() {
+  const createSession = vi.fn(
+    async (
+      userId: string,
+      _tokenId: string | null,
+      _bearer: string,
+      onSessionInitialized: (sessionId: string) => void,
+    ) => {
+      let announced = false;
+      const transport = {
+        sessionId: SESSION_ID,
+        onclose: undefined as undefined | (() => void),
+        handleRequest: vi.fn(async (_req: Request, res: Response) => {
+          if (!announced) {
+            announced = true;
+            onSessionInitialized(SESSION_ID);
+          }
+          res.status(200).json({ forwarded: true, sessionId: SESSION_ID, userId });
+        }),
+        close: vi.fn(async () => {}),
+      };
+      const server = { connect: vi.fn(async () => {}), close: vi.fn(async () => {}) };
+      return { transport, server };
+    },
+  );
+  return { onSessionEvicted: () => {}, createSession };
+}
+
+async function mount(): Promise<{ baseUrl: string; createSession: ReturnType<typeof vi.fn> }> {
+  const mcpService = makeMcpService();
+  const stub = {} as never;
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api',
+    createMcpRoutes(
+      mcpService as never,
+      {} as unknown as IExternalApiKeyService,
+      fakeAuth,
+      fakeAuth,
+      stub,
+      stub,
+      stub,
+      '',
+    ),
+  );
+  httpServer = await new Promise<HttpServer>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const port = (httpServer.address() as { port: number }).port;
+  return { baseUrl: `http://127.0.0.1:${port}`, createSession: mcpService.createSession };
+}
+
+const INITIALIZE = {
+  jsonrpc: '2.0',
+  id: 0,
+  method: 'initialize',
+  params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '0' } },
+};
+const TOOL_CALL = { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} };
+
+async function send(
+  baseUrl: string,
+  opts: { method?: string; sessionId?: string; body?: unknown; user?: string } = {},
+): Promise<Response> {
+  const { method = 'POST', sessionId, body, user } = opts;
+  return fetch(`${baseUrl}/api/mcp`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+      ...(user ? { 'x-test-user': user } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+/** Open a real session so `active` holds SESSION_ID. */
+async function openSession(baseUrl: string): Promise<void> {
+  const res = await send(baseUrl, { body: INITIALIZE });
+  expect(res.status).toBe(200);
+}
+
+describe('POST /mcp session routing', () => {
+  it('answers an unknown session id with 404 / -32001, the re-initialize signal', async () => {
+    const { baseUrl } = await mount();
+    const res = await send(baseUrl, { sessionId: 'sess-from-before-the-restart', body: TOOL_CALL });
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Session not found' },
+      id: null,
+    });
+  });
+
+  it('answers a missing session id with 400 / -32000 — a different code from the miss above', async () => {
+    const { baseUrl } = await mount();
+    const res = await send(baseUrl, { body: TOOL_CALL });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad Request: Mcp-Session-Id header is required' },
+      id: null,
+    });
+  });
+
+  it('opens a new session for an initialize that still carries a STALE session id', async () => {
+    const { baseUrl, createSession } = await mount();
+    // Exactly what a client does after a server restart: it re-initializes
+    // before it has any reason to drop the id it was given last time.
+    const res = await send(baseUrl, { sessionId: 'sess-from-before-the-restart', body: INITIALIZE });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ forwarded: true, sessionId: SESSION_ID });
+    expect(createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a new session for an initialize with no session id', async () => {
+    const { baseUrl, createSession } = await mount();
+    const res = await send(baseUrl, { body: INITIALIZE });
+    expect(res.status).toBe(200);
+    expect(createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards to the live transport once a session exists', async () => {
+    const { baseUrl, createSession } = await mount();
+    await openSession(baseUrl);
+    const res = await send(baseUrl, { sessionId: SESSION_ID, body: TOOL_CALL });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ forwarded: true, sessionId: SESSION_ID });
+    // No second session: the live branch was taken, not the initialize branch.
+    expect(createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses another user’s live session with 403', async () => {
+    const { baseUrl } = await mount();
+    await openSession(baseUrl); // owned by user-A
+    const res = await send(baseUrl, { sessionId: SESSION_ID, body: TOOL_CALL, user: 'user-B' });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Session does not belong to this user' });
+  });
+});
+
+describe.each(['GET', 'DELETE'])('%s /mcp session routing', (method) => {
+  it('answers an unknown session id with 404 / -32001', async () => {
+    const { baseUrl } = await mount();
+    const res = await send(baseUrl, { method, sessionId: 'sess-from-before-the-restart' });
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32001, message: 'Session not found' },
+      id: null,
+    });
+  });
+
+  it('answers a missing session id with 400 / -32000', async () => {
+    const { baseUrl } = await mount();
+    const res = await send(baseUrl, { method });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad Request: Mcp-Session-Id header is required' },
+      id: null,
+    });
+  });
+});

--- a/packages/core-backend/src/modules/mcp/mcp.routes.ts
+++ b/packages/core-backend/src/modules/mcp/mcp.routes.ts
@@ -1,4 +1,4 @@
-import express, { type Request, type RequestHandler } from 'express';
+import express, { type Request, type Response, type RequestHandler } from 'express';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -26,6 +26,34 @@ function extractBearer(req: Request): string {
   const header = req.headers.authorization ?? '';
   const firstSpace = header.indexOf(' ');
   return firstSpace >= 0 ? header.slice(firstSpace + 1).trim() : '';
+}
+
+/**
+ * The two JSON-RPC codes the Streamable HTTP transport defines for a session
+ * fault, paired with the HTTP status each rides on.
+ *
+ * `SESSION_NOT_FOUND` (404) is the one that carries meaning to a client: the
+ * spec makes a 404 on a request bearing an `Mcp-Session-Id` the trigger to
+ * start a new session with a fresh `initialize`. `BAD_REQUEST` (400) is the
+ * client-side mistake — a non-initialize request that never carried a session
+ * id at all — and has no recovery, because there is nothing to recover.
+ */
+const SESSION_NOT_FOUND = -32001;
+const BAD_REQUEST = -32000;
+
+/**
+ * Answer in the transport's own wire shape
+ * (`{ jsonrpc, error: { code, message }, id: null }`).
+ *
+ * These misses are caught by THIS router, one layer before the request would
+ * have reached an SDK transport, so the router has to speak the transport's
+ * language itself — a client that parses the body as JSON-RPC must not get a
+ * bare `{ error }` blob just because we answered early. `id: null` matches the
+ * SDK: the request id is not reliably known on a body we may never have
+ * parsed as a single message.
+ */
+function jsonRpcError(res: Response, status: number, code: number, message: string): void {
+  res.status(status).json({ jsonrpc: '2.0', error: { code, message }, id: null });
 }
 
 /**
@@ -95,10 +123,12 @@ export function createMcpRoutes(
       const sessionIdHeader = req.headers['mcp-session-id'] as string | undefined;
       const body = req.body;
 
-      // Three valid request shapes on POST /mcp:
-      //  1. No session id + body is initialize → spin up a new transport.
-      //  2. Session id + matching active session → forward.
-      //  3. Anything else → 400 / 404.
+      // Four request shapes on POST /mcp, in this order:
+      //  1. Session id naming a live session → forward to its transport.
+      //  2. An initialize body → spin up a new transport, whatever stale
+      //     session id the client still has attached.
+      //  3. A session id we have no transport for → 404 (`-32001`).
+      //  4. No session id on a non-initialize request → 400 (`-32000`).
       if (sessionIdHeader && active.has(sessionIdHeader)) {
         const session = active.get(sessionIdHeader)!;
         // Defense in depth: the auth middleware bound a userId for this
@@ -113,7 +143,17 @@ export function createMcpRoutes(
         return;
       }
 
-      if (!sessionIdHeader && isInitializeRequest(body)) {
+      // An initialize starts a fresh session even when the client is STILL
+      // sending a stale `mcp-session-id`. Requiring the header to be absent
+      // deadlocked exactly the client this endpoint most needs to let back in:
+      // one whose session died with the server and that re-initializes without
+      // first clearing the id — it got the catch-all below forever. The SDK's
+      // own transport orders the two checks this way for the same reason:
+      // initialize is never session-validated. A LIVE session id is still
+      // caught by the branch above, so re-initializing over a working session
+      // stays the SDK's `-32600 Server already initialized`, not a silent
+      // second session.
+      if (isInitializeRequest(body)) {
         // The proxy authenticates its loopback calls with the SAME bearer the
         // client used here, so it acts on the request exactly as the caller
         // would. Captured at initialize and seeded into the session's UtcpClient.
@@ -139,10 +179,21 @@ export function createMcpRoutes(
         return;
       }
 
-      res.status(400).json({
-        error:
-          'Bad request: missing session id, or session id does not match any active session.',
-      });
+      // A session id we hold no transport for: the store evicted it, or the
+      // process restarted and this in-memory map went with it. 404 + `-32001`
+      // is what the spec reserves for that, and it is the signal a client keys
+      // its re-initialize on. Answering 400 here read as "you sent a malformed
+      // request" and stranded the client on a session that can never come
+      // back — every connected agent, on every restart, until a human
+      // reconnected it by hand.
+      if (sessionIdHeader) {
+        jsonRpcError(res, 404, SESSION_NOT_FOUND, 'Session not found');
+        return;
+      }
+
+      // No session id at all on a non-initialize request: the one case here
+      // that genuinely is the caller's mistake, and the only one 400 fits.
+      jsonRpcError(res, 400, BAD_REQUEST, 'Bad Request: Mcp-Session-Id header is required');
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       console.error('[mcp] POST /mcp failed:', msg);
@@ -156,8 +207,17 @@ export function createMcpRoutes(
 
   const sessionRequest: RequestHandler = async (req, res) => {
     const sessionIdHeader = req.headers['mcp-session-id'] as string | undefined;
-    if (!sessionIdHeader || !active.has(sessionIdHeader)) {
-      res.status(404).json({ error: 'Unknown MCP session' });
+    // Same split as POST, mirrored: a request that never carried a session id
+    // is the caller's mistake (400), while one naming a session we no longer
+    // hold is the re-initialize signal (404). These were a single 404 — right
+    // for the case that matters, wrong for the other, and neither of them
+    // parseable as JSON-RPC.
+    if (!sessionIdHeader) {
+      jsonRpcError(res, 400, BAD_REQUEST, 'Bad Request: Mcp-Session-Id header is required');
+      return;
+    }
+    if (!active.has(sessionIdHeader)) {
+      jsonRpcError(res, 404, SESSION_NOT_FOUND, 'Session not found');
       return;
     }
     const session = active.get(sessionIdHeader)!;

--- a/packages/core-backend/src/modules/mcp/mcp.routes.ts
+++ b/packages/core-backend/src/modules/mcp/mcp.routes.ts
@@ -40,6 +40,8 @@ function extractBearer(req: Request): string {
  */
 const SESSION_NOT_FOUND = -32001;
 const BAD_REQUEST = -32000;
+/** JSON-RPC 2.0's own code for a fault on our side, used for the 500 catch-alls. */
+const INTERNAL_ERROR = -32603;
 
 /**
  * Answer in the transport's own wire shape
@@ -54,6 +56,35 @@ const BAD_REQUEST = -32000;
  */
 function jsonRpcError(res: Response, status: number, code: number, message: string): void {
   res.status(status).json({ jsonrpc: '2.0', error: { code, message }, id: null });
+}
+
+/**
+ * The answer to a session this router cannot resolve, shared by all three verbs.
+ *
+ * POST and GET/DELETE reach the miss from opposite directions — POST falls
+ * through to it, GET/DELETE test for it up front — but owe the caller the same
+ * two answers, and they were hand-synchronised copies of the same pair of
+ * codes and strings. Sharing the mechanism makes that parity structural
+ * instead of merely asserted by tests.
+ *
+ * Call only once the session is known to be a miss; a live session id never
+ * reaches here.
+ */
+function rejectSessionMiss(res: Response, sessionIdHeader: string | undefined): void {
+  if (sessionIdHeader) {
+    // A session id we hold no transport for: the store evicted it, or the
+    // process restarted and this in-memory map went with it. 404 + `-32001`
+    // is what the spec reserves for that, and it is the signal a client keys
+    // its re-initialize on. Answering 400 here read as "you sent a malformed
+    // request" and stranded the client on a session that can never come
+    // back — every connected agent, on every restart, until a human
+    // reconnected it by hand.
+    jsonRpcError(res, 404, SESSION_NOT_FOUND, 'Session not found');
+    return;
+  }
+  // No session id at all: the one case here that genuinely is the caller's
+  // mistake, and the only one 400 fits.
+  jsonRpcError(res, 400, BAD_REQUEST, 'Bad Request: Mcp-Session-Id header is required');
 }
 
 /**
@@ -136,7 +167,7 @@ export function createMcpRoutes(
         // a leaked session id from being used cross-user even if the
         // attacker has their own valid connection key.
         if (session.userId !== req.userId) {
-          res.status(403).json({ error: 'Session does not belong to this user' });
+          jsonRpcError(res, 403, BAD_REQUEST, 'Session does not belong to this user');
           return;
         }
         await session.transport.handleRequest(req, res, body);
@@ -179,26 +210,14 @@ export function createMcpRoutes(
         return;
       }
 
-      // A session id we hold no transport for: the store evicted it, or the
-      // process restarted and this in-memory map went with it. 404 + `-32001`
-      // is what the spec reserves for that, and it is the signal a client keys
-      // its re-initialize on. Answering 400 here read as "you sent a malformed
-      // request" and stranded the client on a session that can never come
-      // back — every connected agent, on every restart, until a human
-      // reconnected it by hand.
-      if (sessionIdHeader) {
-        jsonRpcError(res, 404, SESSION_NOT_FOUND, 'Session not found');
-        return;
-      }
-
-      // No session id at all on a non-initialize request: the one case here
-      // that genuinely is the caller's mistake, and the only one 400 fits.
-      jsonRpcError(res, 400, BAD_REQUEST, 'Bad Request: Mcp-Session-Id header is required');
+      // Neither a live session nor an initialize: whichever miss this is,
+      // `rejectSessionMiss` owns both answers.
+      rejectSessionMiss(res, sessionIdHeader);
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       console.error('[mcp] POST /mcp failed:', msg);
       if (!res.headersSent) {
-        res.status(500).json({ error: msg });
+        jsonRpcError(res, 500, INTERNAL_ERROR, msg);
       } else {
         res.end();
       }
@@ -207,22 +226,16 @@ export function createMcpRoutes(
 
   const sessionRequest: RequestHandler = async (req, res) => {
     const sessionIdHeader = req.headers['mcp-session-id'] as string | undefined;
-    // Same split as POST, mirrored: a request that never carried a session id
-    // is the caller's mistake (400), while one naming a session we no longer
-    // hold is the re-initialize signal (404). These were a single 404 — right
-    // for the case that matters, wrong for the other, and neither of them
-    // parseable as JSON-RPC.
-    if (!sessionIdHeader) {
-      jsonRpcError(res, 400, BAD_REQUEST, 'Bad Request: Mcp-Session-Id header is required');
-      return;
-    }
-    if (!active.has(sessionIdHeader)) {
-      jsonRpcError(res, 404, SESSION_NOT_FOUND, 'Session not found');
+    // The same two answers POST gives, from the same helper: these were
+    // collapsed into a single 404 — right for the unknown-session case, wrong
+    // for the missing-header one, and neither parseable as JSON-RPC.
+    if (!sessionIdHeader || !active.has(sessionIdHeader)) {
+      rejectSessionMiss(res, sessionIdHeader);
       return;
     }
     const session = active.get(sessionIdHeader)!;
     if (session.userId !== req.userId) {
-      res.status(403).json({ error: 'Session does not belong to this user' });
+      jsonRpcError(res, 403, BAD_REQUEST, 'Session does not belong to this user');
       return;
     }
     try {
@@ -230,7 +243,7 @@ export function createMcpRoutes(
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error';
       console.error('[mcp] session request failed:', msg);
-      if (!res.headersSent) res.status(500).json({ error: msg });
+      if (!res.headersSent) jsonRpcError(res, 500, INTERNAL_ERROR, msg);
       else res.end();
     }
   };


### PR DESCRIPTION
## The problem

`POST /api/mcp` collapsed two different failures into one `400`:

- a request carrying **no session id**, and
- a request naming a **session the server no longer holds**.

The second is the one that carries meaning. Streamable HTTP reserves `404` (JSON-RPC `-32001 Session not found`) for it precisely so a client knows to start a new session; `400` says the opposite — that the request itself was malformed and retrying is pointless.

The session map is in-process, so it empties on **every restart**, including the `docker compose pull app && docker compose up -d` upgrade `UPGRADING.md` prescribes. Every connected agent therefore held a session id the server had forgotten, got a `400` on its next tool call, and stayed stranded until a person reconnected the client by hand. The idle sweep (4h) and the size cap produce the same state.

`McpSessionStore`'s own docstring already names the contract this missed:

> The MCP protocol tolerates this — a 404 on an unknown session id is a defined response, and clients re-initialize.

Measured against the SDK's own transport, which encodes exactly this distinction:

| condition | before | SDK reference | after |
|---|---|---|---|
| unknown/expired session id | `400` | `404` / `-32001` | `404` / `-32001` |
| no session id header | `400` (identical body) | `400` / `-32000` | `400` / `-32000` |

## What changed

**1. POST splits by which failure it actually is.** `404` + `-32001` for a session we no longer hold, `400` + `-32000` for a request that never carried one.

**2. GET/DELETE get the mirror-image split.** They had collapsed the same pair the other way — both misses were `404`, right for the case that matters, wrong for the other.

**3. `initialize` is no longer refused for carrying a stale session id.** This turned out to matter more than the status code. The old guard was `!sessionIdHeader && isInitializeRequest(body)`, so a client re-initializing *without first clearing its stale id* — exactly what a client recovering from a restart sends — fell through to the catch-all forever. The SDK's transport skips session validation for `initialize` for this reason. A live session id is still caught by the earlier branch, so re-initializing over a working session still gets the SDK's `-32600`, not a silent second session.

Both answers are now real JSON-RPC error objects (`{jsonrpc, error: {code, message}, id: null}`) rather than a bare `{error}` blob, since this router replies before the SDK transport that would otherwise shape them.

## Testing

11 tests in `mcp.routes.session.test.ts` covering both misses on all three verbs, the stale-id initialize, the initialize-over-a-live-session branch order, and the live-session and cross-user branches that must not move.

- Against the fix: **11 pass**.
- Against the previous behaviour: **7 fail, 3 pass** — and the 3 that pass are exactly the branches this change must not alter.
- Full MCP module: 122 passed. Full `core-backend`: 1722 passed. Lint clean on the changed files.

**CI has since run the real gate on the head commit, green** — all six steps: `pnpm install --frozen-lockfile`, `notices:check`, `build`, `typecheck`, `test`, `ds:check`. That supersedes an earlier caveat here: the local runs above were done in a scratch tree with `xlsx` stripped (this sandbox's network policy blocks `cdn.sheetjs.com`), which left 5 test files unable to load and said nothing about the licence gate or the design-system ratchet. All of it has now run for real on the runner.

**Follow-up in `ce1f739`:** a regression test for `initialize` over a *live* session. Dropping the `!sessionIdHeader` guard is what made the order of the two POST branches load-bearing — previously they were mutually exclusive — and nothing pinned it. Verified as a real guard rather than a passing assertion: mutating the live-session branch to let initialize through makes it the only one of eleven tests to fail.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm75m3w37NpohcTxsJ8Pcd)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `/api/mcp` answer a request naming a session it no longer holds with HTTP 404 + JSON-RPC `-32001`, the spec-defined signal clients re-initialize on, instead of a 400 that stranded agents after every server restart or idle-sweep eviction. A request with no session id is still a 400, now `-32000`, so the two cases are distinguishable. `initialize` requests still carrying a stale session id — the exact shape a recovering client sends — now start a new session instead of being refused.

**Details**
- Every transport branch now answers in JSON-RPC wire shape; the cross-user 403 and 500 catch-alls previously returned bare `{error}` bodies.
- The session-miss split is shared by all three verbs through one helper, since POST and GET/DELETE reached it from opposite directions.
- 11 tests lock both misses on all three verbs, the stale-id initialize, live-session forwarding, cross-user 403, and the branch order that keeps initialize off a live session; a shared route-mount harness dedupes the test scaffolding across the three suites.

<sup>Written for commit 28b18517fa93f6d15c046247683fcadddb025f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

