### PR TITLE
The grandchild test stays inside the tool's contract and does not depend on a reaper

### DIFF
--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -1,6 +1,6 @@
 import type { Server as HttpServer } from 'node:http';
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -147,6 +147,25 @@ afterEach(async () => {
   }
 });
 
+/**
+ * True once `pid` has been killed: either it is gone, or it is a zombie
+ * waiting on a reaper (Linux: `State:\tZ` in /proc). `kill(pid, 0)` alone
+ * cannot tell a zombie from a live process.
+ */
+async function isDeadOrZombie(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return true;
+  }
+  try {
+    const status = await readFile(`/proc/${pid}/status`, 'utf8');
+    return /^State:\s*Z/m.test(status);
+  } catch {
+    return false; // no /proc (macOS): alive as far as the signal says
+  }
+}
+
 describe('workspace file primitives', () => {
   it('read_file returns the content', async () => {
     const base = await start();
@@ -196,33 +215,33 @@ describe('workspace file primitives', () => {
   // group goes now. POSIX only: Windows has no process groups to kill.
   it.skipIf(process.platform === 'win32')('execute_command kills what the command started, not just its shell, on timeout', async () => {
     const base = await start();
-    // Print the grandchild's pid, then block on it so the timeout fires.
+    // Print the grandchild's pid, then block on it so the timeout fires. The
+    // timeout is the schema's minimum — inside the tool's declared contract,
+    // and long enough that a slow spawn still prints the pid before it fires.
     const res = (await (
       await post(`${base}/api/agent/tools/execute_command`, {
         branch: 'main',
         command: 'sleep 30 & echo $!; wait',
-        timeout_ms: 300,
+        timeout_ms: 1000,
       })
     ).json()) as { stdout: string; exitCode: number };
     expect(res.exitCode).toBe(-1);
     const grandchild = Number(res.stdout.trim());
     expect(grandchild).toBeGreaterThan(0);
-    // A killed process keeps its pid — and answers `kill(pid, 0)` as alive —
-    // until whoever inherited it reaps it, which on a loaded machine is not
-    // instant. Poll to a deadline rather than trust one fixed pause. Without
-    // the fix the grandchild is not dead at all, so the deadline is what
-    // fails, not a lucky early check that passes.
+    // Dead means killed, not reaped: a SIGKILLed process keeps its pid — and
+    // answers `kill(pid, 0)` as alive — until whoever inherited it reaps it,
+    // and on a host with no reaper (the very thing this guards) that is
+    // never. So where /proc exists, a zombie (`State: Z`) counts as dead; a
+    // vanished pid counts everywhere. Poll to a deadline rather than trust
+    // one fixed pause. Without the fix the grandchild is still sleeping at
+    // the deadline, so what fails is the deadline — never an early check.
     const deadline = Date.now() + 3_000;
-    let alive = true;
-    while (alive && Date.now() < deadline) {
-      try {
-        process.kill(grandchild, 0);
-        await new Promise((r) => setTimeout(r, 50));
-      } catch {
-        alive = false;
-      }
+    let dead = false;
+    while (!dead && Date.now() < deadline) {
+      dead = await isDeadOrZombie(grandchild);
+      if (!dead) await new Promise((r) => setTimeout(r, 50));
     }
-    expect(alive).toBe(false);
+    expect(dead).toBe(true);
   });
 
   it('execute_command 400s when no branch is given AND no focused branch (external caller)', async () => {


### PR DESCRIPTION
Answers cubic's two P2/P3 comments on #121 about the test added in #120.

- **`timeout_ms: 300` → `1000`.** The schema declares a minimum of 1000; the test only passed because tool inputs are not validated against it yet. 1000 also removes the race between a slow spawn and `echo $!` — the pid is printed long before the timer fires, and the poll deadline (3 s) still has room.
- **Killed ≠ reaped.** A SIGKILLed process keeps its pid — and `kill(pid, 0)` says alive — until whoever inherited it reaps it. On a host with no reaper (exactly what #120 guards against) that is never, so the old check could fail with the fix working. `isDeadOrZombie` treats a vanished pid as dead everywhere and, where `/proc` exists, a `State: Z` as dead too; on macOS (no `/proc`) it falls back to the signal.

Test-only change; POSIX-only test as before. `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the grandchild timeout test to stay within the tool's contract and correctly determine when a killed process is dead (test-only change).

- Uses the schema's minimum `timeout_ms` (1000) instead of 300, removing the race with slow spawns and staying inside the declared contract.
- Counts a zombie process (on Linux) or a vanished pid as dead in the poll check, since a SIGKILLed process can keep answering `kill(pid, 0)` until reaped.

<sup>Written for commit ecb07bb2cfb350de5d1686d5ef2e85c0dbf20e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

