### PR TITLE
implemented fix for the delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ open-source core of the Bevel platform.
 
 ## Why Hexis?
 
+Used by companies such as [Unite](https://unite.eu) (formerly Mercateo), [osapiens](https://osapiens.com), [BEO](https://beo.energy), [Workpath](https://www.workpath.com) and others.
+
 ### For teams
 
 One place where engineers and non-technical people alike can browse and load

--- a/packages/core-backend/src/modules/workflow/__tests__/preserve-roles-yaml.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/preserve-roles-yaml.test.ts
@@ -26,6 +26,10 @@ import { RolesYamlPreservationError } from '../../../shared/domain-errors.js';
 const KB_DIR = 'knowledge-base';
 const BASE = 'current-company-state';
 const HEAD = 'mallory/escalate';
+// The head SHA the caller resolved and the merge gate authorised against — the
+// guard reads the head's roles.yaml at this COMMIT, not at `origin/<head>`, so
+// a ref that moved after the gate ran can't be waved through.
+const HEAD_SHA = 'sha';
 const USER = { id: 'u-mallory', email: 'mallory@x.com', name: 'Mallory' };
 const BASE_ROLES = 'roles:\n  Admin:\n    - admin@x.com\n';
 const ATTACKER_ROLES = 'roles:\n  Admin:\n    - admin@x.com\n    - mallory@x.com\n';
@@ -80,10 +84,15 @@ describe('mergeChangeRequest — roles.yaml preservation guard', () => {
 
     const git = {
       fetch: vi.fn().mockResolvedValue(undefined),
+      // The narrow, FAIL-CLOSED refresh the comparison runs before reading the
+      // two origin refs. Distinct from `fetch` on purpose: a swallowed failure
+      // here would compare stale refs and wave a roles.yaml change through.
+      fetchBranchRefs: vi.fn().mockResolvedValue(undefined),
       pull: vi.fn().mockResolvedValue(undefined),
-      // Resolve roles.yaml at origin/<ref> from the per-test content.
+      // Base resolves from `origin/<base>`; head resolves from the authorised
+      // COMMIT (HEAD_SHA), which is what the guard reads.
       readFileAtRef: vi.fn(async (_ws: string, ref: string) =>
-        ref === `origin/${BASE}` ? opts.baseRoles : ref === `origin/${HEAD}` ? opts.headRoles : null,
+        ref === `origin/${BASE}` ? opts.baseRoles : ref === HEAD_SHA ? opts.headRoles : null,
       ),
       commitFile: vi.fn().mockResolvedValue(
         'commitFileResult' in opts ? opts.commitFileResult : { sha: 'preserve-sha' },
@@ -123,11 +132,11 @@ describe('mergeChangeRequest — roles.yaml preservation guard', () => {
     );
     // Conflicts are now surfaced by the local merge inside `reviewWorkflow.mergePr`
     // (mocked to resolve here), so there's no provider "mergeable" pre-check to stub.
-    return { svc, git, prs, reviewWorkflow, fileLocks };
+    return { svc, git, prs, reviewWorkflow, fileLocks, workspaceService };
   }
 
   async function merge(svc: WorkflowService) {
-    return svc.mergeChangeRequest(1, USER, 'sha', [], 'open', 'Title', BASE, 'w1', { bypass: false });
+    return svc.mergeChangeRequest(1, USER, HEAD_SHA, [], 'open', 'Title', BASE, 'w1', { bypass: false });
   }
 
   it('no-ops when the CR does not change roles.yaml (identical content)', async () => {
@@ -137,6 +146,57 @@ describe('mergeChangeRequest — roles.yaml preservation guard', () => {
     expect(git.commitFile).not.toHaveBeenCalled();
     expect(git.push).not.toHaveBeenCalled();
     expect(reviewWorkflow.mergePr).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers the no-op case with NO network and NO source-workspace bootstrap', async () => {
+    // Both halves of the hot path, pinned together.
+    //
+    // No bootstrap: resolving the SOURCE branch's workspace would CLONE it
+    // (checkout + --dissociate) on the critical path of every merge, to answer
+    // "no" almost every time. It is only needed to WRITE a restore.
+    //
+    // No fetch: the caller's `resolvePrShas` already fetched both refs into this
+    // workspace, so re-fetching bought a second ~0.65s HTTPS round-trip for refs
+    // we already had.
+    const { svc, git, workspaceService } = makeSvc({ headRoles: BASE_ROLES, baseRoles: BASE_ROLES });
+    await merge(svc);
+    expect(workspaceService.getOrCreateForBranch).not.toHaveBeenCalledWith(HEAD);
+    expect(git.fetchBranchRefs).not.toHaveBeenCalled();
+    expect(git.fetch).not.toHaveBeenCalled();
+    // Base from the origin ref, head from the AUTHORISED COMMIT — both out of
+    // the workspace the caller passed to merge().
+    expect(git.readFileAtRef).toHaveBeenCalledWith('w1', `origin/${BASE}`, 'roles.yaml');
+    expect(git.readFileAtRef).toHaveBeenCalledWith('w1', HEAD_SHA, 'roles.yaml');
+  });
+
+  it('reads the head roles.yaml at the authorised SHA, never at origin/<head>', async () => {
+    // The gate authorised `HEAD_SHA`. If the guard resolved `origin/<head>`
+    // instead, a push landing between the gate and here would be cleared on the
+    // strength of a commit nobody reviewed. The stub returns the attacker's
+    // roles.yaml ONLY at HEAD_SHA, so a branch-ref read would see null, compare
+    // unequal, and silently take the restore path instead of the no-op.
+    const { svc, git } = makeSvc({ headRoles: BASE_ROLES, baseRoles: BASE_ROLES });
+    await merge(svc);
+    const refsRead = (git.readFileAtRef as unknown as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[1] as string,
+    );
+    expect(refsRead).toContain(HEAD_SHA);
+    expect(refsRead).not.toContain(`origin/${HEAD}`);
+  });
+
+  it('ABORTS the merge when the restore-path fetch fails (fail-closed)', async () => {
+    // The rare path still fetches: it is about to commit and push a restore onto
+    // the source branch, and a stale `origin/<head>` there means a
+    // non-fast-forward push. `fetchBranchRefs` throws (unlike best-effort
+    // `fetchPrRefs`), and that must abort the merge rather than merge unprotected.
+    const { svc, git, reviewWorkflow } = makeSvc({
+      headRoles: ATTACKER_ROLES, baseRoles: BASE_ROLES,
+    });
+    (git.fetchBranchRefs as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('git fetch failed: could not read from remote repository'),
+    );
+    await expect(merge(svc)).rejects.toBeInstanceOf(RolesYamlPreservationError);
+    expect(reviewWorkflow.mergePr).not.toHaveBeenCalled();
   });
 
   it('no-ops when neither base nor head has a roles.yaml (both absent)', async () => {

--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.service.facade.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.service.facade.test.ts
@@ -150,6 +150,13 @@ function makeGit(): GitService {
     // roles.yaml change" — same content at base and head → the guard no-ops.
     resetToRemote: vi.fn().mockResolvedValue(undefined),
     commitChanges: vi.fn().mockResolvedValue(null),
+    // The guard's narrow, fail-closed ref refresh — only the restore path uses
+    // it now, but it must exist for that path to reach its push.
+    fetchBranchRefs: vi.fn().mockResolvedValue(undefined),
+    // Gates the post-merge pull. Default false = "could not prove the workspace
+    // is current", which is the safe answer and keeps the pull-path tests below
+    // exercising the pull. The skip case is asserted separately.
+    matchesRemoteRef: vi.fn().mockResolvedValue(false),
     readFileAtRef: vi.fn().mockResolvedValue('roles:\n  Admin:\n    - admin@x.com\n'),
   } as unknown as GitService;
 }
@@ -336,6 +343,28 @@ describe('WorkflowService — change request delegation + cache invalidation', (
       { bypass: true },
     );
     expect(prs.invalidateDetailCache).toHaveBeenCalledWith(4);
+  });
+
+  it('mergeChangeRequest SKIPS the post-merge pull when the target workspace is already current', async () => {
+    // The merge ran in this very workspace and left it checked out at the merge
+    // commit it pushed, so `pull` would spend an HTTPS round-trip (~0.65s on the
+    // critical path of every merge) confirming what a local rev-parse already
+    // knows. `matchesRemoteRef` true ⇒ skip; the merge still completes normally.
+    const prs = makePrs();
+    const reviewWorkflow = makeReviewWorkflow();
+    const mergeResult = { prNumber: 4, sha: 'abc', mergedAt: 't' };
+    (reviewWorkflow.mergePr as ReturnType<typeof vi.fn>).mockResolvedValue(mergeResult);
+    (prs.getPr as ReturnType<typeof vi.fn>).mockResolvedValue({ branch: 'alice/feat', base: 'main' });
+
+    const git = makeGit();
+    (git.matchesRemoteRef as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const svc = new WorkflowService(makeDb(), git, prs, reviewWorkflow, makeWorkspaceService(), makeAccessControl(), makeFileLockService(), makePendingCommits(), 'knowledge-base');
+    const outcome = await svc.mergeChangeRequest(
+      4, makeUser(), 'sha', [], 'open', 'PR title', 'main', 'w1', { bypass: true },
+    );
+    expect(outcome).toEqual({ kind: 'merged', result: mergeResult });
+    expect(git.matchesRemoteRef).toHaveBeenCalledWith('main', 'main');
+    expect(git.pull).not.toHaveBeenCalled();
   });
 
   it('mergeChangeRequest still merges when the post-merge pull conflicts, and queues recovery on the TARGET workspace', async () => {

--- a/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
+++ b/packages/core-backend/src/modules/workflow/agent-tools/workflow.tools.ts
@@ -448,6 +448,10 @@ export function registerWorkflowTools(
         fresh: true,
         workspaceId,
         viewerEmail: ctx.user.email,
+        // Internal read: only headSha/approvals/state/title/base are consumed
+        // below, never `files[].patch` — skipping patch generation saves one
+        // git subprocess per changed file on every merge.
+        patches: false,
       });
       if (!detail) {        throw new ToolError(`Change request #${number} not found.`, 404);
       }

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.mergeChangeRequest.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.mergeChangeRequest.test.ts
@@ -63,6 +63,14 @@ async function seed(root: string, baseFiles: Record<string, string>) {
   return { upstream, seedDir, baseWsId, baseRepo };
 }
 
+/**
+ * The published tip of `branch` on the bare upstream — what the review gate
+ * would have resolved as `headSha` and what the merge is now pinned to.
+ */
+async function remoteTip(upstream: string, branch: string): Promise<string> {
+  return (await gitOut(upstream, ['rev-parse', `refs/heads/${branch}`])).trim();
+}
+
 /** Branch `name` off origin/BASE in a throwaway clone, apply `mutate`, push. */
 async function pushFeatureBranch(
   root: string,
@@ -96,7 +104,8 @@ describe('GitService.mergeChangeRequest', () => {
 
     const git = new GitService(stubWorkspaceService(baseWsId, baseRepo), new WorkflowHooks(), 'knowledge-base');
     const result = await git.mergeChangeRequest(
-      baseWsId, 'alice/add', BASE, { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
+      baseWsId, 'alice/add', await remoteTip(upstream, 'alice/add'), BASE,
+      { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
     );
 
     expect(result.kind).toBe('merged');
@@ -131,7 +140,8 @@ describe('GitService.mergeChangeRequest', () => {
 
     const git = new GitService(stubWorkspaceService(baseWsId, baseRepo), new WorkflowHooks(), 'knowledge-base');
     const result = await git.mergeChangeRequest(
-      baseWsId, 'alice/edit', BASE, { subject: 'Edit (#2)', body: 'x' }, USER,
+      baseWsId, 'alice/edit', await remoteTip(upstream, 'alice/edit'), BASE,
+      { subject: 'Edit (#2)', body: 'x' }, USER,
     );
 
     expect(result.kind).toBe('conflicts');
@@ -141,5 +151,73 @@ describe('GitService.mergeChangeRequest', () => {
     // The base workspace must be left clean (merge aborted) — not stuck mid-merge.
     const status = await gitOut(baseRepo, ['status', '--porcelain=v1']);
     expect(status.trim()).toBe('');
+  });
+
+  it('merges ONLY the authorised commit when the branch advances after the gate', async () => {
+    // The review gate resolves a head SHA and approvals are pinned to it, but
+    // this method fetches again before merging. Merging `origin/<source>` would
+    // therefore land whatever arrived in between — verified to reach the
+    // protected branch before the SHA pin. The unreviewed commit must not ride in.
+    const { upstream, baseWsId, baseRepo } = await seed(root, { 'base.md': 'base\n' });
+    await pushFeatureBranch(root, upstream, 'mallory/escalate', async (dir) => {
+      await fs.writeFile(path.join(dir, 'reviewed.md'), 'reviewed content\n');
+    });
+    const authorised = await remoteTip(upstream, 'mallory/escalate');
+
+    // A second commit lands on the same branch after the gate ran.
+    const racer = path.join(root, 'racer');
+    await runGit(root, ['clone', '-b', 'mallory/escalate', upstream, racer]);
+    await fs.writeFile(path.join(racer, 'sneaked.md'), 'never reviewed\n');
+    await runGit(racer, ['add', '-A']);
+    await runGit(racer, ['commit', '-m', 'sneaked in after the gate']);
+    await runGit(racer, ['push', 'origin', 'mallory/escalate']);
+    expect(await remoteTip(upstream, 'mallory/escalate')).not.toBe(authorised);
+
+    const git = new GitService(stubWorkspaceService(baseWsId, baseRepo), new WorkflowHooks(), 'knowledge-base');
+    const result = await git.mergeChangeRequest(
+      baseWsId, 'mallory/escalate', authorised, BASE,
+      { subject: 'Apply (#1)', body: 'body' }, USER,
+    );
+    expect(result.kind).toBe('merged');
+
+    const verify = path.join(root, 'verify');
+    await runGit(root, ['clone', '-b', BASE, upstream, verify]);
+    const landed = await fs.readdir(verify);
+    expect(landed).toContain('reviewed.md');
+    expect(landed).not.toContain('sneaked.md');
+  });
+
+  it('REFUSES to merge a head that is no longer on its branch (force-push)', async () => {
+    // Pinning to a SHA on its own would happily merge a commit the author has
+    // since force-pushed away, resurrecting withdrawn content. The ancestor
+    // check makes that a hard failure instead.
+    const { upstream, baseWsId, baseRepo } = await seed(root, { 'base.md': 'base\n' });
+    await pushFeatureBranch(root, upstream, 'alice/withdrawn', async (dir) => {
+      await fs.writeFile(path.join(dir, 'withdrawn.md'), 'oops, secrets\n');
+    });
+    const withdrawn = await remoteTip(upstream, 'alice/withdrawn');
+
+    // The author rewrites the branch to drop that commit entirely.
+    const rewriter = path.join(root, 'rewriter');
+    await runGit(root, ['clone', '-b', 'alice/withdrawn', upstream, rewriter]);
+    await runGit(rewriter, ['reset', '--hard', 'HEAD~1']);
+    await fs.writeFile(path.join(rewriter, 'clean.md'), 'clean replacement\n');
+    await runGit(rewriter, ['add', '-A']);
+    await runGit(rewriter, ['commit', '-m', 'clean replacement']);
+    await runGit(rewriter, ['push', '--force', 'origin', 'alice/withdrawn']);
+
+    const git = new GitService(stubWorkspaceService(baseWsId, baseRepo), new WorkflowHooks(), 'knowledge-base');
+    await expect(
+      git.mergeChangeRequest(
+        baseWsId, 'alice/withdrawn', withdrawn, BASE,
+        { subject: 'Apply (#2)', body: 'body' }, USER,
+      ),
+    ).rejects.toThrow(/no longer on "alice\/withdrawn"/);
+
+    // Nothing landed, and the workspace is clean.
+    const verify = path.join(root, 'verify2');
+    await runGit(root, ['clone', '-b', BASE, upstream, verify]);
+    expect(await fs.readdir(verify)).not.toContain('withdrawn.md');
+    expect((await gitOut(baseRepo, ['status', '--porcelain=v1'])).trim()).toBe('');
   });
 });

--- a/packages/core-backend/src/modules/workflow/git/__tests__/git.service.postMergePull.test.ts
+++ b/packages/core-backend/src/modules/workflow/git/__tests__/git.service.postMergePull.test.ts
@@ -28,6 +28,14 @@ const SOURCE = 'alice/add-feature';
 const KB_DIR = 'knowledge-base';
 const USER: AuthUser = { id: 'u1', email: 'alice@example.com', name: 'Alice' };
 
+/**
+ * The published tip of `branch` on the bare upstream — what the review gate
+ * would have resolved as `headSha` and what the merge is now pinned to.
+ */
+async function remoteTip(upstream: string, branch: string): Promise<string> {
+  return (await gitOut(upstream, ['rev-parse', `refs/heads/${branch}`])).trim();
+}
+
 /** Clone `branch` into `<root>/<wsId>/knowledge-base`, like prod's layout. */
 async function cloneWorkspace(root: string, upstream: string, branch: string): Promise<string> {
   const wsDir = path.join(root, encodeURIComponent(branch));
@@ -81,7 +89,7 @@ describe('post-merge refresh of the target branch workspace', () => {
   });
 
   it('pulls the target workspace up to origin after a merge, even with a drifted clone config', async () => {
-    const { sourceRepo, baseRepo } = await seed(root);
+    const { upstream, sourceRepo, baseRepo } = await seed(root);
 
     // The target branch's workspace has drifted into the state that strands the
     // refresh: the branch tracks two merge refs and origin is fetched through
@@ -114,7 +122,8 @@ describe('post-merge refresh of the target branch workspace', () => {
 
     // 1. The merge lands on origin/BASE (run from the caller's workspace).
     const merged = await git.mergeChangeRequest(
-      sourceWsId, SOURCE, BASE, { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
+      sourceWsId, SOURCE, await remoteTip(upstream, SOURCE), BASE,
+      { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
     );
     expect(merged.kind).toBe('merged');
 
@@ -156,7 +165,7 @@ describe('post-merge refresh of the target branch workspace', () => {
   // `git pull --rebase --autostash origin <base>` this dies with the reported
   // fatal; the refresh now touches no shared state, so it cannot.
   it('refreshes the target workspace while a concurrent fetch rewrites FETCH_HEAD', async () => {
-    const { sourceRepo, baseRepo } = await seed(root);
+    const { upstream, sourceRepo, baseRepo } = await seed(root);
     const git = new GitService(
       stubWorkspaceService({
         [sourceWsId]: path.dirname(sourceRepo),
@@ -167,7 +176,8 @@ describe('post-merge refresh of the target branch workspace', () => {
     );
 
     const merged = await git.mergeChangeRequest(
-      sourceWsId, SOURCE, BASE, { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
+      sourceWsId, SOURCE, await remoteTip(upstream, SOURCE), BASE,
+      { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
     );
     expect(merged.kind).toBe('merged');
 
@@ -257,8 +267,12 @@ describe('post-merge refresh of the target branch workspace', () => {
       KB_DIR,
     );
 
+    // Pinned to that latest revision — the SHA the gate would have resolved.
+    // The drifted refspec must not stop the fetch from bringing its objects, and
+    // the ancestor check must find it on the branch.
     const merged = await git.mergeChangeRequest(
-      sourceWsId, SOURCE, BASE, { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
+      sourceWsId, SOURCE, latestSource, BASE,
+      { subject: 'Add feature (#1)', body: 'Merged via Bevel' }, USER,
     );
     expect(merged.kind).toBe('merged');
 

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -1313,8 +1313,17 @@ export class GitService implements IGitService {
   /**
    * Merge a change request locally and publish it to the target branch — the
    * provider-agnostic replacement for `gh pr merge`. Runs in the *base* branch's
-   * workspace: reset to the published base tip, merge the source's published
-   * tip as a `--no-ff` commit authored by the human triggerer, and push.
+   * workspace: reset to the published base tip, merge `sourceSha` as a `--no-ff`
+   * commit authored by the human triggerer, and push.
+   *
+   * `sourceSha` — NOT `origin/<sourceBranch>` — is what gets merged, and the
+   * distinction is a security boundary rather than a detail. The review gate
+   * resolves a head SHA, approvals are pinned to it, and `prMergeLog` records it
+   * as `headShaAtMerge`; but this method fetches again, and merging the branch
+   * ref would land whatever arrived in between. That is not theoretical — a
+   * commit pushed after the gate ran was observed reaching the protected branch.
+   * The SHA is additionally required to still be an ancestor of the fetched
+   * branch tip, so a force-push cannot make this resurrect withdrawn content.
    *
    * Serialized per base workspace via the mutex, with a bounded retry: if the
    * push is rejected because the base advanced (a concurrent merge), we reset to
@@ -1326,12 +1335,19 @@ export class GitService implements IGitService {
   async mergeChangeRequest(
     baseWorkspaceId: string,
     sourceBranch: string,
+    sourceSha: string,
     targetBranch: string,
     commit: { subject: string; body: string },
     user: AuthUser,
   ): Promise<{ kind: 'merged'; sha: string } | { kind: 'conflicts'; paths: string[] }> {
     assertValidBranchName(sourceBranch);
     assertValidBranchName(targetBranch);
+    // Both `sourceBranch` and `sourceSha` are strings and adjacent in the
+    // parameter list; the shape check here is what makes a swapped call fail
+    // loudly instead of merging something surprising.
+    if (!/^[0-9a-f]{40,64}$/.test(sourceSha)) {
+      throw new WorkflowValidationError(`invalid source commit sha: ${sourceSha}`);
+    }
     assertValidAuthor(user);
     const MAX_ATTEMPTS = 3;
     return this.mutex.run(baseWorkspaceId, async () => {
@@ -1369,10 +1385,43 @@ export class GitService implements IGitService {
         await this.git(cwd, ['checkout', targetBranch]);
         await this.git(cwd, ['reset', '--hard', `origin/${targetBranch}`]);
 
-        // `--no-commit --no-ff` so we author the merge commit as the human and
-        // never fast-forward past the merge record.
+        // The pinned head must still be ON its branch. Merging `sourceSha` is
+        // what stops a commit pushed after the review gate from riding in — but
+        // on its own it would also happily merge a commit that has since been
+        // force-pushed AWAY, resurrecting content the author withdrew.
+        //
+        // Any non-zero exit refuses, and deliberately so. `--is-ancestor` exits
+        // 1 for "no" when both objects resolve, but a commit that was rewritten
+        // away is typically not in this clone's object store at all (the fetch
+        // above force-updates the remote-tracking ref; a base workspace may
+        // never have seen the old tip), which exits 128 instead. Both mean the
+        // same thing here — we cannot show this commit is published on that
+        // branch — and this is a fail-closed guard, so "cannot prove" must
+        // refuse. The git detail rides along so a genuine infra failure is still
+        // diagnosable rather than silently reported as a force-push.
         try {
-          await this.git(cwd, ['merge', '--no-commit', '--no-ff', `origin/${sourceBranch}`]);
+          await this.git(cwd, [
+            'merge-base', '--is-ancestor', sourceSha, `origin/${sourceBranch}`,
+          ]);
+        } catch (err) {
+          throw new Error(
+            `change request head ${sourceSha.slice(0, 8)} is no longer on "${sourceBranch}" ` +
+              '(force-pushed, rewritten, or unreachable); refusing to merge a commit ' +
+              `that is not published on its branch: ${redact(
+                err instanceof Error ? err.message : String(err),
+              )}`,
+          );
+        }
+
+        // `--no-commit --no-ff` so we author the merge commit as the human and
+        // never fast-forward past the merge record. Merging the pinned SHA, not
+        // `origin/<source>`: the branch ref can advance between the review gate
+        // resolving `headSha` and this fetch, and merging the ref would land
+        // commits nobody approved (verified: a commit pushed after the gate
+        // reached the protected branch). Pinning also makes the retry loop
+        // below deterministic — only the base moves between attempts.
+        try {
+          await this.git(cwd, ['merge', '--no-commit', '--no-ff', sourceSha]);
         } catch (err) {
           const paths = await this.conflictedPaths(cwd);
           await this.git(cwd, ['merge', '--abort']).catch(() => undefined);

--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -1469,6 +1469,73 @@ export class GitService implements IGitService {
   }
 
   /**
+   * Refresh `refs/remotes/origin/<branch>` for named branches only, and FAIL
+   * when the refresh doesn't land.
+   *
+   * The narrow counterpart to `fetch`. Explicit destination refspecs, so the
+   * refs the caller is about to read move regardless of any
+   * `remote.origin.fetch` drift (same reasoning as `mergeChangeRequest`), and
+   * nothing else moves. `--no-write-fetch-head` keeps it out of the clone's
+   * shared `FETCH_HEAD` (see `pull`).
+   *
+   * The distinction from `fetchPrRefs` is the error handling, and it is the
+   * whole point of this method existing. `fetchPrRefs` is best-effort: it backs
+   * the change-request DETAIL reads, where a stale ref costs a slightly-off
+   * diff. This one PROPAGATES. It exists for `preserveBaseRolesYaml`, which
+   * compares base-vs-head `roles.yaml` to decide whether a change request is
+   * smuggling a privilege escalation across a merge — answering that from a
+   * silently stale `origin/<head>` would fail OPEN. A caller that must fail
+   * closed needs the throw.
+   *
+   * Runs OUTSIDE the workspace mutex: a network round-trip must not hold a lock
+   * that local operations queue behind, and this only advances remote-tracking
+   * refs, which nothing reads mid-flight.
+   */
+  /**
+   * True when this workspace's HEAD already IS `origin/<branch>` — checked
+   * entirely from local refs, with no network.
+   *
+   * The point is to let a caller skip a refresh it does not need.
+   * `WorkflowService.mergeChangeRequest` pulls the target workspace after a
+   * merge so the working tree the file tools serve isn't behind origin — but
+   * the merge it just ran happened IN that same workspace (`git
+   * mergeChangeRequest` checks out the target, resets to it, commits and
+   * pushes), so the tree is current and the pull's fetch is a ~0.65s HTTPS
+   * round-trip to learn nothing.
+   *
+   * Answers FALSE on any failure — an unresolvable ref, a detached HEAD, a
+   * missing remote-tracking ref. "I could not prove it is current" must send
+   * the caller down the refresh path, never skip it: this gates a freshness
+   * guarantee, so the safe default is to do the work.
+   */
+  async matchesRemoteRef(workspaceId: string, branch: string): Promise<boolean> {
+    assertValidBranchName(branch);
+    try {
+      const cwd = await this.repoDir(workspaceId);
+      const [{ stdout: head }, { stdout: remote }] = await Promise.all([
+        this.git(cwd, ['rev-parse', 'HEAD']),
+        this.git(cwd, ['rev-parse', `refs/remotes/origin/${branch}`]),
+      ]);
+      const h = head.trim();
+      return h.length > 0 && h === remote.trim();
+    } catch {
+      return false;
+    }
+  }
+
+  async fetchBranchRefs(workspaceId: string, branches: string[]): Promise<void> {
+    if (branches.length === 0) return;
+    for (const branch of branches) assertValidBranchName(branch);
+    const cwd = await this.repoDir(workspaceId);
+    await this.git(cwd, [
+      'fetch',
+      '--no-write-fetch-head',
+      'origin',
+      ...branches.map((b) => `+refs/heads/${b}:refs/remotes/origin/${b}`),
+    ]);
+  }
+
+  /**
    * Collapse the clone's drifted tracking config back to one fetch refspec and
    * one upstream ref, then refresh `refs/remotes/origin/<branch>` through an
    * explicit refspec — never touching the shared `FETCH_HEAD`. Returns the ref

--- a/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
@@ -647,6 +647,11 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
       mergeResult = await this.git.mergeChangeRequest(
         baseWorkspace.id,
         cr.sourceBranch,
+        // The gate above authorised THIS commit, and it is what `prMergeLog`
+        // records as `headShaAtMerge`. Passing it through pins the merge to it,
+        // so the commit that lands is the commit that was approved — the branch
+        // ref can advance between the detail resolve and the merge's own fetch.
+        headSha,
         cr.targetBranch,
         { subject, body },
         user,

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -901,6 +901,12 @@ export function createWorkflowRoutes(
           fresh: true,
           workspaceId: workspace.id,
           viewerEmail: user.email,
+          // Internal read, same as the reject route above: the merge pins its
+          // work on headSha/approvals/state/title/base and never reads
+          // `files[].patch`. Generating them is one git subprocess per changed
+          // file — up to 400, sequentially — on the critical path of every
+          // merge, and the patch-less result stays out of the client cache.
+          patches: false,
         });
         if (!detail) {
           events.emit({

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -1969,7 +1969,9 @@ export class WorkflowService implements IWorkflowService {
     // Roles & Members surface (itself admin-gated). The rest of the CR merges
     // normally. Best-effort by design is NOT acceptable here — a failure to
     // neutralise must abort the merge, never fall through.
-    const preserved = await this.preserveBaseRolesYaml(number, user, baseBranch);
+    const preserved = await this.preserveBaseRolesYaml(
+      number, user, baseBranch, workspaceId, headSha,
+    );
 
     // When preservation pushed a restore commit, the source-branch head advanced,
     // so the caller's `headSha`/`approvals` (resolved against the pre-preservation
@@ -1985,6 +1987,10 @@ export class WorkflowService implements IWorkflowService {
         fresh: true,
         workspaceId,
         viewerEmail: user.email,
+        // Only `headSha`/`approvals` are read off this re-resolve, so skip the
+        // per-file patch generation — otherwise a preservation commit makes
+        // every merge pay for the whole patch set a SECOND time.
+        patches: false,
       });
       if (!fresh) {
         throw new RolesYamlPreservationError(
@@ -2022,11 +2028,24 @@ export class WorkflowService implements IWorkflowService {
     // this a read right after a merge misses the just-merged change. Best-effort:
     // the merge already succeeded on origin, so a pull hiccup must not fail the
     // response (a later fetch/pull reconciles).
+    //
+    // Usually there is nothing to pull. `git.mergeChangeRequest` runs in THIS
+    // workspace — `getOrCreateForBranch(cr.targetBranch)` there and
+    // `getOrCreateForBranch(baseBranch)` here resolve to the same clone, since
+    // `preserveBaseRolesYaml` already cross-checked `summary.base === baseBranch`
+    // — and it leaves the target checked out at the merge commit it just pushed.
+    // So the tree is already current and `pull` would spend an HTTPS round-trip
+    // (~0.65s on the critical path of every merge) learning that. `matchesRemoteRef`
+    // settles it from local refs in ~12ms and answers false whenever it cannot
+    // prove currency, so the pull — and with it the stranded-workspace recovery
+    // ladder below — still runs in every case that actually needs it.
     let targetWorkspaceId: string | undefined;
     try {
       const targetWorkspace = await this.workspaceService.getOrCreateForBranch(baseBranch);
       targetWorkspaceId = targetWorkspace.id;
-      await this.git.pull(targetWorkspace.id);
+      if (!(await this.git.matchesRemoteRef(targetWorkspace.id, baseBranch))) {
+        await this.git.pull(targetWorkspace.id);
+      }
     } catch (err) {
       // Still best-effort for the merge response (the merge already landed
       // on origin) — but a rebase CONFLICT here means the target workspace
@@ -2129,10 +2148,14 @@ export class WorkflowService implements IWorkflowService {
     number: number,
     user: AuthUser,
     baseBranch: string,
+    workspaceId: string,
+    headSha: string,
   ): Promise<boolean> {
     const ROLES_YAML = 'roles.yaml';
     let headBranch: string;
     try {
+      if (!workspaceId) throw new Error('workspace id is required');
+      if (!headSha) throw new Error('head sha is required');
       const summary = await this.prs.getPr(number);
       if (!summary) throw new Error(`change request #${number} not found`);
       // Use the PR's own authoritative base rather than trusting the caller's
@@ -2147,21 +2170,51 @@ export class WorkflowService implements IWorkflowService {
       // Guard against a degenerate self-targeting CR (head === base) just in case.
       if (!headBranch || headBranch === summary.base) return false;
 
-      // Work in the SOURCE branch's own per-branch workspace (already checked out
-      // on that branch). Fetch so we read the CR's TRUE published roles.yaml from
-      // the origin refs below (the comparison never touches the working tree) and
-      // so a restoring commit fast-forwards on push. We deliberately DON'T
+      // ANSWER THE QUESTION IN THE CALLER'S WORKSPACE, NOT THE SOURCE BRANCH'S.
+      //
+      // The comparison only needs to read two origin refs, and any clone of this
+      // repo can serve them. The caller's workspace is already bootstrapped (the
+      // merge route / agent tool resolves it before calling), whereas
+      // `getOrCreateForBranch(headBranch)` CLONES when that branch has never been
+      // opened on this instance — checkout plus `--dissociate` — on the critical
+      // path of every merge, to answer "no" almost every time. The source branch's
+      // workspace is now touched only when a restore actually has to be written,
+      // below.
+      //
+      // NO FETCH HERE, and the head side is read at a COMMIT, not a branch ref.
+      //
+      // `headSha` is what the caller resolved through `resolvePrShas`, which
+      // fetched both refs into THIS workspace moments ago, and it is the same
+      // commit the merge gate authorised against (`headShaAtMerge`). Reading the
+      // head's roles.yaml at that exact commit is therefore both fresher than a
+      // re-fetch would make it and strictly more precise than `origin/<head>`:
+      // the ref could have moved since the gate ran, which would have us clear a
+      // commit the merge was never authorised for. Re-fetching here bought a
+      // second round-trip for the same two refs and did not close that gap.
+      //
+      // The base side stays on `origin/<base>`, refreshed by the same
+      // `resolvePrShas` fetch. A stale base cannot fail OPEN: it can only make
+      // base and head look DIFFERENT and trigger a restore that was not needed
+      // (fail-closed, and the merge still lands correctly), never make a real
+      // roles.yaml change look identical.
+      const baseRoles = await this.git.readFileAtRef(
+        workspaceId, `origin/${summary.base}`, ROLES_YAML,
+      );
+      const headRoles = await this.git.readFileAtRef(workspaceId, headSha, ROLES_YAML);
+
+      // Identical (incl. both-absent) → the CR doesn't change roles.yaml. Done,
+      // and the source workspace was never touched.
+      if (baseRoles === headRoles) return false;
+
+      // A restore IS needed, so from here we do need the source branch's own
+      // per-branch workspace (already checked out on that branch) — paying the
+      // bootstrap in the rare case rather than the common one. Fetch so a
+      // restoring commit fast-forwards on push. We deliberately DON'T
       // `resetToRemote` here: that workspace is shared per-branch and can carry
       // disk-first edits whose commits are still queued (see PendingCommitsService),
       // and a hard reset would silently discard them.
       const ws = await this.workspaceService.getOrCreateForBranch(headBranch);
-      await this.git.fetch(ws.id);
-
-      const baseRoles = await this.git.readFileAtRef(ws.id, `origin/${summary.base}`, ROLES_YAML);
-      const headRoles = await this.git.readFileAtRef(ws.id, `origin/${headBranch}`, ROLES_YAML);
-
-      // Identical (incl. both-absent) → the CR doesn't change roles.yaml. Done.
-      if (baseRoles === headRoles) return false;
+      await this.git.fetchBranchRefs(ws.id, [headBranch]);
 
       // The restore below writes roles.yaml directly to the shared per-branch
       // working tree. `LockingFilesystem` serializes every OTHER roles.yaml edit


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up change-request merges and closes a race where commits pushed after the review gate could ride into the merge.

- Merges now pin to the exact head SHA the gate authorised; a branch that advances after the gate merges only the approved commit, and a force-pushed-away head refuses fail-closed.
- The roles.yaml preservation guard now runs in the caller's workspace, reading the head roles at the exact SHA the merge gate authorized, instead of cloning the source branch and reading `origin/<head>`.
- The post-merge target-workspace pull is skipped when local refs already match the remote, saving a ~0.65s HTTPS round-trip on every merge.
- Internal change-request reads for the merge path skip diff/patch generation, saving one git subprocess per changed file.
- The restore path's narrow branch-ref fetch now propagates errors and aborts the merge on failure, instead of silently proceeding with stale refs.

<sup>Written for commit 5de93b0667d7d7c2e85596adc9d66c365bb4996b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

