### PR TITLE
Show-Tool-Source-On-Tool-Page — Show a tool's .tool source on its tool page, in a toggleable view

### DIFF
--- a/packages/core-frontend/src/modules/library/__tests__/ToolPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/ToolPage.test.tsx
@@ -45,6 +45,9 @@ vi.mock('../services/library.api', () => ({
   getSkill: libraryMock.getSkill,
 }));
 
+const sourceMock = vi.hoisted(() => ({ readFileOnBranch: vi.fn() }));
+vi.mock('../../change-requests/services/change-requests.api', () => sourceMock);
+
 vi.mock('../../secrets-vault/services/connect.api', () => ({ startToolOAuth: vi.fn() }));
 vi.mock('../utils/navigate-external', () => ({ navigateExternal: vi.fn() }));
 
@@ -72,6 +75,29 @@ const DETAIL: ToolManualDetail = {
   ],
 };
 
+/**
+ * A `.tool` with everything a formatter would be tempted to touch: the `---`
+ * fences, a folded description, a comment, and a fenced template carrying an
+ * unexpanded `${VAR}`. The section shows these bytes or it shows a lie.
+ */
+const SOURCE = [
+  '---',
+  'name: heyreach',
+  'description: >-',
+  '  Runs LinkedIn',
+  '  outreach campaigns.',
+  '---',
+  '',
+  '# heyreach',
+  '',
+  '<!-- keep me: a reader is here precisely for this -->',
+  '',
+  '```http',
+  'GET https://api.heyreach.io/campaigns',
+  'Authorization: Bearer ${HEYREACH_API_KEY}',
+  '```',
+  '',
+].join('\n');
 const workspace = {
   workspaceId: 'target-company-state',
   kbDirName: 'knowledge-base',
@@ -126,6 +152,7 @@ beforeEach(() => {
   toolsMock.getMcpServer.mockClear();
   libraryMock.listSkills.mockReset().mockResolvedValue([]);
   libraryMock.getSkill.mockReset().mockResolvedValue({ allowedTools: [] });
+  sourceMock.readFileOnBranch.mockReset().mockResolvedValue(SOURCE);
 });
 
 describe('ToolPage: frame', () => {
@@ -362,5 +389,126 @@ describe('ToolPage: OAuth round-trip', () => {
     expect(window.location.pathname).toBe(
       '/workspace/main/knowledge-base/Plugins/Everyone/mcp.json',
     );
+  });
+});
+
+/**
+ * The `.tool` itself, at the bottom of the page.
+ *
+ * The four things worth pinning are the four the section can get wrong in a
+ * way nobody notices: it must be CLOSED (a reader who wanted the tool, not its
+ * file, sees no change), the text must be the file's BYTES (a view that
+ * reformats is worse than no view — it invents a source that does not exist),
+ * a failed read must cost the section and nothing else, and the read must not
+ * happen until it is asked for.
+ */
+describe('ToolPage: source', () => {
+  const toggle = () => screen.getByRole('button', { name: 'Source' });
+
+  it('is closed on first visit, with the file path beside its label', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+
+    expect(toggle()).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Plugins/GTM/heyreach.tool')).toBeInTheDocument();
+    expect(document.querySelector('pre')).toBeNull();
+  });
+
+  it('reads nothing until it is opened, and then exactly once', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+    // The whole point of the disclosure: no reader pays for a file they did
+    // not ask to see.
+    expect(sourceMock.readFileOnBranch).not.toHaveBeenCalled();
+
+    fireEvent.click(toggle());
+    await waitFor(() => expect(sourceMock.readFileOnBranch).toHaveBeenCalledTimes(1));
+    // The OFFICIAL version — the file the platform runs, not a draft branch.
+    expect(sourceMock.readFileOnBranch).toHaveBeenCalledWith(
+      'target-company-state',
+      'Plugins/GTM/heyreach.tool',
+    );
+  });
+
+  it('shows the file verbatim — fences, comments, folding and all', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+    fireEvent.click(toggle());
+
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    // Byte for byte. Not "contains", not "matches after trimming".
+    expect(document.querySelector('pre')!.textContent).toBe(SOURCE);
+    expect(toggle()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('offers no way to edit what it shows', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+    fireEvent.click(toggle());
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+
+    expect(document.querySelector('textarea')).toBeNull();
+    expect(document.querySelector('pre')!.closest('[contenteditable]')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('opening it changes nothing above it', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+    fireEvent.click(toggle());
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+
+    expect(screen.getByText('Runs LinkedIn outreach campaigns.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'What it lets the assistant do' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Powers these skills' })).toBeInTheDocument();
+    expect(screen.getByText('Managed by the Admins.')).toBeInTheDocument();
+  });
+
+  it('shows a short message in place of the content when the file cannot be read, and retries on reopen', async () => {
+    sourceMock.readFileOnBranch.mockRejectedValueOnce(new Error('HTTP 404'));
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+
+    fireEvent.click(toggle());
+    expect(await screen.findByText("Couldn't load the source.")).toBeInTheDocument();
+    expect(document.querySelector('pre')).toBeNull();
+    // The page around it is untouched — a missing file is not a broken page.
+    expect(screen.getByRole('heading', { name: 'heyreach', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('Runs LinkedIn outreach campaigns.')).toBeInTheDocument();
+
+    fireEvent.click(toggle()); // close
+    fireEvent.click(toggle()); // open again — a failed read is never the final answer
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    expect(document.querySelector('pre')!.textContent).toBe(SOURCE);
+  });
+
+  it.each(['inline', 'http', 'mcp'] as const)('is present on a %s tool', async (type) => {
+    secretsMock.listToolSecrets.mockResolvedValue([{ ...GITHUB, type }]);
+    toolsMock.getToolDetail.mockResolvedValue({ ...DETAIL, type, capabilities: [] });
+
+    renderPage();
+    await screen.findByRole('heading', { name: 'heyreach', level: 1 });
+    expect(toggle()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('shows the mcp.json for a tool declared through a plugin, like every other type', async () => {
+    const MCP_JSON = '{\n  "mcpServers": {\n    "notion": { "url": "https://mcp.notion.com/mcp" }\n  }\n}\n';
+    secretsMock.listToolSecrets.mockResolvedValue([
+      { ...GITHUB, slug: 'notion', name: 'notion', type: 'mcp', path: 'Plugins/GTM/mcp.json' },
+    ]);
+    toolsMock.getToolDetail.mockResolvedValue({ ...DETAIL, slug: 'notion', name: 'notion' });
+    sourceMock.readFileOnBranch.mockResolvedValue(MCP_JSON);
+
+    renderPage({ slug: 'notion' });
+    await screen.findByRole('heading', { name: 'notion', level: 1 });
+    expect(screen.getByText('Plugins/GTM/mcp.json')).toBeInTheDocument();
+
+    fireEvent.click(toggle());
+    await waitFor(() => expect(document.querySelector('pre')).not.toBeNull());
+    expect(sourceMock.readFileOnBranch).toHaveBeenCalledWith(
+      'target-company-state',
+      'Plugins/GTM/mcp.json',
+    );
+    expect(document.querySelector('pre')!.textContent).toBe(MCP_JSON);
   });
 });

--- a/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/tool-page/ToolPage.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useId, useState, type ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../../../../lib/utils';
 import { Banner, Button, buttonClasses } from '../../../../shared/components';
 import { useToolPage } from '../../hooks/useToolPage';
+import { useToolSource } from '../../hooks/useToolSource';
 import { McpServerSection } from './McpServerSection';
 import { libraryHomeForItemPath, LIBRARY_ROOT } from '../../routes/library-paths';
 import { readOAuthFragment } from '../../utils/oauth-fragment';
@@ -175,6 +178,10 @@ export function ToolPage({
         Managed by the Admins.
       </div>
 
+      {/* Last, and for EVERY type: `path` is the file the platform reads to
+          make this tool — the `.tool`, or the plugin `mcp.json` that declares
+          the server. */}
+      <SourceSection path={tool.path} />
     </Article>
   );
 }
@@ -237,6 +244,66 @@ function PoweredSkillsSection({
           ))}
         </div>
       )}
+    </section>
+  );
+}
+
+/**
+ * The definition file, as text, behind a closed disclosure.
+ *
+ * A WINDOW, NOT AN EDITOR. The file is edited where files are edited; showing
+ * it here is what saves a developer the trip to the knowledge tree to answer
+ * "which template does this capability use" — and nothing in this section can
+ * change it.
+ *
+ * Closed by default is the mechanism, not just the default: the read hangs off
+ * the open state (`useToolSource`), so a reader who never opens the section
+ * never costs a file read, and everything above it renders the same whether
+ * the read succeeds, fails, or never happens.
+ */
+function SourceSection({ path }: { path: string }) {
+  const [open, setOpen] = useState(false);
+  const source = useToolSource(path, open);
+  const panelId = useId();
+
+  return (
+    <section className="mt-8">
+      <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={panelId}
+          className="flex items-center gap-1.5 text-label font-semibold uppercase text-ink-faint transition-colors hover:text-ink"
+        >
+          <ChevronRight
+            size={11}
+            className={cn('transition-transform duration-150', open && 'rotate-90')}
+          />
+          Source
+        </button>
+        <span className="min-w-0 truncate font-mono text-meta text-ink-faint" title={path}>
+          {path}
+        </span>
+      </div>
+
+      {/* Always in the tree, so `aria-controls` never points at nothing; the
+          CONTENT is what is conditional, which is what keeps the read lazy. */}
+      <div id={panelId} hidden={!open}>
+        {open &&
+          (source.status === 'error' ? (
+            <p className="mt-2.5 text-detail text-ink-muted">Couldn't load the source.</p>
+          ) : source.status === 'loaded' ? (
+            /* `whitespace-pre` and nothing else: the bytes are shown as the
+               platform stores them — no wrapping, reindenting or trimming.
+               Long lines scroll rather than fold. */
+            <pre className="mt-2.5 max-h-[32rem] select-text overflow-auto whitespace-pre rounded-lg border border-line bg-sunken p-3 font-mono text-meta leading-relaxed text-ink">
+              {source.content}
+            </pre>
+          ) : (
+            <p className="mt-2.5 text-detail text-ink-faint">Loading the source…</p>
+          ))}
+      </div>
     </section>
   );
 }

--- a/packages/core-frontend/src/modules/library/hooks/useToolSource.ts
+++ b/packages/core-frontend/src/modules/library/hooks/useToolSource.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import { readFileOnBranch } from '../../change-requests/services/change-requests.api';
+
+/**
+ * The raw bytes of a tool's definition file, read LAZILY — nothing is asked
+ * for until the caller says the source section is open.
+ *
+ * Why the official version and not the reader's current branch: the tool
+ * catalog is resolved against the default branch, so that is the file the
+ * platform actually runs AND the file whose read verdict admitted the tool to
+ * the page in the first place. Reading any other branch could 404 (or refuse)
+ * a file the listing just showed, and would show a draft as if it were live.
+ *
+ * Access needs no check here. `GET /api/workspace/:id/file` applies the same
+ * per-file read rule the tool listing filters on, against the same
+ * repo-relative path — so the endpoint is the authority, and a refusal simply
+ * lands as the error state.
+ *
+ * Not `useDefaultBranchFile`, which reads the same file from the same branch:
+ * that hook collapses "still reading" and "could not read" into one `null`,
+ * because its callers (a diff, an editor seed) render nothing either way. A
+ * disclosure must tell them apart — it owes the reader a visible answer when
+ * the read fails, and a silent spinner is not one.
+ */
+export type ToolSourceStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+export interface ToolSourceState {
+  status: ToolSourceStatus;
+  /** The file's text, verbatim — only on `loaded`. */
+  content: string | null;
+}
+
+const IDLE: ToolSourceState = { status: 'idle', content: null };
+const LOADING: ToolSourceState = { status: 'loading', content: null };
+const FAILED: ToolSourceState = { status: 'error', content: null };
+
+export function useToolSource(path: string | null, open: boolean): ToolSourceState {
+  const [state, setState] = useState<ToolSourceState>(IDLE);
+  const requestRef = useRef(0);
+
+  /**
+   * `null` while closed, which is what makes the fetch lazy and what makes a
+   * close-then-reopen RETRY: the key changes on both edges, so a failed read is
+   * never cached as the section's permanent answer.
+   *
+   * Reset during render against the previous key, not in the effect — the same
+   * rule `useToolPage` follows. An effect would repaint the previous tool's
+   * source under the new heading for a frame, and the synchronous setState is
+   * what `react-hooks/set-state-in-effect` flags.
+   */
+  const key = open && path ? path : null;
+  const [seenKey, setSeenKey] = useState(key);
+  if (key !== seenKey) {
+    setSeenKey(key);
+    setState(key === null ? IDLE : LOADING);
+  }
+
+  useEffect(() => {
+    // Bumped on every pass, closes included, so an answer for a path the
+    // reader has already navigated (or closed) away from can never land.
+    const request = ++requestRef.current;
+    if (key === null) return;
+
+    readFileOnBranch(DEFAULT_BRANCH, key)
+      .then((content) => {
+        if (requestRef.current === request) setState({ status: 'loaded', content });
+      })
+      .catch(() => {
+        // Deliberately not the backend's message: a read refusal and a missing
+        // file must read the same, the way the page's not-found state does.
+        if (requestRef.current === request) setState(FAILED);
+      });
+  }, [key]);
+
+  return state;
+}


### PR DESCRIPTION
Ticket: `Data/Engineering/Knowledge/Hexis/Tickets/Show-Tool-Source-On-Tool-Page.md`

## Summary

Adds a collapsed, read-only "Source" section at the bottom of a tool's page that, once opened, shows the tool's declaring file (`.tool`, or the plugin's `mcp.json` for an mcp-declared tool) verbatim in a monospace block, with the file's knowledge-base path shown beside the toggle.

- **Lazy, closed by default**: the file is fetched only when the section is opened (`useToolSource` gates the read on the open flag), so a reader who never opens it costs no extra request, and everything above the section renders identically whether the read succeeds, fails, or never happens.
- **The official version, byte for byte**: reads `tool.path` on the default branch via `readFileOnBranch`, rendered into a `<pre>` with no reformatting, reordering or summarizing — `---` fences, comments and unexpanded `${VAR}`s included.
- **Read-only**: no editing affordance, nothing on the page writes the file.
- **Same access rule as opening the file directly**: the read re-applies the same per-file access check the tool listing itself uses, so a refusal simply lands as the section's error state, indistinguishable from a missing file.
- **Works for every tool type** the page renders — inline, http, and mcp (including an mcp tool declared through a plugin's `mcp.json`, for which the section shows that declaration's file).

Tests cover: closed by default, verbatim content on open, the error state, and lazy loading (no fetch until opened, then exactly once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsed, read-only Source section to the bottom of a tool's page that shows the tool's defining file (the `.tool` file, or a plugin's `mcp.json` for MCP-declared tools) verbatim.

- The file is fetched only when the section is opened, so closing it costs no extra request.
- A failed read shows a short error message, and the page around it renders the same whether the read succeeds, fails, or never happens.
- The read applies the same per-file access rule the tool listing uses, so a refusal just lands as the section's error state.

<sup>Written for commit 2d696456e67ab1765aaf052386922e78fc6ce9e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

