### PR TITLE
The shell tool kills the tree it started, and the image carries its own reaper

### DIFF
--- a/.changeset/shell-tool-kills-its-tree.md
+++ b/.changeset/shell-tool-kills-its-tree.md
@@ -2,4 +2,4 @@
 '@bevel-software/platform-core-backend': patch
 ---
 
-The shell tool's timeout and abort now kill the whole process tree the command started, not just the `sh` in front of it — the orphans that accumulated as unreaped zombies until a host could no longer fork. The server image now runs under `tini`, so a deployment built from the Dockerfile alone gets a reaper without depending on `init: true` in its compose file.
+The shell tool's timeout and abort now kill the whole process tree the command started, not just the `sh` in front of it — the orphans that accumulated as unreaped zombies until a host could no longer fork. Workspace clones are stamped with `gc.autoDetach=false`, so git's automatic gc runs inside the command that triggered it instead of detaching into a background process nothing reaps — the source of the zombie `git` processes seen piling up under a platform container. The server image now runs under `tini`, so a deployment built from the Dockerfile alone gets a reaper without depending on `init: true` in its compose file.

--- a/.changeset/shell-tool-kills-its-tree.md
+++ b/.changeset/shell-tool-kills-its-tree.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-backend': patch
+---
+
+The shell tool's timeout and abort now kill the whole process tree the command started, not just the `sh` in front of it — the orphans that accumulated as unreaped zombies until a host could no longer fork. The server image now runs under `tini`, so a deployment built from the Dockerfile alone gets a reaper without depending on `init: true` in its compose file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,16 @@ FROM node:22-slim AS production
 RUN corepack enable && corepack prepare pnpm@10.33.3 --activate
 
 # git backs every workspace operation (clone/commit/push of the KB repo).
+# tini is PID 1: the reaper. The server spawns git, MCP servers and the
+# shell tool's commands; a grandchild that outlives its parent reparents to
+# PID 1, and a node process there never reaps it — zombies accumulate until
+# the host cannot fork (a self-hosted deployment reached ~4,500 tasks that
+# way). The shipped compose files set `init: true` for the same reason, but a
+# deployment built from this Dockerfile alone — a Coolify "Dockerfile" app, a
+# hand-written compose — got no reaper. Baking it in means no deployment can
+# forget it; `init: true` on top is harmless.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git ca-certificates \
+      git ca-certificates tini \
     && rm -rf /var/lib/apt/lists/*
 
 # tsx runs the TypeScript server shell at runtime. It lives in apps/server's
@@ -121,4 +129,5 @@ ENV GIT_SHA=${GIT_SHA}
 EXPOSE 3001
 
 WORKDIR /app/apps/server
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["tsx", "src/main.ts"]

--- a/packages/core-backend/src/modules/kb-fs/__tests__/clone-config.test.ts
+++ b/packages/core-backend/src/modules/kb-fs/__tests__/clone-config.test.ts
@@ -11,11 +11,14 @@ describe('cloneTrackingConfigArgs', () => {
   // A slashed draft name is the everyday case (`<email-localpart>/<slug>`), and
   // the branch lands verbatim inside the config KEY — pin the exact tuples so a
   // future quoting/encoding change can't silently re-point tracking.
-  it('emits the three --replace-all tuples for a slashed branch', () => {
+  it('emits the tracking tuples for a slashed branch, and keeps gc in the foreground', () => {
     expect(cloneTrackingConfigArgs('feature/x')).toEqual([
       ['config', '--replace-all', 'remote.origin.fetch', ORIGIN_FETCH_REFSPEC],
       ['config', '--replace-all', 'branch.feature/x.remote', 'origin'],
       ['config', '--replace-all', 'branch.feature/x.merge', 'refs/heads/feature/x'],
+      // A detached `gc --auto` outlives the command this process waits on and
+      // is never reaped; stamped here so existing clones get it on next pull.
+      ['config', '--replace-all', 'gc.autoDetach', 'false'],
     ]);
   });
 });

--- a/packages/core-backend/src/modules/kb-fs/clone-config.ts
+++ b/packages/core-backend/src/modules/kb-fs/clone-config.ts
@@ -68,12 +68,23 @@ export const SAFE_IMPLICIT_FETCH_ARGS: readonly string[] = [
  * Returns the arguments rather than running them so each caller can use its own
  * git runner (the git service's mutex-aware wrapper, `git -C` from the
  * workspace service) — no process is spawned here.
+ *
+ * `gc.autoDetach=false` rides along because it is stamped in the same two
+ * places — on adopt, and before every pull — which is how clones already on
+ * disk pick it up. After a fetch or a commit git may decide to run
+ * `gc --auto`, and by default it forks that into the BACKGROUND, detached from
+ * the git command this process is waiting on. The detached gc reparents to
+ * PID 1 and, when it exits, stays a zombie unless PID 1 reaps it — a node
+ * server does not. One shared host was found carrying 1,500 zombie `git`
+ * processes under a single platform container. With auto-detach off the gc
+ * runs inside the command that triggered it, and that command's exit reaps it.
  */
 export function cloneTrackingConfigArgs(branch: string): string[][] {
   return [
     ['config', '--replace-all', 'remote.origin.fetch', ORIGIN_FETCH_REFSPEC],
     ['config', '--replace-all', `branch.${branch}.remote`, 'origin'],
     ['config', '--replace-all', `branch.${branch}.merge`, `refs/heads/${branch}`],
+    ['config', '--replace-all', 'gc.autoDetach', 'false'],
   ];
 }
 

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -191,6 +191,33 @@ describe('workspace file primitives', () => {
     expect(res.exitCode).toBe(0);
   });
 
