### PR TITLE
The review comment links only to a one-pager that exists

### DIFF
--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -392,8 +392,11 @@ jobs:
           case "$url" in
             "${KB_ORIGIN%/}"/workspace/*)
               # <origin>/workspace/<branch>/<workspace path>, both URL-encoded.
-              # The charset filter above already dropped backslashes, so the
-              # %XX → \xXX decode cannot be fed an escape of the agent's own.
+              # The %XX → \xXX decode CAN yield characters the charset filter
+              # dropped (`%5C` is a backslash, `%20` a space): the decoded
+              # branch and path are agent-chosen text. They are safe because
+              # of where they go — `jq --arg` and a JSON request body, both of
+              # which escape their input — and never into a command line.
               rest=${url#"${KB_ORIGIN%/}"/workspace/}
               rest=${rest%%[?#]*}
               enc_branch=${rest%%/*}
@@ -415,9 +418,16 @@ jobs:
                 code=$(curl -sS -m 20 -o stat.json -w '%{http_code}' -X POST \
                         -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' \
                         -d "$stat_args" "${KB_ORIGIN%/}/api/agent/tools/file_stat" || echo 000)
+                # "Definite not found" is the knowledge base's own answer for
+                # a missing path: `file_stat` surfaces the filesystem's ENOENT
+                # as `{ "error": "File not found: <path>" }` — served with a
+                # 500, not a 404, so the status code is no help — while an
+                # access refusal or an outage says something else entirely.
+                # Match that one error message, in the JSON field it lives in,
+                # so no other failure text can pass for an absence.
                 if [ "$code" = 200 ] && jq -e '.type == "file"' stat.json >/dev/null 2>&1; then
                   echo "One-pager verified in the knowledge base: $branch:$path"
-                elif grep -qi 'not found' stat.json 2>/dev/null; then
+                elif jq -e '(.error? // "") | tostring | startswith("File not found: ")' stat.json >/dev/null 2>&1; then
                   echo "::warning::The agent's one_pager_url names a file the knowledge base does not have ($branch:$path) — dropping the link."
                   url=""; onepager_missing=1
                 else

--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -265,6 +265,10 @@ jobs:
   # Runs on every outcome so the check is never left stuck on "pending —
   # running": the agent can fail to reach a verdict without failing its step (it
   # exits 0 having declined to act), and `failure()` does not fire for that.
+  #
+  # It holds the knowledge-base key, for one read: checking that the one-pager
+  # the agent links to is really there. That is safe here precisely because
+  # this job reads nothing the PR's author wrote — only the four fields below.
   # ---------------------------------------------------------------------------
   publish:
     needs: [start, review]
@@ -285,13 +289,15 @@ jobs:
       # Everything in the verdict came through an agent that reads attacker-
       # controllable text, so treat all four fields as hostile: allowlist the
       # outcome, cap and de-newline the prose, cap the finding count, and
-      # require the link to point at the knowledge base or this repository.
+      # require the link to point at the knowledge base or this repository —
+      # and, for a knowledge-base link, to name a file that actually exists.
       # jq does the parsing — the payload never reaches the shell as code.
       - name: Render the verdict
         id: render
         env:
           VERDICT_B64: ${{ needs.review.outputs.verdict_b64 }}
           KB_ORIGIN: ${{ vars.KNOWLEDGE_BASE_API_URL }}
+          KB_KEY: ${{ secrets.KNOWLEDGE_BASE_CONNECTION_KEY }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -374,6 +380,54 @@ jobs:
             *) echo "::warning::Discarding off-site one_pager_url from the agent: $url"; url="" ;;
           esac
 
+          # A knowledge-base link is also checked for EXISTENCE. The agent
+          # records `one_pager_url` BEFORE it writes the one-pager, so a run
+          # that stops early publishes a link to a file that was never written
+          # — the PR then carries a dead link, and nothing on the PR says so.
+          # Ask the knowledge base whether the file is there: one session, one
+          # stat. Drop the link only on a definite "not found"; when the check
+          # itself cannot run (no key, KB down, access refused) keep the link
+          # and warn, so a hiccup here never hides a one-pager that exists.
+          onepager_missing=0
+          case "$url" in
+            "${KB_ORIGIN%/}"/workspace/*)
+              # <origin>/workspace/<branch>/<workspace path>, both URL-encoded.
+              # The charset filter above already dropped backslashes, so the
+              # %XX → \xXX decode cannot be fed an escape of the agent's own.
+              rest=${url#"${KB_ORIGIN%/}"/workspace/}
+              rest=${rest%%[?#]*}
+              enc_branch=${rest%%/*}
+              enc_path=${rest#*/}
+              branch=$(printf '%b' "${enc_branch//%/\\x}")
+              path=$(printf '%b' "${enc_path//%/\\x}")
+
+              if [ -z "$enc_branch" ] || [ "$enc_path" = "$rest" ] || [ -z "$path" ]; then
+                echo "::warning::The agent's one_pager_url names no file in the knowledge base — dropping the link: $url"
+                url=""; onepager_missing=1
+              elif ! sid=$(curl -sS -f -m 20 -X POST \
+                        -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' -d '{}' \
+                        "${KB_ORIGIN%/}/api/agent/tools/start_session" | jq -r '.sessionId // empty') \
+                   || [ -z "$sid" ]; then
+                echo "::warning::Could not open a knowledge-base session to verify the one-pager — keeping the link unverified."
+              else
+                stat_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
+                  '{branch: $b, path: $p, sessionId: $s}')
+                code=$(curl -sS -m 20 -o stat.json -w '%{http_code}' -X POST \
+                        -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' \
+                        -d "$stat_args" "${KB_ORIGIN%/}/api/agent/tools/file_stat" || echo 000)
+                if [ "$code" = 200 ] && jq -e '.type == "file"' stat.json >/dev/null 2>&1; then
+                  echo "One-pager verified in the knowledge base: $branch:$path"
+                elif grep -qi 'not found' stat.json 2>/dev/null; then
+                  echo "::warning::The agent's one_pager_url names a file the knowledge base does not have ($branch:$path) — dropping the link."
+                  url=""; onepager_missing=1
+                else
+                  echo "::warning::Could not verify the one-pager (HTTP $code) — keeping the link unverified."
+                  cat stat.json 2>/dev/null || true
+                fi
+              fi
+              ;;
+          esac
+
           {
             echo "outcome=$outcome"
             echo "headline=$headline"
@@ -406,6 +460,10 @@ jobs:
             printf '\n'
             if [ -n "$url" ]; then
               printf '[Full analysis](%s)\n' "$url"
+            elif [ "$onepager_missing" = 1 ]; then
+              # Say so on the PR rather than silently dropping the link: the
+              # reader would otherwise assume there is no deeper analysis.
+              echo "The full analysis this review refers to was never written to the knowledge base — re-trigger with \`/bevel-review\` to regenerate it."
             elif [ "$outcome" = none ]; then
               printf '[Run log](%s)\n' "$RUN_URL"
             fi


### PR DESCRIPTION
The agent records `one_pager_url` in its verdict BEFORE it writes the one-pager, and a run that stops early — as four did on 2026-08-27, for #105, #106 and #107 — publishes a link to a file that was never written. `publish` checked that the link points at the knowledge base, not that anything is there, so the pull request carried a dead link and nothing on the PR said so.

`publish` now asks the knowledge base whether the file exists: one `start_session`, one `file_stat` on the branch and path parsed out of the link. A definite "not found" drops the link, warns in the run, and tells the PR reader the analysis was not written and how to regenerate it; the commit status then targets the run log. When the check itself cannot run — no key, KB unreachable, access refused — the link is kept and a warning is logged, so a knowledge-base hiccup never hides a one-pager that exists.

This puts the connection key in `publish`. That is safe: the job reads nothing the PR's author wrote, only the four validated verdict fields. `review` stays read-only on the repository and `publish` stays blind to the PR, exactly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workflow so review comments no longer link to one-pagers that were never written. The agent records `one_pager_url` before writing the file, so an early-stopped run published a dead link; `publish` now verifies the file exists in the knowledge base.

- A link is dropped only on a definite absence: the knowledge base's own `File not found: <path>` message in the error field, served with a 500, so the status code can't be the gate and nothing looser passes.
- Every other failure — no key, KB unreachable, access refused, an unexpected response — keeps the link and warns; a dropped link makes the run warn, tells the PR reader the analysis was never written and how to regenerate it, and falls back to the run log for the commit status.
- The connection key now lives in `publish`, which reads only the four validated verdict fields; the branch and path decoded from the link are agent-chosen text, safe only because they flow through `jq --arg` and a JSON body.

<sup>Written for commit b0fd97d77c70c2740d0b89356581125077971670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

