### PR TITLE
A terminal review verdict without a fresh one-pager is an errored check

### DIFF
--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -437,9 +437,12 @@ jobs:
                   # previous run's page, and nothing distinguishes the two.
                   # The page names the head it reviewed in a meta tag; require
                   # this run's head there. Read only the top of the file — the
-                  # tag is in <head>, the page can be long. The needle is built
-                  # here and handed to jq as an argument, never as jq syntax.
-                  needle="name=\"bevel-review-head\" content=\"$HEAD_SHA\""
+                  # tag is in <head>, the page can be long. The needle is the
+                  # WHOLE tag exactly as the template emits it — an attribute
+                  # fragment alone would match the same text quoted anywhere
+                  # in the page — built here and handed to jq as an argument,
+                  # never as jq syntax.
+                  needle="<meta name=\"bevel-review-head\" content=\"$HEAD_SHA\">"
                   read_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
                     '{branch: $b, path: $p, sessionId: $s, limit: 4000}')
                   rcode=$(curl -sS -m 20 -o page.json -w '%{http_code}' -X POST \

--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -266,9 +266,11 @@ jobs:
   # running": the agent can fail to reach a verdict without failing its step (it
   # exits 0 having declined to act), and `failure()` does not fire for that.
   #
-  # It holds the knowledge-base key, for one read: checking that the one-pager
-  # the agent links to is really there. That is safe here precisely because
-  # this job reads nothing the PR's author wrote — only the four fields below.
+  # It holds the knowledge-base key, for two reads: checking that the one-pager
+  # the agent links to is really there, and that it was written for THIS run's
+  # head rather than left over from an earlier one. That is safe here precisely
+  # because this job reads nothing the PR's author wrote — only the four fields
+  # below, and the head of a page the agent wrote into the knowledge base.
   # ---------------------------------------------------------------------------
   publish:
     needs: [start, review]
@@ -300,6 +302,7 @@ jobs:
           KB_KEY: ${{ secrets.KNOWLEDGE_BASE_CONNECTION_KEY }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ needs.start.outputs.sha }}
         run: |
           set -euo pipefail
 
@@ -389,6 +392,7 @@ jobs:
           # itself cannot run (no key, KB down, access refused) keep the link
           # and warn, so a hiccup here never hides a one-pager that exists.
           onepager_missing=0
