### PR TITLE
The one-pager names the RUN that wrote it; any terminal verdict without a page from this run errors

### DIFF
--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -211,6 +211,7 @@ jobs:
             - Repository: ${{ github.repository }}
             - Pull request: #${{ github.event.issue.number }}
             - Knowledge base origin: ${{ vars.KNOWLEDGE_BASE_API_URL }}
+            - Review run id (stamp it into the one-pager's `bevel-review-run` meta tag): ${{ github.run_id }}
             - Verdict file (write your verdict JSON here): ${{ runner.temp }}/bevel-verdict.json
 
       # Hand the verdict to `publish` as one base64 line. `always()` so a
@@ -266,11 +267,11 @@ jobs:
   # running": the agent can fail to reach a verdict without failing its step (it
   # exits 0 having declined to act), and `failure()` does not fire for that.
   #
-  # It holds the knowledge-base key, for two reads: checking that the one-pager
-  # the agent links to is really there, and that it was written for THIS run's
-  # head rather than left over from an earlier one. That is safe here precisely
-  # because this job reads nothing the PR's author wrote — only the four fields
-  # below, and the head of a page the agent wrote into the knowledge base.
+  # It holds the knowledge-base key, for one read: checking that the one-pager
+  # the agent links to is really there AND was written by this run rather than
+  # left over from an earlier one. That is safe here precisely because this job
+  # reads nothing the PR's author wrote — only the four fields below, and the
+  # head of a page the agent wrote into the knowledge base.
   # ---------------------------------------------------------------------------
   publish:
     needs: [start, review]
@@ -302,7 +303,7 @@ jobs:
           KB_KEY: ${{ secrets.KNOWLEDGE_BASE_CONNECTION_KEY }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          HEAD_SHA: ${{ needs.start.outputs.sha }}
+          REVIEW_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -393,6 +394,13 @@ jobs:
           # and warn, so a hiccup here never hides a one-pager that exists.
           onepager_missing=0
           onepager_stale=0
+          # 1 only when the one-pager was read back and names THIS run — or
+          # when the knowledge base could not be asked at all, because an
+          # outage must never fail a review by itself. Everything else — no
+          # link, an off-site or over-long link, a missing file, another
+          # run's page — leaves it 0, and a terminal verdict is then published
+          # as an errored, incomplete review (see the status step).
+          onepager_ok=0
           case "$url" in
             "${KB_ORIGIN%/}"/workspace/*)
               # <origin>/workspace/<branch>/<workspace path>, both URL-encoded.
@@ -416,53 +424,45 @@ jobs:
                         "${KB_ORIGIN%/}/api/agent/tools/start_session" | jq -r '.sessionId // empty') \
                    || [ -z "$sid" ]; then
                 echo "::warning::Could not open a knowledge-base session to verify the one-pager — keeping the link unverified."
+                onepager_ok=1
               else
-                stat_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
-                  '{branch: $b, path: $p, sessionId: $s}')
-                code=$(curl -sS -m 20 -o stat.json -w '%{http_code}' -X POST \
+                # ONE read answers both questions. `read_file` on a missing
+                # path surfaces the filesystem's ENOENT as
+                # `{ "error": "File not found: <path>" }` — served with a 500,
+                # not a 404, so the status code is no help — while an access
+                # refusal or an outage says something else entirely; match
+                # that one message, in the JSON field it lives in, so no other
+                # failure text can pass for an absence. And existence is not
+                # enough: every terminal run must REGENERATE the one-pager at
+                # its fixed per-PR path, so a run that stopped after the
+                # verdict still links to the previous run's page — which may
+                # even review the same head, when a re-trigger applies changed
+                # rules to unchanged code. So the page names the RUN that wrote
+                # it, and only this run's id passes. Read the top of the file
+                # only (the tag is in <head>; the page can be long). The
+                # pattern is handed to jq as an argument — POSIX classes, no
+                # backslashes — and tolerates quote style, spacing and a
+                # self-closing `/>`, never a different run id.
+                read_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
+                  '{branch: $b, path: $p, sessionId: $s, limit: 4000}')
+                code=$(curl -sS -m 20 -o page.json -w '%{http_code}' -X POST \
                         -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' \
-                        -d "$stat_args" "${KB_ORIGIN%/}/api/agent/tools/file_stat" || echo 000)
-                # "Definite not found" is the knowledge base's own answer for
-                # a missing path: `file_stat` surfaces the filesystem's ENOENT
-                # as `{ "error": "File not found: <path>" }` — served with a
-                # 500, not a 404, so the status code is no help — while an
-                # access refusal or an outage says something else entirely.
-                # Match that one error message, in the JSON field it lives in,
-                # so no other failure text can pass for an absence.
-                if [ "$code" = 200 ] && jq -e '.type == "file"' stat.json >/dev/null 2>&1; then
-                  echo "One-pager verified in the knowledge base: $branch:$path"
-                  # EXISTENCE is not enough. Every terminal run must REGENERATE
-                  # the one-pager, and the file sits at a fixed per-PR path —
-                  # so a run that stops after the verdict still links to the
-                  # previous run's page, and nothing distinguishes the two.
-                  # The page names the head it reviewed in a meta tag; require
-                  # this run's head there. Read only the top of the file — the
-                  # tag is in <head>, the page can be long. The needle is the
-                  # WHOLE tag exactly as the template emits it — an attribute
-                  # fragment alone would match the same text quoted anywhere
-                  # in the page — built here and handed to jq as an argument,
-                  # never as jq syntax.
-                  needle="<meta name=\"bevel-review-head\" content=\"$HEAD_SHA\">"
-                  read_args=$(jq -n --arg b "$branch" --arg p "$path" --arg s "$sid" \
-                    '{branch: $b, path: $p, sessionId: $s, limit: 4000}')
-                  rcode=$(curl -sS -m 20 -o page.json -w '%{http_code}' -X POST \
-                          -H "Authorization: Bearer $KB_KEY" -H 'Content-Type: application/json' \
-                          -d "$read_args" "${KB_ORIGIN%/}/api/agent/tools/read_file" || echo 000)
-                  if [ "$rcode" = 200 ] && [ -n "${HEAD_SHA:-}" ] \
-                     && jq -e --arg needle "$needle" '(.content? // "") | tostring | contains($needle)' page.json >/dev/null 2>&1; then
-                    echo "One-pager is fresh: it names this run's head $HEAD_SHA"
-                  elif [ "$rcode" = 200 ]; then
-                    echo "::warning::The one-pager at $branch:$path does not name this run's head ($HEAD_SHA) — it is a previous run's page; dropping the link."
-                    url=""; onepager_stale=1
-                  else
-                    echo "::warning::Could not read the one-pager to check its freshness (HTTP $rcode) — keeping the link unverified."
-                  fi
-                elif jq -e '(.error? // "") | tostring | startswith("File not found: ")' stat.json >/dev/null 2>&1; then
+                        -d "$read_args" "${KB_ORIGIN%/}/api/agent/tools/read_file" || echo 000)
+                tag_pattern="<meta[[:space:]]+name=[\"']bevel-review-run[\"'][[:space:]]+content=[\"']${REVIEW_RUN_ID}[\"'][[:space:]]*/?>"
+                if [ "$code" = 200 ] && [ -n "${REVIEW_RUN_ID:-}" ] \
+                   && jq -e --arg pat "$tag_pattern" '(.content? // "") | tostring | test($pat; "i")' page.json >/dev/null 2>&1; then
+                  echo "One-pager verified in the knowledge base and written by this run: $branch:$path"
+                  onepager_ok=1
+                elif [ "$code" = 200 ]; then
+                  echo "::warning::The one-pager at $branch:$path was not written by this run ($REVIEW_RUN_ID) — a previous run's page; dropping the link."
+                  url=""; onepager_stale=1
+                elif jq -e '(.error? // "") | tostring | startswith("File not found: ")' page.json >/dev/null 2>&1; then
                   echo "::warning::The agent's one_pager_url names a file the knowledge base does not have ($branch:$path) — dropping the link."
                   url=""; onepager_missing=1
                 else
                   echo "::warning::Could not verify the one-pager (HTTP $code) — keeping the link unverified."
-                  cat stat.json 2>/dev/null || true
+                  cat page.json 2>/dev/null || true
+                  onepager_ok=1
                 fi
               fi
               ;;
@@ -472,8 +472,7 @@ jobs:
             echo "outcome=$outcome"
             echo "headline=$headline"
             echo "url=$url"
-            echo "onepager_missing=$onepager_missing"
-            echo "onepager_stale=$onepager_stale"
+            echo "onepager_ok=$onepager_ok"
           } >> "$GITHUB_OUTPUT"
 
           # The comment body: verdict line, the risks and blockers, the link.
@@ -502,14 +501,17 @@ jobs:
             printf '\n'
             if [ -n "$url" ]; then
               printf '[Full analysis](%s)\n' "$url"
-            elif [ "$onepager_missing" = 1 ]; then
-              # Say so on the PR rather than silently dropping the link: the
-              # reader would otherwise assume there is no deeper analysis. For
-              # a terminal verdict this also fails the check (see the status
-              # step) — a review without its one-pager is an unfinished review.
-              echo "The full analysis this review refers to was never written to the knowledge base, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
-            elif [ "$onepager_stale" = 1 ]; then
-              echo "The full analysis at the expected link is from an earlier run and does not cover this head, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
+            elif [ "$outcome" = go-ahead ] || [ "$outcome" = escalated ]; then
+              # A terminal verdict without its one-pager: say so on the PR
+              # rather than silently dropping the link — the reader would
+              # otherwise assume there is no deeper analysis — and say what
+              # the status step does about it. This condition and that step's
+              # are the same on purpose; a bounce owes no one-pager.
+              if [ "$onepager_stale" = 1 ]; then
+                echo "The full analysis at the expected link was written by an earlier run, not this one, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
+              else
+                echo "The full analysis this review refers to was not written to the knowledge base, so the check is marked as errored — re-trigger with \`/bevel-review\` to regenerate it."
+              fi
             elif [ "$outcome" = none ]; then
               printf '[Run log](%s)\n' "$RUN_URL"
             fi
@@ -544,8 +546,7 @@ jobs:
           OUTCOME: ${{ steps.render.outputs.outcome }}
           HEADLINE: ${{ steps.render.outputs.headline }}
           URL: ${{ steps.render.outputs.url }}
-          ONEPAGER_MISSING: ${{ steps.render.outputs.onepager_missing }}
-          ONEPAGER_STALE: ${{ steps.render.outputs.onepager_stale }}
+          ONEPAGER_OK: ${{ steps.render.outputs.onepager_ok }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -562,16 +563,18 @@ jobs:
             *)         state=error;   fallback="Review agent posted no verdict — see run log, then re-trigger /bevel-review" ;;
           esac
 
-          # A terminal verdict owes a one-pager written for THIS head — it is
+          # A terminal verdict owes a one-pager written by THIS run — it is
           # where the rule checks, the evidence table and the lead's approval
-          # instrument live. A run that wrote the verdict and stopped, or that
-          # left an earlier run's page in place, has not finished reviewing;
-          # publishing it green would reward exactly that, run after run. The
+          # instrument live. A run that wrote the verdict and stopped, linked
+          # nothing (or something off-site), or left an earlier run's page in
+          # place has not finished reviewing; publishing it green would reward
+          # exactly that, run after run. Only a verified page — or a knowledge
+          # base that could not be asked — keeps the verdict's own state. The
           # verdict stays visible in the comment; the check says "incomplete".
           if [ "$OUTCOME" = go-ahead ] || [ "$OUTCOME" = escalated ]; then
-            if [ "${ONEPAGER_MISSING:-0}" = 1 ] || [ "${ONEPAGER_STALE:-0}" = 1 ]; then
+            if [ "${ONEPAGER_OK:-0}" != 1 ]; then
               state=error
-              fallback="review incomplete — one-pager missing or stale for this head; re-trigger /bevel-review"
+              fallback="review incomplete — no one-pager written by this run; re-trigger /bevel-review"
             fi
           fi
 


### PR DESCRIPTION
## Why

Follow-up to #116 (merged), from a second review pass on that change and from the first live runs under it:

- A head SHA cannot tell a **re-run on unchanged code** — the normal reason to re-trigger `/bevel-review`: the rules changed — from the previous run's page, so a run that wrote the verdict and stopped still passed the gate.
- `start`'s snapshot of the head can differ from the head the agent checks out (branch by name) when the author pushes between trigger and review, so a freshly written page could be judged stale.
- The gate only fired when a KB link was checked and found missing/stale; an **empty, off-site or over-long `one_pager_url`** set neither flag and published green with no one-pager at all.
- The exact-substring tag match errored a complete review for benign variance (`/>`, quote style, spacing).
- The comment said "marked as errored" on a bounce too, where the status is `failure`.
- `file_stat` + `read_file` were two round trips for one question.

## What changes

The one-pager carries `<meta name="bevel-review-run" content="<github.run_id>">`; the run id is handed to the agent in its run context. `publish` does one `read_file` (existence + freshness), matches the tag with a POSIX-class regex via `--arg` (no jq escapes), and computes a single `onepager_ok`: 1 only for a page written by this run, or when the KB could not be asked at all. A `go-ahead`/`escalated` verdict with `onepager_ok != 1` publishes `error` — "review incomplete — no one-pager written by this run". The comment's sentence shares that condition.

KB half: knowledge-base CR #47 (template `{{REVIEW_RUN_ID}}` + pipeline contract). **Merge together** — the workflow on `main` and the KB template must agree on the tag, or every review errors. Same change needed in bevel-platform.

## Verification

YAML parses; `bash -n` on both edited steps; failure paths degrade to "unverified" exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the one-pager gate so a previous run's page can no longer pass a re-triggered review, and any terminal verdict without a page from this run now errors.

**Bug Fixes**
- Verifies by run ID stamped in a `bevel-review-run` meta tag instead of the head SHA, which can't distinguish a re-run on unchanged code.
- Errors on empty, off-site, or over-long `one_pager_url` values, not just missing or stale linked files.
- Folds `file_stat` and `read_file` into one `read_file` call.
- Matches the tag with a POSIX-class regex so quote style, spacing, and self-closing tags don't fail the check.
- The comment's "marked as errored" sentence now shares the status step's condition, so a bounce isn't told to regenerate a page it doesn't owe.

Requires the matching knowledge-base template change (CR #47) to deploy together, or every review errors.

<sup>Written for commit 9b10309c816cf71d9bc5304b31b3d4a010d62b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