+  // The command runs under `sh -c`; a timeout used to SIGKILL that shell and
+  // leave what it had started running on as an orphan. The whole process
+  // group goes now. POSIX only: Windows has no process groups to kill.
+  it.skipIf(process.platform === 'win32')('execute_command kills what the command started, not just its shell, on timeout', async () => {
+    const base = await start();
+    // Print the grandchild's pid, then block on it so the timeout fires.
+    const res = (await (
+      await post(`${base}/api/agent/tools/execute_command`, {
+        branch: 'main',
+        command: 'sleep 30 & echo $!; wait',
+        timeout_ms: 300,
+      })
+    ).json()) as { stdout: string; exitCode: number };
+    expect(res.exitCode).toBe(-1);
+    const grandchild = Number(res.stdout.trim());
+    expect(grandchild).toBeGreaterThan(0);
+    // Give the kernel a beat to deliver the signal, then the pid must be gone.
+    await new Promise((r) => setTimeout(r, 200));
+    let alive = true;
+    try {
+      process.kill(grandchild, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  });
+
   it('execute_command 400s when no branch is given AND no focused branch (external caller)', async () => {
     const base = await start();
     // No `branch` arg and no `ctx.focusedBranch` (an external caller carries no

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -207,13 +207,20 @@ describe('workspace file primitives', () => {
     expect(res.exitCode).toBe(-1);
     const grandchild = Number(res.stdout.trim());
     expect(grandchild).toBeGreaterThan(0);
-    // Give the kernel a beat to deliver the signal, then the pid must be gone.
-    await new Promise((r) => setTimeout(r, 200));
+    // A killed process keeps its pid — and answers `kill(pid, 0)` as alive —
+    // until whoever inherited it reaps it, which on a loaded machine is not
+    // instant. Poll to a deadline rather than trust one fixed pause. Without
+    // the fix the grandchild is not dead at all, so the deadline is what
+    // fails, not a lucky early check that passes.
+    const deadline = Date.now() + 3_000;
     let alive = true;
-    try {
-      process.kill(grandchild, 0);
-    } catch {
-      alive = false;
+    while (alive && Date.now() < deadline) {
+      try {
+        process.kill(grandchild, 0);
+        await new Promise((r) => setTimeout(r, 50));
+      } catch {
+        alive = false;
+      }
     }
     expect(alive).toBe(false);
   });

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -1069,14 +1069,32 @@ export function registerWorkspaceTools(
           }
         : process.env;
       return new Promise((resolve) => {
-        const child = spawn(a.command as string, { cwd, shell: true, env });
+        // Own process group on POSIX, so a timeout or abort kills the WHOLE
+        // tree. `shell: true` puts an `sh` between us and the command; killing
+        // only that shell left whatever it had started running on — orphaned,
+        // unreaped, still holding the workspace and its memory. A self-hosted
+        // deployment leaked ~4,500 tasks that way before nothing could fork.
+        const detached = process.platform !== 'win32';
+        const child = spawn(a.command as string, { cwd, shell: true, env, detached });
         let stdout = '';
         let stderr = '';
-        const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
-        // If the caller disconnects (request aborted), kill the child instead of
+        const killTree = () => {
+          try {
+            if (detached && child.pid) process.kill(-child.pid, 'SIGKILL');
+            else child.kill('SIGKILL');
+          } catch {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // Already gone.
+            }
+          }
+        };
+        const timer = setTimeout(killTree, timeoutMs);
+        // If the caller disconnects (request aborted), kill the tree instead of
         // letting it run to the timeout; the resulting `close`/`error` settles
         // the promise through `finish`.
-        const onAbort = () => child.kill('SIGKILL');
+        const onAbort = killTree;
         ctx.abortSignal.addEventListener('abort', onAbort, { once: true });
         const finish = (value: unknown) => {
           clearTimeout(timer);


### PR DESCRIPTION
## Why

#95 named the mechanism behind a self-hosted deployment leaking ~4,500 tasks — *the agent shell tool SIGKILLs `sh`, not what's under it* — and contained it with `init: true` + `pids_limit` in the shipped compose files. Today a shared host was found with 1,600+ zombies under two deployments whose compose files had never taken those lines. Containment that lives in a file a deployment may not use is not containment.

## Changes

**The shell tool kills its tree.** `execute_command` spawns under `sh -c`; on POSIX the child now runs in its own process group (`detached: true`) and both the timeout and the abort path `SIGKILL` the group, falling back to the direct child. Windows keeps the previous behaviour — it has no process groups to kill. Same pattern the coding-agent runner uses for its sessions.

**The image is its own reaper.** `tini` is installed and set as `ENTRYPOINT`; `CMD` is unchanged. A deployment built from the Dockerfile alone — a Coolify "Dockerfile" app, a hand-written or enterprise compose — now reaps orphans regardless of what its compose file says. `init: true` on top is harmless.

## Verification

- New test, POSIX only: a command that backgrounds `sleep 30`, prints its pid and blocks is run with a 300 ms timeout; the tool returns `exitCode: -1` and the grandchild pid must be gone. Skipped on Windows where I ran the file (66 passed, 3 skipped); it runs in this PR's CI.
- `tsc --noEmit` clean.
- Changeset: patch on `platform-core-backend` (rides the fixed group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #95's root cause: the shell tool now kills the entire process tree it started on timeout or abort, the server image carries its own reaper via `tini`, and git's auto-gc stays in the foreground instead of detaching into an unreaped zombie.

**Bug Fixes**
- The shell tool ran commands under `sh -c` and only SIGKILLed that shell on timeout or abort, leaving grandchildren orphaned until the host could no longer fork (one self-hosted deployment leaked ~4,500 tasks this way).
- On POSIX commands now spawn in their own process group and the kill path targets the whole group, falling back to the direct child; Windows keeps the previous behavior.
- A new POSIX-only test backgrounds `sleep 30`, blocks until the timeout fires, and polls to a deadline to confirm the grandchild is reaped — a killed process keeps its pid until reaped, so a fixed pause was a race on a loaded machine.
- Workspace clones are stamped with `gc.autoDetach=false`, so git's auto-gc runs inside the triggering command instead of forking into the background where nothing reaps it (a shared host carried 1,375 zombie `git` processes under one container).
- The Dockerfile installs `tini` and sets it as `ENTRYPOINT`, so the image reaps orphans for git, MCP servers, and shell tool children regardless of compose settings.
- Adds a patch changeset for `@bevel-software/platform-core-backend`.

<sup>Written for commit f25edf7f2d92cf06fcae01edf0122f1fef550d42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

