### PR TITLE
The empty state's suggestions skip access.md

### DIFF
--- a/.changeset/empty-state-skips-access-md.md
+++ b/.changeset/empty-state-skips-access-md.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+The empty state's opening suggestions no longer offer `access.md` files. They are a folder's access-control rules, not pages to read — and because every plugin and governed folder carries one inside the knowledge tree, the existing root-file exclusion never reached them.

--- a/packages/core-frontend/src/modules/workspace/utils/__tests__/fileTree.test.ts
+++ b/packages/core-frontend/src/modules/workspace/utils/__tests__/fileTree.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import type { FileTreeEntry } from '@bevel-software/platform-shared';
+import { suggestedPages } from '../fileTree';
+
+/**
+ * The empty state's opening offer walks the tree the server already filtered
+ * (`.bevelignore`, the reader's access), so visibility is inherited. What the
+ * walk must decide for itself is what counts as a PAGE — and an `access.md`
+ * is a document by extension only.
+ */
+
+const file = (relativePath: string): FileTreeEntry => ({
+  name: relativePath.split('/').pop()!,
+  relativePath,
+  type: 'file',
+});
+const dir = (relativePath: string, children: FileTreeEntry[]): FileTreeEntry => ({
+  name: relativePath.split('/').pop()!,
+  relativePath,
+  type: 'directory',
+  children,
+});
+
+const TREE: FileTreeEntry = dir('', [
+  dir('knowledge-base', [
+    file('knowledge-base/access.md'),
+    file('knowledge-base/roles.yaml'),
+    dir('knowledge-base/KnowledgeBase', [
+      file('knowledge-base/KnowledgeBase/access.md'),
+      file('knowledge-base/KnowledgeBase/Access.MD'),
+      file('knowledge-base/KnowledgeBase/Onboarding.md'),
+      dir('knowledge-base/KnowledgeBase/GTM', [
+        file('knowledge-base/KnowledgeBase/GTM/access.md'),
+        file('knowledge-base/KnowledgeBase/GTM/Pricing.md'),
+        file('knowledge-base/KnowledgeBase/GTM/deals.csv'),
+      ]),
+    ]),
+    dir('knowledge-base/Plugins', [
+      dir('knowledge-base/Plugins/GTM', [file('knowledge-base/Plugins/GTM/README.md')]),
+    ]),
+  ]),
+]);
+
+describe('suggestedPages', () => {
+  it('offers documents, never a folder\'s access rules — at any depth, in any case', () => {
+    const offered = suggestedPages(TREE, 10).map((e) => e.relativePath);
+    expect(offered).toEqual([
+      'knowledge-base/KnowledgeBase/Onboarding.md',
+      'knowledge-base/KnowledgeBase/GTM/Pricing.md',
+    ]);
+  });
+
+  it('honours the limit breadth-first and reports an empty knowledge base as such', () => {
+    expect(suggestedPages(TREE, 1).map((e) => e.name)).toEqual(['Onboarding.md']);
+    expect(suggestedPages(dir('', [dir('knowledge-base', [dir('knowledge-base/KnowledgeBase', [])])]), 3)).toEqual([]);
+    expect(suggestedPages(null, 3)).toEqual([]);
+  });
+});

--- a/packages/core-frontend/src/modules/workspace/utils/fileTree.ts
+++ b/packages/core-frontend/src/modules/workspace/utils/fileTree.ts
@@ -46,6 +46,15 @@ export function findKbRoot(node: FileTreeEntry | null): FileTreeEntry | null {
 const READABLE_PAGE = /\.(md|markdown)$/i;
 
 /**
+ * An `access.md` is a document by extension only: it is a folder's
+ * access-control rules, and it sits INSIDE the knowledge tree (every plugin
+ * and any governed folder carries one), so the root-file exclusion below
+ * never reaches it. Nobody opens a knowledge base to read who may edit it.
+ */
+const ACCESS_RULES_FILE = 'access.md';
+const isAccessRulesFile = (entry: FileTreeEntry): boolean => entry.name.toLowerCase() === ACCESS_RULES_FILE;
+
+/**
  * Pages worth offering to someone who has nothing open: the documents nearest
  * the top of the knowledge tree, breadth-first, so the opening suggestion is a
  * section heading rather than the fifth file inside the first folder.
@@ -83,7 +92,7 @@ export function suggestedPages(tree: FileTreeEntry | null, limit: number): FileT
       // Dot-prefixed entries are the repository's own bookkeeping.
       if (entry.name.startsWith('.')) continue;
       if (entry.type === 'file') {
-        if (READABLE_PAGE.test(entry.name)) pages.push(entry);
+        if (READABLE_PAGE.test(entry.name) && !isAccessRulesFile(entry)) pages.push(entry);
       } else if (entry.name !== PLUGINS_DIR) {
         next.push(...(entry.children ?? []));
       }


### PR DESCRIPTION
## Why

The empty state offered `access.md` files as pages to read. They match the page pattern (`.md`) and sit inside the knowledge tree — every plugin and governed folder carries one — so the root-file exclusion in `suggestedPages` never reached them.

## What changes

One guard in `suggestedPages`: a file named `access.md` (any case) is not a page. The walk still runs over the tree the server already built under `.bevelignore` and the reader's access filter, so visibility stays inherited — no new route, no second filtering pipeline. Smaller alternative to #100.

## Verification

New `fileTree.test.ts`: access rules at root, in `KnowledgeBase/`, nested, and upper-cased are all skipped while sibling pages are offered; limit and empty-tree behaviour pinned. Typecheck clean; workspace component suite 426/426. Changeset: patch, core-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the empty state suggestions so `access.md` files are no longer offered as readable pages, since they are a folder's access-control rules rather than content to read.

- Suggests pages still inherit the server's existing `.bevelignore` and access filtering, with only the new `access.md` guard added.
- Adds tests for root, nested, and upper-cased `access.md` files plus empty-tree behavior.
- Ships as a patch changeset for `@bevel-software/platform-core-frontend`.

<sup>Written for commit 91f4edb2c2fb0b1b1f0eb3a1371156bd48965eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

