### PR TITLE
Flow and quoted verb values reach the full parser; a menu at the top edge keeps its margin

### DIFF
--- a/.changeset/own-entries-flow-and-menu-margin.md
+++ b/.changeset/own-entries-flow-and-menu-margin.md
@@ -1,0 +1,6 @@
+---
+'@bevel-software/platform-core-backend': patch
+'@bevel-software/platform-core-frontend': patch
+---
+
+A file's own access verbs written as a flow sequence (`read: [A, B]`) or a quoted scalar (`read: "A <a@x>"`) now resolve to the grants they spell; before, the brackets or quotes reached the entry parser as text and the entry was dropped — or a quoted role kept its quotes as part of its name. A right-click menu opened in the first pixels of the window keeps the same top margin every other placement does.

--- a/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
+++ b/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
@@ -202,6 +202,21 @@ describe('parseOwnAccessEntries — quoted and flow-sequence verb values', () =>
     ]);
   });
 
+  it('keeps the plain entries beside a quoted one exactly as the subset parser read them', () => {
+    // One quoted value sends the whole document to the full parser, which
+    // TYPES scalars: `true` and `42` would come back as a boolean and a number
+    // and never reach the entry grammar. They must resolve exactly as they do
+    // on the subset path — as the (odd, but legal) role names they spell.
+    const viaFull = parseOwnAccessEntries(
+      ['---', 'read: "coding-agent <coding-agent@bevel.software>"', 'write: true', 'owner:', '  - 42', '---', ''].join('\n'),
+    );
+    const viaSubset = parseOwnAccessEntries(['---', 'write: true', 'owner:', '  - 42', '---', ''].join('\n'));
+    expect(viaFull!.write).toEqual(viaSubset!.write);
+    expect(viaFull!.owner).toEqual(viaSubset!.owner);
+    expect(viaFull!.write).toMatchObject([{ kind: 'role', role: 'true' }]);
+    expect(viaFull!.owner).toMatchObject([{ kind: 'role', role: '42' }]);
+  });
+
   it('leaves the plain forms on the subset path', () => {
     // An empty flow collection and bare scalars are the subset parser\'s own
     // grammar; nothing about them asks for the full parser.

--- a/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
+++ b/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
@@ -178,3 +178,36 @@ describe('parseOwnAccessEntries — whole-document YAML the subset parser cannot
     expect(parseOwnAccessEntries(node)!.owner).toMatchObject([{ kind: 'user', email: 's@x.io' }]);
   });
 });
+
+describe('parseOwnAccessEntries — quoted and flow-sequence verb values', () => {
+  // The subset parser SUCCEEDS on these and hands the brackets or quotes to
+  // the entry parser as text, so before the fallback they were dropped — or a
+  // quoted role kept its quotes as part of its name. They are real YAML and
+  // must resolve to the grants they spell.
+  it('reads a flow sequence', () => {
+    const own = parseOwnAccessEntries('---\nread: [coding-agent <coding-agent@bevel.software>, Developer]\n---\n');
+    expect(own!.read).toMatchObject([
+      { kind: 'user', email: 'coding-agent@bevel.software' },
+      { kind: 'role', role: 'developer' },
+    ]);
+  });
+
+  it('reads quoted scalars, inline and in a block list', () => {
+    expect(parseOwnAccessEntries('---\nread: "coding-agent <coding-agent@bevel.software>"\n---\n')!.read).toMatchObject([
+      { kind: 'user', email: 'coding-agent@bevel.software' },
+    ]);
+    expect(parseOwnAccessEntries("---\nwrite: 'Developer'\n---\n")!.write).toMatchObject([{ kind: 'role', role: 'developer' }]);
+    expect(parseOwnAccessEntries('---\nowner:\n  - "Someone <s@x.io>"\n---\n')!.owner).toMatchObject([
+      { kind: 'user', email: 's@x.io' },
+    ]);
+  });
+
+  it('leaves the plain forms on the subset path', () => {
+    // An empty flow collection and bare scalars are the subset parser\'s own
+    // grammar; nothing about them asks for the full parser.
+    expect(parseOwnAccessEntries('---\nread: []\nwrite: Developer\n---\n')).toMatchObject({
+      read: [],
+      write: [{ kind: 'role', role: 'developer' }],
+    });
+  });
+});

