### PR TITLE
A file's own access verbs are read even when its YAML is more than the subset parser knows

### DIFF
--- a/.changeset/own-access-entries-full-yaml.md
+++ b/.changeset/own-access-entries-full-yaml.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-backend': patch
+---
+
+A whole-document configuration file's own `owner:` / `read:` / `write:` are now read even when the document uses YAML the access grammar's subset parser does not (folded `>-` descriptions, literal `|` blocks, nested maps). Before, such a file's verbs were silently dropped: a reviewed, merged `.tool` grant did not exist, and the file was unreadable by the very principal it named. The subset parser still answers first; the full parser is consulted only when it cannot, and only the top-level verb keys are used.

--- a/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
+++ b/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
@@ -129,3 +129,52 @@ describe('the access-frontmatter extension set', () => {
     expect(entries!.write).toEqual([]);
   });
 });
+
+describe('parseOwnAccessEntries — whole-document YAML the subset parser cannot read', () => {
+  // A `.tool` / `.pipeline` / `.agent` is one `---` fenced YAML document, and
+  // real ones use folded and literal scalars and nested maps. The subset
+  // parser stops at the first such line; the verbs must still be read.
+  const doc = [
+    '---',
+    'apiVersion: bevel.software/v1',
+    'kind: Agent',
+    'id: delivery_coder',
+    'description: >-',
+    '  Writes and verifies the code for one delivery ticket. Runs the agent steps',
+    '  of a coding pipeline.',
+    'systemPrompt:',
+    '  extend: |',
+    '    You are executing exactly ONE step of a pipeline.',
+    '    When your verdict is recorded, stop.',
+    'env:',
+    '  - { name: STAGING_URL, from: params, param: stagingUrl }',
+    'owner: razvan.radulescu <razvan@bevel.software>',
+    'read: coding-agent <coding-agent@bevel.software>',
+    'write: Developer',
+    '---',
+    '',
+    '# notes after the fence',
+    '',
+  ].join('\n');
+
+  it('reads the verbs out of a document with folded and literal scalars', () => {
+    const own = parseOwnAccessEntries(doc);
+    expect(own).not.toBeNull();
+    expect(own!.owner).toMatchObject([{ kind: 'user', email: 'razvan@bevel.software', deny: false }]);
+    expect(own!.read).toMatchObject([{ kind: 'user', email: 'coding-agent@bevel.software', deny: false }]);
+    expect(own!.write).toMatchObject([{ kind: 'role', role: 'developer', deny: false }]);
+  });
+
+  it('still answers null for a document that declares no verb, and for broken YAML', () => {
+    expect(parseOwnAccessEntries('---\ndescription: >-\n  folded\n  text\n---\n')).toBeNull();
+    // Broken for BOTH parsers: the folded scalar stops the subset one, the
+    // unclosed flow sequence the full one.
+    expect(parseOwnAccessEntries('---\ndescription: >-\n  folded\nread: [unclosed\n---\n')).toBeNull();
+  });
+
+  it('does not change what the subset parser already read', () => {
+    // A node's frontmatter: the historical path, byte for byte.
+    const node = '---\nnodeType: "[Project](../NodeTypes/Project.md)"\nid: project-x\nowner: Someone <s@x.io>\n---\n# Name\n';
+    expect(parseOwnAccessEntries(node)!.owner).toMatchObject([{ kind: 'user', email: 's@x.io' }]);
+  });
+});

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -801,16 +801,6 @@ export function parseAccessFile(
  */
 export type OwnEntries = Record<Verb, ParsedEntry[]>;
 /**
- * Parse the access verbs a node file declares in its own YAML frontmatter.
- * Returns the per-verb entry lists, or null when the file has no frontmatter
- * or declares no access verb at all.
- *
- * Forgiving by design — a node's frontmatter legitimately carries non-access
- * keys (notably `nodeType:`), so unknown keys are ignored, and a malformed
- * entry is dropped rather than failing the file. A typo in a node's `owner:`
- * must never make the node unreadable; it just doesn't grant anything.
- */
-/**
  * The top-level mapping of a file's own frontmatter, for the verb keys.
  *
  * The subset parser is tried first: it is what every `access.md` and node
@@ -835,6 +825,16 @@ function ownEntriesRoot(frontmatter: string): unknown {
   }
 }
 
+/**
+ * Parse the access verbs a node file declares in its own YAML frontmatter.
+ * Returns the per-verb entry lists, or null when the file has no frontmatter
+ * or declares no access verb at all.
+ *
+ * Forgiving by design — a node's frontmatter legitimately carries non-access
+ * keys (notably `nodeType:`), so unknown keys are ignored, and a malformed
+ * entry is dropped rather than failing the file. A typo in a node's `owner:`
+ * must never make the node unreadable; it just doesn't grant anything.
+ */
 export function parseOwnAccessEntries(text: string): OwnEntries | null {
   const fm = extractFrontmatter(text);
   if (!fm.ok) return null;

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -11,6 +11,7 @@
  * `./group-files.js` import below is access-model's own file, not a breach.)
  */
 
+import { parse as parseFullYaml } from 'yaml';
 import type { GroupsIndex } from './group-files.js';
 
 // ---------------------------------------------------------------------------
@@ -809,12 +810,35 @@ export type OwnEntries = Record<Verb, ParsedEntry[]>;
  * entry is dropped rather than failing the file. A typo in a node's `owner:`
  * must never make the node unreadable; it just doesn't grant anything.
  */
+/**
+ * The top-level mapping of a file's own frontmatter, for the verb keys.
+ *
+ * The subset parser is tried first: it is what every `access.md` and node
+ * frontmatter has always been read with, and its answer must not change. But
+ * a whole-document configuration file (`.tool`, and whatever an overlay
+ * registers) is real YAML — folded descriptions (`>-`), literal blocks (`|`),
+ * nested maps — and the subset parser stops at the first line it does not
+ * understand. Before this fallback that meant the file's `owner:` / `read:` /
+ * `write:` were silently dropped: a grant that was reviewed and merged did
+ * not exist, and the file was unreadable by the very principal it named.
+ * So on a subset failure the frontmatter is read by the full parser and only
+ * its top-level mapping is used — the verb keys are looked up exactly as
+ * before, everything else is ignored exactly as before.
+ */
+function ownEntriesRoot(frontmatter: string): unknown {
+  const subset = parseYamlSubset(frontmatter);
+  if (subset.ok) return subset.value;
+  try {
+    return parseFullYaml(frontmatter);
+  } catch {
+    return null;
+  }
+}
+
 export function parseOwnAccessEntries(text: string): OwnEntries | null {
   const fm = extractFrontmatter(text);
   if (!fm.ok) return null;
-  const parsed = parseYamlSubset(fm.frontmatter);
-  if (!parsed.ok) return null;
-  const root = parsed.value;
+  const root = ownEntriesRoot(fm.frontmatter);
   if (root == null || typeof root !== 'object' || Array.isArray(root)) return null;
 
   const entries = emptyEntries();

--- a/packages/core-backend/src/modules/access/__tests__/access-own-read-grant.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-own-read-grant.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../access-control.service.js';
+import { registerAccessFrontmatterExtensions } from '../../access-model/access-grammar.js';
+
+const KB = 'knowledge-base';
+
+const ROLES_YAML = `roles:
+  Admin:
+    - razvan@bevel.software
+  Developer:
+    - coding-agent@bevel.software
+  Agent:
+    - coding-agent@bevel.software
+`;
+
+// Shaped like the real files: folded descriptions, literal blocks, nested
+// maps, comments — everything the access grammar's subset parser stops at.
+const PIPELINE = `---
+apiVersion: bevel.software/v1
+kind: Pipeline
+id: coding-delivery-process
+name: Coding Delivery
+description: >-
+  End-to-end delivery of one coding ticket: workspace preparation, coding, local
+  testing, a two-check review gate, staged rollout, and production verification.
+# Which tickets this runner works.
+queue:
+  trigger: dataStatus
+  projects:
+    - KnowledgeBase/Engineering/Knowledge/Bevel-Platform.md
+do:
+  - name: Coding
+    kind: agent
+    instructions: |
+      Implement the ticket in the workspace.
+      Commit locally; never push.
+owner: razvan.radulescu <razvan@bevel.software>
+read: coding-agent <coding-agent@bevel.software>
+write: Developer
+---
+`;
+
+const AGENT = `---
+apiVersion: bevel.software/v1
+kind: Agent
+id: delivery_coder
+name: delivery-coder
+description: >-
+  Writes and verifies the code for one delivery ticket.
+systemPrompt:
+  extend: |
+    You are executing exactly ONE step of a pipeline.
+env:
+  - { name: STAGING_URL, from: params, param: stagingUrl }
+owner: razvan.radulescu <razvan@bevel.software>
+read: coding-agent <coding-agent@bevel.software>
+write: Developer
+---
+
+# delivery-coder
+`;
+
+describe('a file-own read grant on a whole-document configuration file', () => {
+  let root: string;
+  let repo: string;
+  const ws = 'ws-1';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'own-read-'));
+    repo = path.join(root, ws, KB);
+    await fs.mkdir(path.join(repo, 'Pipelines'), { recursive: true });
+    await fs.mkdir(path.join(repo, 'Agents'), { recursive: true });
+    await fs.writeFile(path.join(repo, 'roles.yaml'), ROLES_YAML);
+    await fs.writeFile(path.join(repo, 'access.md'), '---\nwrite:\n  - Admin\ndownload:\n  - Admin\nowner: []\n---\n');
+    await fs.writeFile(path.join(repo, 'Pipelines', 'access.md'), '---\nwrite: []\n---\n');
+    await fs.writeFile(path.join(repo, 'Pipelines', 'Coding-Delivery.pipeline'), PIPELINE);
+    await fs.writeFile(path.join(repo, 'Agents', 'access.md'), '---\nwrite: []\n---\n');
+    await fs.writeFile(path.join(repo, 'Agents', 'delivery-coder.agent'), AGENT);
+  });
+  afterEach(() => fs.rm(root, { recursive: true, force: true }));
+
+  const svc = () =>
+    new AccessControlService(
+      { getWorkspacePath: async () => path.join(root, ws) } as unknown as WorkspaceService,
+      KB,
+    );
+
+  it('the grantee reads the file (registered kinds)', async () => {
+    registerAccessFrontmatterExtensions(['.pipeline', '.agent']);
+    const s = svc();
+    expect(await s.canRead(ws, 'coding-agent@bevel.software', 'Pipelines/Coding-Delivery.pipeline')).toBe(true);
+    expect(await s.canRead(ws, 'coding-agent@bevel.software', 'Agents/delivery-coder.agent')).toBe(true);
+    expect(await s.canWrite(ws, 'coding-agent@bevel.software', 'Pipelines/Coding-Delivery.pipeline')).toBe(true);
+    // Batch path, which the explorer and the tool catalog use.
+    const batch = await s.canReadBatch(ws, 'coding-agent@bevel.software', [
+      'Pipelines/Coding-Delivery.pipeline',
+      'Agents/delivery-coder.agent',
+      'Pipelines/README.md',
+    ]);
+    expect([...batch.entries()]).toEqual([
+      ['Pipelines/Coding-Delivery.pipeline', true],
+      ['Agents/delivery-coder.agent', true],
+      ['Pipelines/README.md', false],
+    ]);
+  });
+
+  it('a stranger does not', async () => {
+    registerAccessFrontmatterExtensions(['.pipeline', '.agent']);
+    expect(await svc().canRead(ws, 'someone@else.io', 'Pipelines/Coding-Delivery.pipeline')).toBe(false);
+  });
+});