+          onepager_stale=0
           case "$url" in
             "${KB_ORIGIN%/}"/workspace/*)
               # <origin>/workspace/<branch>/<workspace path>, both URL-encoded.
@@ -427,6 +431,29 @@ jobs:
                 # so no other failure text can pass for an absence.
                 if [ "$code" = 200 ] && jq -e '.type == "file"' stat.json >/dev/null 2>&1; then
                   echo "One-pager verified in the knowledge base: $branch:$path"
+                  # EXISTENCE is not enough. Every terminal run must REGENERATE
+                  # the one-pager, and the file sits at a fixed per-PR path —
+                  # so a run that stops after the verdict still links to the
+                  # previous run's page, and nothing distinguishes the two.
+                  # The page names the head it reviewed in a meta tag; require
+                  # this run's head there. Read only the top of the file — the
+                  # tag is in <head>, the page can be long. The needle is built
+                  # here and handed to jq as an argument, never as jq syntax.
+                  needle="name=\"bevel-review-head\" content=\"$HEAD_SHA\""
+                  read_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
+                    '{branch: $b, path: $p, sessionId: $s, limit: 4000}')
+                  rcode=$(curl -sS -m 20 -o page.json -w '%{http_code}' -X POST \
+                          -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' \
+                          -d "$read_args" "${KB_ORIGIN%/}/api/agent/tools/read_file" || echo 000)
+                  if [ "$rcode" = 200 ] && [ -n "${HEAD_SHA:-}" ] \
+                     && jq -e --arg needle "$needle" '(.content? // "") | tostring | contains($needle)' page.json >/dev/null 2>&1; then
+                    echo "One-pager is fresh: it names this run's head $HEAD_SHA"
+                  elif [ "$rcode" = 200 ]; then
+                    echo "::warning::The one-pager at $branch:$path does not name this run's head ($HEAD_SHA) — it is a previous run's page; dropping the link."
+                    url=""; onepager_stale=1
+                  else
+                    echo "::warning::Could not read the one-pager to check its freshness (HTTP $rcode) — keeping the link unverified."
+                  fi
                 elif jq -e '(.error? // "") | tostring | startswith("File not found: ")' stat.json >/dev/null 2>&1; then
                   echo "::warning::The agent's one_pager_url names a file the knowledge base does not have ($branch:$path) — dropping the link."
                   url=""; onepager_missing=1
@@ -442,6 +469,8 @@ jobs:
             echo "outcome=$outcome"
             echo "headline=$headline"
             echo "url=$url"
+            echo "onepager_missing=$onepager_missing"
+            echo "onepager_stale=$onepager_stale"
           } >> "$GITHUB_OUTPUT"
 
           # The comment body: verdict line, the risks and blockers, the link.
@@ -472,8 +501,12 @@ jobs:
               printf '[Full analysis](%s)\n' "$url"
             elif [ "$onepager_missing" = 1 ]; then
               # Say so on the PR rather than silently dropping the link: the
-              # reader would otherwise assume there is no deeper analysis.
-              echo "The full analysis this review refers to was never written to the knowledge base — re-trigger with \`/bevel-review\` to regenerate it."
+              # reader would otherwise assume there is no deeper analysis. For
+              # a terminal verdict this also fails the check (see the status
+              # step) — a review without its one-pager is an unfinished review.
+              echo "The full analysis this review refers to was never written to the knowledge base, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
+            elif [ "$onepager_stale" = 1 ]; then
+              echo "The full analysis at the expected link is from an earlier run and does not cover this head, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
             elif [ "$outcome" = none ]; then
               printf '[Run log](%s)\n' "$RUN_URL"
             fi
@@ -508,6 +541,8 @@ jobs:
           OUTCOME: ${{ steps.render.outputs.outcome }}
           HEADLINE: ${{ steps.render.outputs.headline }}
           URL: ${{ steps.render.outputs.url }}
+          ONEPAGER_MISSING: ${{ steps.render.outputs.onepager_missing }}
+          ONEPAGER_STALE: ${{ steps.render.outputs.onepager_stale }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -523,6 +558,19 @@ jobs:
             escalated) state=pending; fallback="awaiting tech lead decision" ;;
             *)         state=error;   fallback="Review agent posted no verdict — see run log, then re-trigger /bevel-review" ;;
           esac
+
+          # A terminal verdict owes a one-pager written for THIS head — it is
+          # where the rule checks, the evidence table and the lead's approval
+          # instrument live. A run that wrote the verdict and stopped, or that
+          # left an earlier run's page in place, has not finished reviewing;
+          # publishing it green would reward exactly that, run after run. The
+          # verdict stays visible in the comment; the check says "incomplete".
+          if [ "$OUTCOME" = go-ahead ] || [ "$OUTCOME" = escalated ]; then
+            if [ "${ONEPAGER_MISSING:-0}" = 1 ] || [ "${ONEPAGER_STALE:-0}" = 1 ]; then
+              state=error
+              fallback="review incomplete — one-pager missing or stale for this head; re-trigger /bevel-review"
+            fi
+          fi
 
           description="${HEADLINE:-}"
           if [ "$state" = "error" ] || [ -z "$description" ]; then


### PR DESCRIPTION
## Why

Re-running `/bevel-review` on #107, #108 and #109 after the KB rule changes showed the failure mode: the agent read the rules, wrote the verdict file, and **stopped**. #107 and #109 wrote no one-pager at all (zero `write_file` calls in the run logs; the #109 link pointed at the previous day's page), and only #108 produced one. This predates the new rules — #107's 08-27 run also went green with no page, and #106's run reused a stale page "because it already exists". The `publish` job only *warned* on a missing or unverifiable one-pager and published the check green, so a run that stops after the cheap artefact is rewarded every time — and since the rule checks and evidence table live only in the one-pager, they vanished with it.

## What changes

`publish` → *Render the verdict*: after the existing existence check, read the top of the one-pager (`read_file`, 4000 chars) and require `<meta name="bevel-review-head" content="<this run's head SHA>">`. Missing tag or older head → `onepager_stale=1`, link dropped, reason stated in the comment. The needle is built in shell and handed to jq via `--arg` — no jq escapes (per the earlier lesson about backslashes in workflow jq).

`publish` → *Publish the review status*: a `go-ahead`/`escalated` verdict with a missing or stale one-pager publishes `bevel/architecture-review` as **error**, description "review incomplete — one-pager missing or stale for this head; re-trigger /bevel-review". The verdict and findings still land in the comment; only the check refuses to be green. Bounces are unaffected (no one-pager expected).

KB half (template meta tag + pipeline-skill contract) is knowledge-base CR #45. Note: `issue_comment` workflows run from the default branch, so this takes effect after the next release merge to `main`. The same workflow in bevel-platform needs the same change.

## Verification

YAML parses; `bash -n` on both edited steps; the freshness check degrades to "unverified + warning" on any transport failure, exactly like the existence check, so a KB outage can never fail a review by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the architecture review check from going green when the one-pager is missing or was written for an earlier run.

Previously `publish` only warned when the agent's one-pager was missing or unverifiable and still published the check green, so a run that wrote the verdict and stopped was rewarded every time. The one-pager now names the head it reviewed in a `<meta name="bevel-review-head">` tag; `publish` reads the top of the page and requires this run's head. A `go-ahead` or `escalated` verdict with a missing or stale one-pager publishes `bevel/architecture-review` as errored, while the verdict still lands in the comment. Bounces are unaffected. Freshness checks degrade to warnings on any transport failure, so a KB outage can't fail a review by itself.

<sup>Written for commit f525cbd0bd954e5f3421dab3926bb59e4a7905c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