--- a/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
+++ b/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
@@ -208,13 +208,14 @@ describe('parseOwnAccessEntries — quoted and flow-sequence verb values', () =>
     // and never reach the entry grammar. They must resolve exactly as they do
     // on the subset path — as the (odd, but legal) role names they spell.
     const viaFull = parseOwnAccessEntries(
-      ['---', 'read: "coding-agent <coding-agent@bevel.software>"', 'write: true', 'owner:', '  - 42', '---', ''].join('\n'),
+      ['---', 'read: "coding-agent <coding-agent@bevel.software>"', 'write: true', 'owner:', '  - 42', '  - 0x10', '  - 1e3', '---', ''].join('\n'),
     );
-    const viaSubset = parseOwnAccessEntries(['---', 'write: true', 'owner:', '  - 42', '---', ''].join('\n'));
+    const viaSubset = parseOwnAccessEntries(['---', 'write: true', 'owner:', '  - 42', '  - 0x10', '  - 1e3', '---', ''].join('\n'));
     expect(viaFull!.write).toEqual(viaSubset!.write);
     expect(viaFull!.owner).toEqual(viaSubset!.owner);
     expect(viaFull!.write).toMatchObject([{ kind: 'role', role: 'true' }]);
-    expect(viaFull!.owner).toMatchObject([{ kind: 'role', role: '42' }]);
+    // Source spelling, not the number it parses to: `0x10` stays `0x10`.
+    expect(viaFull!.owner.map((e) => (e as { role: string }).role)).toEqual(['42', '0x10', '1e3']);
   });
 
   it('leaves the plain forms on the subset path', () => {

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -819,38 +819,18 @@ function ownEntriesRoot(frontmatter: string): unknown {
   const subset = parseYamlSubset(frontmatter);
   if (subset.ok && !verbValuesNeedFullYaml(subset.value)) return subset.value;
   try {
-    const full = parseFullYaml(frontmatter);
+    // The FAILSAFE schema: every scalar stays the text it was written as —
+    // `true`, `42`, `0x10`, `2026-01-01` — which is all the subset parser has
+    // ever handed the entry grammar. The core schema would type them, and a
+    // role spelled `0x10` would come back as `16` the moment another verb on
+    // the same file used a quoted value.
+    const full = parseFullYaml(frontmatter, { schema: 'failsafe' });
     // A document the full parser rejects but the subset parser accepted keeps
     // the subset answer — whatever it read is what has always been read.
-    return full == null ? (subset.ok ? subset.value : null) : verbValuesAsText(full);
+    return full == null ? (subset.ok ? subset.value : null) : full;
   } catch {
     return subset.ok ? subset.value : null;
   }
-}
-
-/**
- * The full parser TYPES its scalars — `write: true` is a boolean, `- 42` a
- * number, `owner: 2026-01-01` a date — where the subset parser has only ever
- * handed the entry grammar text. A principal is text, so a verb value is put
- * back into the form every entry has always arrived in: scalars become their
- * source text, list items likewise, and a nested mapping (which the grammar
- * never accepted) is left for the entry parser to refuse as before.
- */
-function verbValuesAsText(root: unknown): unknown {
-  if (!root || typeof root !== 'object' || Array.isArray(root)) return root;
-  const asText = (v: unknown): unknown =>
-    typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint'
-      ? String(v)
-      : v instanceof Date
-        ? v.toISOString().slice(0, 10)
-        : v;
-  const out: Record<string, unknown> = { ...(root as Record<string, unknown>) };
-  for (const key of Object.keys(out)) {
-    if (!KNOWN_VERBS_SET.has(key)) continue;
-    const value = out[key];
-    out[key] = Array.isArray(value) ? value.map(asText) : asText(value);
-  }
-  return out;
 }
 
 /**

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -817,12 +817,36 @@ export type OwnEntries = Record<Verb, ParsedEntry[]>;
  */
 function ownEntriesRoot(frontmatter: string): unknown {
   const subset = parseYamlSubset(frontmatter);
-  if (subset.ok) return subset.value;
+  if (subset.ok && !verbValuesNeedFullYaml(subset.value)) return subset.value;
   try {
-    return parseFullYaml(frontmatter);
+    const full = parseFullYaml(frontmatter);
+    // A document the full parser rejects but the subset parser accepted keeps
+    // the subset answer — whatever it read is what has always been read.
+    return full ?? (subset.ok ? subset.value : null);
   } catch {
-    return null;
+    return subset.ok ? subset.value : null;
   }
+}
+
+/**
+ * Whether a verb's value, as the subset parser read it, is really YAML syntax
+ * the subset parser does not understand and passed through as text: a flow
+ * sequence (`read: [A, B]`) or a quoted scalar (`read: "A <a@x>"`, `- 'Role'`).
+ * The subset parser SUCCEEDS on these — it just hands the brackets and quotes
+ * to the entry parser, which then drops the entry, or worse, keeps the quotes
+ * as part of a role name. Such a value means the full parser has to read the
+ * document.
+ */
+function verbValuesNeedFullYaml(root: unknown): boolean {
+  if (!root || typeof root !== 'object' || Array.isArray(root)) return false;
+  const looksLikeSyntax = (v: unknown): boolean =>
+    typeof v === 'string' && /^\s*(\[\s*\S|\{\s*\S|"|')/.test(v);
+  for (const [key, value] of Object.entries(root as Record<string, unknown>)) {
+    if (!KNOWN_VERBS_SET.has(key)) continue;
+    if (looksLikeSyntax(value)) return true;
+    if (Array.isArray(value) && value.some(looksLikeSyntax)) return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -822,10 +822,35 @@ function ownEntriesRoot(frontmatter: string): unknown {
     const full = parseFullYaml(frontmatter);
     // A document the full parser rejects but the subset parser accepted keeps
     // the subset answer — whatever it read is what has always been read.
-    return full ?? (subset.ok ? subset.value : null);
+    return full == null ? (subset.ok ? subset.value : null) : verbValuesAsText(full);
   } catch {
     return subset.ok ? subset.value : null;
   }
+}
+
+/**
+ * The full parser TYPES its scalars — `write: true` is a boolean, `- 42` a
+ * number, `owner: 2026-01-01` a date — where the subset parser has only ever
+ * handed the entry grammar text. A principal is text, so a verb value is put
+ * back into the form every entry has always arrived in: scalars become their
+ * source text, list items likewise, and a nested mapping (which the grammar
+ * never accepted) is left for the entry parser to refuse as before.
+ */
+function verbValuesAsText(root: unknown): unknown {
+  if (!root || typeof root !== 'object' || Array.isArray(root)) return root;
+  const asText = (v: unknown): unknown =>
+    typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint'
+      ? String(v)
+      : v instanceof Date
+        ? v.toISOString().slice(0, 10)
+        : v;
+  const out: Record<string, unknown> = { ...(root as Record<string, unknown>) };
+  for (const key of Object.keys(out)) {
+    if (!KNOWN_VERBS_SET.has(key)) continue;
+    const value = out[key];
+    out[key] = Array.isArray(value) ? value.map(asText) : asText(value);
+  }
+  return out;
 }
 
 /**

--- a/packages/core-frontend/src/shared/components/__tests__/usePointerMenuPosition.test.tsx
+++ b/packages/core-frontend/src/shared/components/__tests__/usePointerMenuPosition.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { usePointerMenuPosition } from '../usePointerMenuPosition';
+
+/**
+ * The hook measures the panel and places it relative to the pointer, keeping
+ * an 8px margin from every window edge. jsdom lays nothing out, so the panel
+ * is a stub with a fixed size.
+ */
+function panel(w: number, h: number) {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'offsetWidth', { value: w });
+  Object.defineProperty(el, 'offsetHeight', { value: h });
+  return { current: el };
+}
+
+describe('usePointerMenuPosition', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: 1000, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 600, configurable: true });
+  });
+
+  it('opens at the pointer when the menu fits below it', () => {
+    const { result } = renderHook(() => usePointerMenuPosition(panel(200, 100), 300, 200));
+    expect(result.current).toEqual({ left: 300, top: 200 });
+  });
+
+  it('keeps the top margin when the pointer is in the first pixels of the window', () => {
+    // Fits below, so the downward branch places it — but never above the
+    // margin every other placement keeps from the window edge.
+    const { result } = renderHook(() => usePointerMenuPosition(panel(200, 100), 300, 2));
+    expect(result.current.top).toBe(8);
+  });
+
+  it('flips above the pointer when it does not fit below', () => {
+    const { result } = renderHook(() => usePointerMenuPosition(panel(200, 100), 300, 560));
+    expect(result.current.top).toBe(560 - 4 - 100);
+  });
+
+  it('pins to the bottom margin when it fits neither below nor above', () => {
+    const { result } = renderHook(() => usePointerMenuPosition(panel(200, 700), 300, 100));
+    expect(result.current.top).toBe(8);
+    expect(result.current.left).toBe(300);
+  });
+
+  it('keeps the right margin', () => {
+    const { result } = renderHook(() => usePointerMenuPosition(panel(200, 100), 950, 200));
+    expect(result.current.left).toBe(1000 - 200 - 8);
+  });
+});