### PR DESCRIPTION
`parseOwnAccessEntries` reads a file's own `owner:` / `read:` / `write:` with the access grammar's **subset** YAML parser. A whole-document configuration file — a `.tool`, or a kind an overlay registers — is real YAML: folded `>-` descriptions, literal `|` blocks, nested maps. The subset parser stops at the first such line, and the function answered `null` for the whole file: the verbs were silently dropped, a reviewed and merged grant did not exist, and the file was unreadable by the very principal it named. Every real `.tool` in the knowledge base this was found on was affected; the trivial frontmatter in the tests was not.

**Fix:** the subset parser still answers first (an `access.md` or a node's frontmatter must resolve exactly as before). Only when it cannot, the frontmatter is read by the full `yaml` parser (already a dependency) and its top-level mapping is used — the verb keys are looked up as before, everything else ignored as before, and a document neither parser can read still yields `null`.

**Tests:** grammar-level (folded + literal scalars read; no-verb and doubly-broken documents still `null`; the subset path unchanged) and service-level (a `.pipeline`/`.agent`-shaped document with a file-own `read:` under an otherwise closed folder chain: the grantee reads, a stranger does not, `canReadBatch` agrees). Full access suites: 436 green.

Changeset: patch on `@bevel-software/platform-core-backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads a file's own `owner:` / `read:` / `write:` access verbs even when the file uses YAML the access grammar's subset parser cannot read. Before, a whole-document configuration file (a `.tool`, or a kind an overlay registers) with a folded `>-` description, a literal `|` block, or a nested map silently dropped its verbs — a reviewed and merged grant did not exist, and the file was unreadable by the very principal it named.

- The subset parser still answers first, so `access.md` and node frontmatter resolve exactly as before.
- Only on subset failure does the full `yaml` parser read the frontmatter, and only its top-level verb keys are used.
- A document neither parser can read still yields `null`.

<sup>Written for commit f3879aed16ba569a0592a8e3f5e091e9ec407a95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