--- a/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
+++ b/packages/core-frontend/src/shared/components/usePointerMenuPosition.ts
@@ -59,8 +59,13 @@ export function usePointerMenuPosition<T extends HTMLElement>(
       const h = el.offsetHeight;
       const left = Math.max(MENU_MARGIN, Math.min(x, window.innerWidth - w - MENU_MARGIN));
       let top: number;
-      if (y + h <= window.innerHeight - MENU_MARGIN) {
-        top = y;
+      // Downward from the pointer, but never above the top margin: a pointer
+      // in the first few pixels of the window would otherwise put the menu's
+      // edge flush against the chrome, the one placement every other branch
+      // here keeps a margin from.
+      const below = Math.max(MENU_MARGIN, y);
+      if (below + h <= window.innerHeight - MENU_MARGIN) {
+        top = below;
       } else if (y - MENU_GAP - h >= MENU_MARGIN) {
         top = y - MENU_GAP - h;
       } else {


### PR DESCRIPTION
Both findings cubic raised on the release PR (#114), fixed on `dev` so the release carries them.

**Access grammar (P2, on #113's fallback).** The subset parser *succeeds* on `read: [A, B]` and `read: "A <a@x>"` — it passes the brackets or quotes to the entry parser as text, which drops the entry, or worse keeps the quotes as part of a role name (`'Developer'` resolved to the role `'developer'`). So the fallback never fired for these. A verb value that looks like syntax the subset parser passed through (flow sequence/mapping, quoted scalar — inline or as a list item) now sends the document to the full parser; a document the full parser rejects keeps the subset answer. Tests: flow sequence, quoted inline and in a block list, and the plain forms staying on the subset path. Access suites: 439 green.

**Menu placement (P3).** The downward branch placed the menu at the pointer's own `y` even inside the top margin. Clamped to `MENU_MARGIN` and re-checked for fit at the clamped position; the other branches are unchanged. New hook test covers the four placements and the top-edge case.

Changeset: patch on core-backend and core-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two release findings: flow-sequence and quoted access verbs now resolve to the grants they spell, and a menu opened at the top edge keeps the same margin as every other placement.

**Bug Fixes**
- Verbs like `read: [A, B]` or `read: "A <a@x>"` previously passed their brackets or quotes to the entry parser as text, dropping the entry or keeping quotes in the role name; now they reach the full parser, and a document it rejects keeps the subset answer.
- The full parser now uses the failsafe schema, so scalars stay the text they were written as — `0x10` stays `0x10`, not `16` — and plain entries beside a quoted one keep resolving exactly as on the subset path.
- The downward menu placement clamps the pointer's y to the margin and re-checks fit there.
- Adds tests for quoted and flow values and the top-edge placement, and ships a patch changeset for `@bevel-software/platform-core-backend` and `@bevel-software/platform-core-frontend`.

<sup>Written for commit 0ed9a56d35dba96ac0443a757eb63d1845382bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

