### PR TITLE
Name the MCP server "Skills, Tools and Knowledge" and add an Add to ChatGPT button

### DIFF
--- a/packages/core-frontend/src/modules/onboarding/__tests__/onboarding.test.tsx
+++ b/packages/core-frontend/src/modules/onboarding/__tests__/onboarding.test.tsx
@@ -343,7 +343,7 @@ describe('WelcomePage', () => {
     expect(screen.getByText(/\/api\/mcp$/)).toBeInTheDocument();
     expect(screen.queryByText(/mcpServers/)).toBeNull();
     await userEvent.click(screen.getByRole('radio', { name: 'Other' }));
-    expect(screen.getByText(/knowledge-base/)).toBeInTheDocument();
+    expect(screen.getByText(/skills-tools-knowledge/)).toBeInTheDocument();
   });
 
   /**
@@ -388,7 +388,7 @@ describe('WelcomePage', () => {
       const href = new URL(link.getAttribute('href')!);
       expect(href.origin + href.pathname).toBe('https://claude.ai/customize/connectors');
       expect(href.searchParams.get('connectorUrl')).toBe('https://kb.acme.com/api/mcp');
-      expect(href.searchParams.get('connectorName')).toBe('Knowledge — kb.acme.com');
+      expect(href.searchParams.get('connectorName')).toBe('Skills, Tools and Knowledge — kb.acme.com');
     });
 
     /**
@@ -428,6 +428,36 @@ describe('WelcomePage', () => {
       expect(screen.queryByRole('link', { name: 'Add to Claude' })).toBeNull();
       await userEvent.click(screen.getByRole('radio', { name: 'Other' }));
       expect(screen.queryByRole('link', { name: 'Add to Claude' })).toBeNull();
+    });
+
+    /**
+     * ChatGPT gets its own button, on its own option only. It cannot prefill
+     * anything — ChatGPT has no such link — so it opens the settings pane and
+     * the hint beside it spells out the name to type, which is what stops a
+     * dozen employees each inventing their own.
+     */
+    it('offers Add to ChatGPT on the ChatGPT option alone, with the name to type', async () => {
+      configureMcpUrl('https://kb.acme.com/api/mcp');
+      mountPage();
+      expect(screen.queryByRole('link', { name: 'Add to ChatGPT' })).toBeNull();
+      await userEvent.click(screen.getByRole('radio', { name: 'Claude' }));
+      expect(screen.queryByRole('link', { name: 'Add to ChatGPT' })).toBeNull();
+      await userEvent.click(screen.getByRole('radio', { name: 'ChatGPT' }));
+      const link = screen.getByRole('link', { name: 'Add to ChatGPT' });
+      expect(new URL(link.getAttribute('href')!).origin).toBe('https://chatgpt.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(screen.getByText(/Skills, Tools and Knowledge/)).toBeInTheDocument();
+      // …and the URL to paste is still the copy block.
+      expect(screen.getByText('https://kb.acme.com/api/mcp')).toBeInTheDocument();
+    });
+
+    it('offers no ChatGPT button on a localhost deployment either', async () => {
+      configureMcpUrl('http://localhost:3001/api/mcp');
+      mountPage();
+      await userEvent.click(screen.getByRole('radio', { name: 'ChatGPT' }));
+      expect(screen.queryByRole('link', { name: 'Add to ChatGPT' })).toBeNull();
+      expect(screen.getByText('http://localhost:3001/api/mcp')).toBeInTheDocument();
     });
 
     // Opening claude.ai must not hand it a handle on this window.

--- a/packages/core-frontend/src/modules/onboarding/agent-clients.ts
+++ b/packages/core-frontend/src/modules/onboarding/agent-clients.ts
@@ -1,4 +1,9 @@
-import { hexisMcpJsonSnippet, jsonConfigSnippet, workspaceBaseUrl } from '../../shared/mcp';
+import {
+  MCP_DISPLAY_NAME,
+  hexisMcpJsonSnippet,
+  jsonConfigSnippet,
+  workspaceBaseUrl,
+} from '../../shared/mcp';
 
 /**
  * The ways an agent connects, named by PRODUCT rather than surface —
@@ -53,8 +58,9 @@ export const AGENT_CLIENTS: AgentClient[] = [
     id: 'chatgpt',
     label: 'ChatGPT',
     // Developer mode first: it is off by default, and every "Create" button
-    // someone hunts for is behind it.
-    hint: 'Settings → Apps & Connectors → Advanced → turn on Developer mode, then Create and paste this.',
+    // someone hunts for is behind it. The name is spelled out because, unlike
+    // Claude, ChatGPT has no link that prefills it.
+    hint: `Settings → Apps & Connectors → Advanced → turn on Developer mode, then Create: name it “${MCP_DISPLAY_NAME}” and paste this.`,
     snip: (url) => url,
   },
   {

--- a/packages/core-frontend/src/modules/onboarding/components/WelcomePage.tsx
+++ b/packages/core-frontend/src/modules/onboarding/components/WelcomePage.tsx
@@ -10,7 +10,7 @@ import { pathForLibraryFilter } from '../../library/routes/library-paths';
 import { useAppRegistry } from '../../../core/registry';
 import { displayFirstName } from '../../library/utils/personal-plugin';
 import { setSidebarCollapsed } from '../../layout/state/sidebar';
-import { ClaudeInstallLink, mcpEndpointUrl } from '../../../shared/mcp';
+import { ChatGptInstallLink, ClaudeInstallLink, mcpEndpointUrl } from '../../../shared/mcp';
 import { AGENT_CLIENTS, type AgentClient } from '../agent-clients';
 import { useOnboarding } from '../state/onboarding';
 import { useWelcomeRouteState } from '../welcome-state';
@@ -314,13 +314,15 @@ export function WelcomePage() {
 
         <p className="mt-2.5 text-meta leading-normal text-ink-faint">{client.hint}</p>
 
-        {/* Claude only, because Claude is the only client with an install
-            link — and it renders nothing at all when this deployment is one
-            Anthropic could not reach, rather than offering a shortcut that
-            dead-ends. No `showHint`: the reader here is a new employee, and
-            naming an env var they cannot change is noise. The copy block
-            below is the route that always works. */}
+        {/* The web assistants only: Claude's link prefills the connector,
+            ChatGPT's opens the settings pane it is created in. Both render
+            nothing at all when this deployment is one their vendor could not
+            reach, rather than offering a shortcut that dead-ends. No
+            `showHint`: the reader here is a new employee, and naming an env
+            var they cannot change is noise. The copy block below is the route
+            that always works. */}
         {client.id === 'claude' && <ClaudeInstallLink mcpUrl={mcpUrl} className="mt-3.5" />}
+        {client.id === 'chatgpt' && <ChatGptInstallLink mcpUrl={mcpUrl} className="mt-3.5" />}
 
         {/* The copy rides the block it copies. */}
         <div className="relative mt-3.5">

--- a/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
@@ -85,14 +85,14 @@ describe('the interactive tab: local first, hosted second, each with its own add
 
     // 1. the Claude Code one-liner
     expect(values).toContain(
-      `claude mcp add --transport http knowledge-base ${PUBLIC_URL}`,
+      `claude mcp add --transport http skills-tools-knowledge ${PUBLIC_URL}`,
     );
     // 2. the bare URL for claude.ai / Claude Desktop
     expect(values).toContain(PUBLIC_URL);
     // 3. the JSON config for everything else — the LOCAL section renders a
     // `mcpServers` block too, so pick the hosted one by its server name.
-    const json = values.find((v) => v.includes('knowledge-base') && v.includes('mcpServers'));
-    expect(JSON.parse(json!).mcpServers['knowledge-base'].url).toBe(PUBLIC_URL);
+    const json = values.find((v) => v.includes('"type": "http"') && v.includes('mcpServers'));
+    expect(JSON.parse(json!).mcpServers['skills-tools-knowledge'].url).toBe(PUBLIC_URL);
   });
 
   /**
@@ -118,10 +118,10 @@ describe('the interactive tab: local first, hosted second, each with its own add
 
     const values = snippets();
     expect(values).toContain(
-      `claude mcp add knowledge --env HEXIS_URL="${window.location.origin}" -- npx -y @bevel-software/hexis-mcp`,
+      `claude mcp add skills-tools-knowledge --env HEXIS_URL="${window.location.origin}" -- npx -y @bevel-software/hexis-mcp`,
     );
-    const json = values.find((v) => v.includes('mcpServers') && v.includes('"knowledge"'));
-    const parsed = JSON.parse(json!).mcpServers['knowledge'];
+    const json = values.find((v) => v.includes('mcpServers') && v.includes('"command"'));
+    const parsed = JSON.parse(json!).mcpServers['skills-tools-knowledge'];
     expect(parsed.args).toEqual(['-y', '@bevel-software/hexis-mcp']);
     expect(parsed.env.HEXIS_URL).toBe(window.location.origin);
     // Keyless = interactive: the browser-sign-in mode carries no key env.
@@ -175,7 +175,7 @@ describe('the key-bearing snippets quote the deployment too', () => {
 
     // 4. the Claude Code one-liner, with the key
     expect(values).toContain(
-      `claude mcp add --transport http knowledge-base ${PUBLIC_URL} --header "Authorization: Bearer ${KEY}"`,
+      `claude mcp add --transport http skills-tools-knowledge ${PUBLIC_URL} --header "Authorization: Bearer ${KEY}"`,
     );
     // 5. the Langdock field list
     expect(values).toContain(
@@ -183,7 +183,7 @@ describe('the key-bearing snippets quote the deployment too', () => {
     );
     // 6. the JSON config, with the key
     const json = values.find((v) => v.includes('mcpServers') && v.includes('headers'));
-    const parsed = JSON.parse(json!).mcpServers['knowledge-base'];
+    const parsed = JSON.parse(json!).mcpServers['skills-tools-knowledge'];
     expect(parsed.url).toBe(PUBLIC_URL);
     expect(parsed.headers.Authorization).toBe(`Bearer ${KEY}`);
   });
@@ -209,11 +209,11 @@ describe('the key-bearing snippets quote the deployment too', () => {
 
     // 7. the Claude Code stdio one-liner
     expect(values).toContain(
-      `claude mcp add knowledge --env HEXIS_URL="${window.location.origin}" --env HEXIS_CONNECTION_KEY="${KEY}" -- npx -y @bevel-software/hexis-mcp`,
+      `claude mcp add skills-tools-knowledge --env HEXIS_URL="${window.location.origin}" --env HEXIS_CONNECTION_KEY="${KEY}" -- npx -y @bevel-software/hexis-mcp`,
     );
     // 8. the JSON config that spawns the package
-    const json = values.find((v) => v.includes('mcpServers') && v.includes('"knowledge"'));
-    const parsed = JSON.parse(json!).mcpServers['knowledge'];
+    const json = values.find((v) => v.includes('mcpServers') && v.includes('"command"'));
+    const parsed = JSON.parse(json!).mcpServers['skills-tools-knowledge'];
     expect(parsed.args).toEqual(['-y', '@bevel-software/hexis-mcp']);
     expect(parsed.env.HEXIS_URL).toBe(window.location.origin);
     expect(parsed.env.HEXIS_CONNECTION_KEY).toBe(KEY);
@@ -246,7 +246,7 @@ describe('the one-click install link', () => {
     expect(href.origin + href.pathname).toBe('https://claude.ai/customize/connectors');
     expect(href.searchParams.get('modal')).toBe('add-custom-connector');
     expect(href.searchParams.get('connectorUrl')).toBe(PUBLIC_URL);
-    expect(href.searchParams.get('connectorName')).toBe('Knowledge — kb.acme.com');
+    expect(href.searchParams.get('connectorName')).toBe('Skills, Tools and Knowledge — kb.acme.com');
   });
 
   it('opens in a new tab without handing Claude a window reference', () => {
@@ -254,6 +254,26 @@ describe('the one-click install link', () => {
     const link = screen.getByRole('link', { name: 'Add to Claude' });
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  /**
+   * ChatGPT sits beside Claude, with the honest difference: no prefill
+   * exists, so the button opens the settings pane and the copy under it
+   * names the connector to type. Same gate — an endpoint Anthropic cannot
+   * reach is one OpenAI cannot reach.
+   */
+  it('offers Add to ChatGPT beside it, naming what to call the connector', () => {
+    mount(PUBLIC_URL);
+    const link = screen.getByRole('link', { name: 'Add to ChatGPT' });
+    expect(new URL(link.getAttribute('href')!).origin).toBe('https://chatgpt.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByText('Skills, Tools and Knowledge')).toBeInTheDocument();
+  });
+
+  it('offers no ChatGPT button on a localhost deployment', () => {
+    mount(LOCALHOST_URL);
+    expect(screen.queryByRole('link', { name: 'Add to ChatGPT' })).toBeNull();
   });
 
   /**

--- a/packages/core-frontend/src/shared/mcp/ChatGptInstallLink.tsx
+++ b/packages/core-frontend/src/shared/mcp/ChatGptInstallLink.tsx
@@ -1,0 +1,45 @@
+import { ExternalLink } from 'lucide-react';
+import { buttonClasses } from '../components';
+import { canDeepLink, chatgptInstallUrl } from './connect-snippets';
+
+/**
+ * The ChatGPT counterpart of {@link ClaudeInstallLink} — with one honest
+ * difference. Claude's link PREFILLS the connector; ChatGPT publishes no
+ * such link, so this one only opens the settings pane where a custom MCP
+ * server is created. The person still turns on Developer mode, presses
+ * Create, types the name and pastes the URL. It is a shortcut through a menu
+ * nobody finds on the first try, not a grant of anything — which is why it
+ * carries no warning, and why every surface that shows it also shows the
+ * name and the URL to paste.
+ *
+ * Same gate as the Claude link: ChatGPT fetches the server from OpenAI's
+ * infrastructure, so an endpoint Anthropic could not reach (plain http,
+ * localhost, private ranges — see `canDeepLink`) is one OpenAI cannot reach
+ * either, and a button that opens a dialog you cannot complete is worse than
+ * none. No `showHint` variant: on the one surface that wants the operator
+ * hint, this renders next to the Claude link, whose hint already names both
+ * products and the variable that fixes them.
+ */
+export function ChatGptInstallLink({
+  mcpUrl,
+  className,
+}: {
+  mcpUrl: string;
+  /** Spacing belongs to the caller, ON the element — see `ClaudeInstallLink`. */
+  className?: string;
+}) {
+  if (!canDeepLink(mcpUrl)) return null;
+
+  return (
+    <a
+      href={chatgptInstallUrl()}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={buttonClasses({ variant: 'outline', size: 'sm', className })}
+    >
+      Add to ChatGPT
+      {/* Decoration: the link's own text is its accessible name. */}
+      <ExternalLink size={12} className="opacity-70" aria-hidden="true" />
+    </a>
+  );
+}

--- a/packages/core-frontend/src/shared/mcp/ClaudeInstallLink.tsx
+++ b/packages/core-frontend/src/shared/mcp/ClaudeInstallLink.tsx
@@ -65,9 +65,9 @@ export function ClaudeInstallLink({
          new copy goes on-scale even when it sits beside copy that is not. */
       <p className={cn('text-meta text-ink-muted leading-snug', className)}>
         One-click connect is off because this deployment&rsquo;s public address is{' '}
-        <code className="font-mono">{withoutCredentials(mcpUrl)}</code>, which Claude cannot reach from the
-        internet. Set <code className="font-mono">PUBLIC_BACKEND_URL</code> to the https
-        address people actually use to turn it on. The URL below works either way.
+        <code className="font-mono">{withoutCredentials(mcpUrl)}</code>, which Claude and ChatGPT cannot
+        reach from the internet. Set <code className="font-mono">PUBLIC_BACKEND_URL</code> to the
+        https address people actually use to turn it on. The URL below works either way.
       </p>
     );
   }

--- a/packages/core-frontend/src/shared/mcp/ConnectionInstructions.tsx
+++ b/packages/core-frontend/src/shared/mcp/ConnectionInstructions.tsx
@@ -1,11 +1,12 @@
 import { CopyBlock } from './CopyBlock';
 import { ClaudeInstallLink } from './ClaudeInstallLink';
-import { claudeCodeCommand, jsonConfigSnippet } from './connect-snippets';
+import { ChatGptInstallLink } from './ChatGptInstallLink';
+import { MCP_DISPLAY_NAME, claudeCodeCommand, jsonConfigSnippet } from './connect-snippets';
 
 /**
  * How to point an interactive agent at this workspace: the three
- * no-key connection configs, plus the one-click Claude install link when the
- * deployment is reachable enough for it to work.
+ * no-key connection configs, plus the Claude and ChatGPT install links when
+ * the deployment is reachable enough for them to work.
  *
  * Its own component rather than a block inside `ExternalAgentAccessPage`
  * because that page fetches external API keys on mount. Testing "does the
@@ -24,17 +25,22 @@ export function ConnectionInstructions({ mcpUrl }: { mcpUrl: string }) {
     <>
       <CopyBlock label="Connect Claude Code" value={claudeCodeCommand(mcpUrl)} rows={2} />
       <div>
-        <div className="text-xs font-medium text-ink mb-1">claude.ai / Claude Desktop</div>
-        {/* The button first, then the manual route underneath — the fallback
-            has to stay visible, because one-click is unavailable on any
-            deployment Claude cannot reach and the copy-paste URL is the only
-            thing that always works. */}
-        <div className="mb-1.5">
+        <div className="text-xs font-medium text-ink mb-1">claude.ai, Claude Desktop and ChatGPT</div>
+        {/* The buttons first, then the manual routes underneath — the fallback
+            has to stay visible, because the buttons are unavailable on any
+            deployment the assistants cannot reach, and the copy-paste URL is
+            the only thing that always works. ChatGPT's button only opens the
+            settings pane (no prefill exists), so the name and URL to type sit
+            right below it. */}
+        <div className="mb-1.5 flex flex-wrap items-center gap-2">
           <ClaudeInstallLink mcpUrl={mcpUrl} showHint />
+          <ChatGptInstallLink mcpUrl={mcpUrl} />
         </div>
         <p className="text-[11px] text-ink-muted mb-1 leading-snug">
-          Or add it by hand: Settings → Connectors → Add custom connector, then paste this
-          URL. When asked to authorize, your browser opens this app to finish connecting.
+          Or add it by hand — Claude: Settings → Connectors → Add custom connector. ChatGPT:
+          Settings → Apps &amp; Connectors → Advanced → turn on Developer mode, then Create.
+          Name it <span className="font-medium">{MCP_DISPLAY_NAME}</span> and paste this URL.
+          When asked to authorize, your browser opens this app to finish connecting.
         </p>
         <CopyBlock label={null} value={mcpUrl} rows={1} />
       </div>

--- a/packages/core-frontend/src/shared/mcp/__tests__/ChatGptInstallLink.test.tsx
+++ b/packages/core-frontend/src/shared/mcp/__tests__/ChatGptInstallLink.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChatGptInstallLink } from '../ChatGptInstallLink';
+
+/**
+ * Two states, not three: a live button on a reachable address and nothing on
+ * a dead one. There is no hint variant — the Claude link next to it on the
+ * settings page carries the operator hint for both.
+ */
+describe('ChatGptInstallLink', () => {
+  it('opens ChatGPT’s connector settings for a reachable https address', () => {
+    render(<ChatGptInstallLink mcpUrl="https://kb.acme.com/api/mcp" />);
+    const link = screen.getByRole('link', { name: 'Add to ChatGPT' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('chatgpt.com'));
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  /**
+   * ChatGPT has no prefill link, so the endpoint must NOT be smuggled into
+   * the href on the hope that some parameter picks it up — an address in a
+   * URL ChatGPT does not read is a leak with no upside.
+   */
+  it('does not put the endpoint in the href', () => {
+    render(<ChatGptInstallLink mcpUrl="https://kb.acme.com/api/mcp" />);
+    const href = screen.getByRole('link', { name: 'Add to ChatGPT' }).getAttribute('href')!;
+    expect(href).not.toContain('kb.acme.com');
+  });
+
+  it('renders nothing for an address OpenAI could not reach', () => {
+    const { container } = render(<ChatGptInstallLink mcpUrl="http://localhost:3001/api/mcp" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/core-frontend/src/shared/mcp/__tests__/connect-snippets.test.ts
+++ b/packages/core-frontend/src/shared/mcp/__tests__/connect-snippets.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
+  MCP_DISPLAY_NAME,
+  MCP_SERVER_KEY,
   canDeepLink,
+  chatgptInstallUrl,
   claudeCodeCommand,
   claudeInstallUrl,
   configureMcpUrl,
@@ -325,9 +328,42 @@ describe('claudeInstallUrl: the documented install link', () => {
   });
 });
 
+describe('chatgptInstallUrl: the settings pane, since ChatGPT prefills nothing', () => {
+  it('opens ChatGPT’s connector settings over https', () => {
+    const link = chatgptInstallUrl();
+    expect(link.startsWith('https://chatgpt.com/')).toBe(true);
+    expect(link).toContain('settings');
+  });
+});
+
+describe('the two spellings of the name', () => {
+  // Humans read this one: it is what the connector list and the ChatGPT
+  // Create dialog show, so it is the product's words, not a slug.
+  it('shows people "Skills, Tools and Knowledge"', () => {
+    expect(MCP_DISPLAY_NAME).toBe('Skills, Tools and Knowledge');
+  });
+
+  /**
+   * Config files read this one. Claude Code derives every tool name from it
+   * (`mcp__<server>__<tool>`), so a space or a comma here would surface in
+   * an identifier — and the same key must serve the hosted endpoint and the
+   * local server, so nothing drifts between the two families of snippets.
+   */
+  it('gives config files a plain slug that every snippet shares', () => {
+    expect(MCP_SERVER_KEY).toMatch(/^[a-z0-9-]+$/);
+    const URL_UNDER_TEST = 'https://kb.acme.com/api/mcp';
+    expect(claudeCodeCommand(URL_UNDER_TEST)).toContain(` ${MCP_SERVER_KEY} `);
+    expect(Object.keys(JSON.parse(jsonConfigSnippet(URL_UNDER_TEST)).mcpServers)).toEqual([MCP_SERVER_KEY]);
+    expect(hexisMcpClaudeCommand('https://kb.acme.com')).toContain(`claude mcp add ${MCP_SERVER_KEY} `);
+    expect(Object.keys(JSON.parse(hexisMcpJsonSnippet('https://kb.acme.com')).mcpServers)).toEqual([
+      MCP_SERVER_KEY,
+    ]);
+  });
+});
+
 describe('connectorName: what it is called in a connector list', () => {
   it('names the product and the deployment', () => {
-    expect(connectorName('https://kb.acme.com/api/mcp')).toBe('Knowledge — kb.acme.com');
+    expect(connectorName('https://kb.acme.com/api/mcp')).toBe('Skills, Tools and Knowledge — kb.acme.com');
   });
 
   /**
@@ -343,11 +379,11 @@ describe('connectorName: what it is called in a connector list', () => {
 
   // `host`, not `hostname` — two instances on one machine differ only by port.
   it('keeps a non-default port', () => {
-    expect(connectorName('https://kb.acme.com:8443/api/mcp')).toBe('Knowledge — kb.acme.com:8443');
+    expect(connectorName('https://kb.acme.com:8443/api/mcp')).toBe('Skills, Tools and Knowledge — kb.acme.com:8443');
   });
 
   it('still names something when the URL is unparseable', () => {
-    expect(connectorName('not a url')).toBe('Knowledge');
+    expect(connectorName('not a url')).toBe('Skills, Tools and Knowledge');
   });
 });
 
@@ -357,13 +393,13 @@ describe('snippets: one builder per client, keyed or not', () => {
 
   it('builds the Claude Code command without a key', () => {
     expect(claudeCodeCommand(URL_UNDER_TEST)).toBe(
-      `claude mcp add --transport http knowledge-base ${URL_UNDER_TEST}`,
+      `claude mcp add --transport http skills-tools-knowledge ${URL_UNDER_TEST}`,
     );
   });
 
   it('appends the Authorization header when there is a key', () => {
     expect(claudeCodeCommand(URL_UNDER_TEST, KEY)).toBe(
-      `claude mcp add --transport http knowledge-base ${URL_UNDER_TEST} --header "Authorization: Bearer ${KEY}"`,
+      `claude mcp add --transport http skills-tools-knowledge ${URL_UNDER_TEST} --header "Authorization: Bearer ${KEY}"`,
     );
   });
 
@@ -373,16 +409,16 @@ describe('snippets: one builder per client, keyed or not', () => {
    */
   it('omits headers entirely from the keyless JSON config', () => {
     const parsed = JSON.parse(jsonConfigSnippet(URL_UNDER_TEST));
-    expect(parsed.mcpServers['knowledge-base']).toEqual({
+    expect(parsed.mcpServers['skills-tools-knowledge']).toEqual({
       type: 'http',
       url: URL_UNDER_TEST,
     });
-    expect('headers' in parsed.mcpServers['knowledge-base']).toBe(false);
+    expect('headers' in parsed.mcpServers['skills-tools-knowledge']).toBe(false);
   });
 
   it('carries the key in the JSON config when there is one', () => {
     const parsed = JSON.parse(jsonConfigSnippet(URL_UNDER_TEST, KEY));
-    expect(parsed.mcpServers['knowledge-base']).toEqual({
+    expect(parsed.mcpServers['skills-tools-knowledge']).toEqual({
       type: 'http',
       url: URL_UNDER_TEST,
       headers: { Authorization: `Bearer ${KEY}` },
@@ -396,7 +432,7 @@ describe('snippets: one builder per client, keyed or not', () => {
    */
   it('escapes shell metacharacters in the key for the Claude Code command', () => {
     expect(claudeCodeCommand(URL_UNDER_TEST, 'a"b$c`d\\e')).toBe(
-      `claude mcp add --transport http knowledge-base ${URL_UNDER_TEST} --header "Authorization: Bearer a\\"b\\$c\\\`d\\\\e"`,
+      `claude mcp add --transport http skills-tools-knowledge ${URL_UNDER_TEST} --header "Authorization: Bearer a\\"b\\$c\\\`d\\\\e"`,
     );
   });
 
@@ -404,7 +440,7 @@ describe('snippets: one builder per client, keyed or not', () => {
   // the client reading the file gets the exact bytes back.
   it('does not shell-escape the key in the JSON config', () => {
     const parsed = JSON.parse(jsonConfigSnippet(URL_UNDER_TEST, 'a"b$c'));
-    expect(parsed.mcpServers['knowledge-base'].headers.Authorization).toBe('Bearer a"b$c');
+    expect(parsed.mcpServers['skills-tools-knowledge'].headers.Authorization).toBe('Bearer a"b$c');
   });
 
   it('spells the Langdock fields out separately', () => {
@@ -430,7 +466,7 @@ describe('snippets: one builder per client, keyed or not', () => {
 
     it('builds a JSON config that spawns the package with the key', () => {
       const parsed = JSON.parse(hexisMcpJsonSnippet(BASE, KEY));
-      expect(parsed.mcpServers['knowledge']).toEqual({
+      expect(parsed.mcpServers['skills-tools-knowledge']).toEqual({
         command: 'npx',
         args: ['-y', '@bevel-software/hexis-mcp'],
         env: {
@@ -448,7 +484,7 @@ describe('snippets: one builder per client, keyed or not', () => {
      */
     it('omits the key env entirely when no key was minted — keyless selects browser sign-in', () => {
       const parsed = JSON.parse(hexisMcpJsonSnippet(BASE));
-      expect(parsed.mcpServers['knowledge'].env).toEqual({
+      expect(parsed.mcpServers['skills-tools-knowledge'].env).toEqual({
         HEXIS_URL: BASE,
       });
       expect(hexisMcpJsonSnippet(BASE)).not.toContain(KEY);
@@ -456,7 +492,7 @@ describe('snippets: one builder per client, keyed or not', () => {
 
     it('builds the Claude Code command as a stdio add with both env values', () => {
       expect(hexisMcpClaudeCommand(BASE, KEY)).toBe(
-        `claude mcp add knowledge --env HEXIS_URL="${BASE}" --env HEXIS_CONNECTION_KEY="${KEY}" -- npx -y @bevel-software/hexis-mcp`,
+        `claude mcp add skills-tools-knowledge --env HEXIS_URL="${BASE}" --env HEXIS_CONNECTION_KEY="${KEY}" -- npx -y @bevel-software/hexis-mcp`,
       );
     });
 

--- a/packages/core-frontend/src/shared/mcp/connect-snippets.ts
+++ b/packages/core-frontend/src/shared/mcp/connect-snippets.ts
@@ -29,6 +29,25 @@
 const MCP_PATH = '/api/mcp';
 
 /**
+ * What this workspace is called when it shows up in an agent's server list.
+ * Two spellings of one name, because the two places it goes have different
+ * rules:
+ *
+ * - {@link MCP_DISPLAY_NAME} is for humans: the connector name claude.ai
+ *   shows, and what someone types into ChatGPT's "Create" dialog. Spaces and
+ *   punctuation are fine there.
+ * - {@link MCP_SERVER_KEY} is for config files: the `mcpServers` key and the
+ *   `claude mcp add <name>` argument. Clients derive identifiers from it —
+ *   Claude Code names every tool `mcp__<server>__<tool>` — so it has to be a
+ *   plain slug. The same key serves the hosted endpoint and the local server:
+ *   they are one workspace, and nobody adds both to one client.
+ *
+ * Everything below spells the name through these two; nothing re-types it.
+ */
+export const MCP_DISPLAY_NAME = 'Skills, Tools and Knowledge';
+export const MCP_SERVER_KEY = 'skills-tools-knowledge';
+
+/**
  * The deployment's own answer, from `GET /api/config`. Module-global because
  * it is a property of the deployment rather than of any component, and it is
  * settled once during boot — the same shape as the branch model next door.
@@ -279,9 +298,9 @@ function isPrivateIpv6(bracketed: string): boolean {
  */
 export function connectorName(mcpUrl: string): string {
   try {
-    return `Knowledge — ${new URL(mcpUrl).host}`;
+    return `${MCP_DISPLAY_NAME} — ${new URL(mcpUrl).host}`;
   } catch {
-    return 'Knowledge';
+    return MCP_DISPLAY_NAME;
   }
 }
 
@@ -308,6 +327,22 @@ export function claudeInstallUrl(mcpUrl: string, name: string): string {
   return `${CLAUDE_ADD_CONNECTOR}?${params}`;
 }
 
+/**
+ * Where ChatGPT keeps its connector settings — the pane whose "Advanced"
+ * section holds the Developer mode toggle and, once it is on, the "Create"
+ * button for a custom MCP server.
+ *
+ * Unlike Claude, ChatGPT publishes no install link: there is no query
+ * parameter that prefills a connector's name or URL. So this is a shortcut to
+ * the right settings pane and nothing more — the person still types the name
+ * and pastes the endpoint, which is why every surface that offers this link
+ * shows both right beside it. The settings pane is a hash route, so it takes
+ * no parameters and there is nothing to encode.
+ */
+export function chatgptInstallUrl(): string {
+  return 'https://chatgpt.com/#settings/Connectors';
+}
+
 /* ------------------------------------------------------------------ *
  * The snippets themselves. One builder per client, each taking the URL
  * so no caller ever re-derives it, and an optional bearer token for the
@@ -326,7 +361,7 @@ function escapeForDoubleQuotes(value: string): string {
 
 /** The `claude mcp add` one-liner, with the key appended when there is one. */
 export function claudeCodeCommand(mcpUrl: string, bearer?: string): string {
-  const base = `claude mcp add --transport http knowledge-base ${mcpUrl}`;
+  const base = `claude mcp add --transport http ${MCP_SERVER_KEY} ${mcpUrl}`;
   return bearer ? `${base} --header "Authorization: Bearer ${escapeForDoubleQuotes(bearer)}"` : base;
 }
 
@@ -335,7 +370,7 @@ export function jsonConfigSnippet(mcpUrl: string, bearer?: string): string {
   return JSON.stringify(
     {
       mcpServers: {
-        'knowledge-base': {
+        [MCP_SERVER_KEY]: {
           type: 'http',
           url: mcpUrl,
           ...(bearer ? { headers: { Authorization: `Bearer ${bearer}` } } : {}),
@@ -394,7 +429,7 @@ export function hexisMcpJsonSnippet(baseUrl: string, bearer?: string): string {
   return JSON.stringify(
     {
       mcpServers: {
-        knowledge: {
+        [MCP_SERVER_KEY]: {
           command: 'npx',
           args: ['-y', '@bevel-software/hexis-mcp'],
           env: {
@@ -421,7 +456,7 @@ export function hexisMcpJsonSnippet(baseUrl: string, bearer?: string): string {
  */
 export function hexisMcpClaudeCommand(baseUrl: string, bearer?: string): string {
   return (
-    `claude mcp add knowledge` +
+    `claude mcp add ${MCP_SERVER_KEY}` +
     ` --env HEXIS_URL="${escapeForDoubleQuotes(baseUrl)}"` +
     (bearer ? ` --env HEXIS_CONNECTION_KEY="${escapeForDoubleQuotes(bearer)}"` : '') +
     ` -- npx -y @bevel-software/hexis-mcp`

--- a/packages/core-frontend/src/shared/mcp/index.ts
+++ b/packages/core-frontend/src/shared/mcp/index.ts
@@ -12,7 +12,10 @@
  * Tests import it straight from `./connect-snippets`, as `test-setup.ts` does.
  */
 export {
+  MCP_DISPLAY_NAME,
+  MCP_SERVER_KEY,
   canDeepLink,
+  chatgptInstallUrl,
   claudeCodeCommand,
   claudeInstallUrl,
   configureMcpUrl,
@@ -26,6 +29,7 @@ export {
 } from './connect-snippets';
 
 export { ClaudeInstallLink } from './ClaudeInstallLink';
+export { ChatGptInstallLink } from './ChatGptInstallLink';
 export { ConnectionInstructions } from './ConnectionInstructions';
 export { CopyBlock } from './CopyBlock';
 export { useCopyFeedback } from './useCopyFeedback';


### PR DESCRIPTION
## What

- Every connection setup (welcome-page picker, External agent access page — both drawers, the key-reveal modal, `ConnectionInstructions`) now names the MCP server **Skills, Tools and Knowledge** instead of *Knowledge*.
- A new **Add to ChatGPT** button sits next to **Add to Claude** on the welcome page (ChatGPT option) and the settings page.

## How

The name is spelled once, in `shared/mcp/connect-snippets.ts`, in two forms:

| constant | value | used for |
|---|---|---|
| `MCP_DISPLAY_NAME` | `Skills, Tools and Knowledge` | the claude.ai connector name (`Skills, Tools and Knowledge — <host>`), and the name the ChatGPT hints tell people to type |
| `MCP_SERVER_KEY` | `skills-tools-knowledge` | the `mcpServers` key and the `claude mcp add <name>` argument — a slug, because Claude Code derives `mcp__<server>__<tool>` identifiers from it |

The key replaces both the old hosted `knowledge-base` and local `knowledge` keys; one workspace, one key.

**ChatGPT has no prefill link** (nothing like Claude's `?connectorName=&connectorUrl=`), so `ChatGptInstallLink` opens ChatGPT's connector settings (`chatgpt.com/#settings/Connectors`) and the copy beside it names the connector and shows the URL to paste. Same reachability gate as the Claude button (hidden on http / localhost / private ranges); the endpoint is deliberately kept out of its href.

## Tests

- New: `ChatGptInstallLink.test.tsx`; ChatGPT-button cases on the welcome page and settings page; the slug/display-name split and the shared key across all four snippet builders.
- Updated: every expectation that spelled `knowledge-base` / `knowledge` / `Knowledge — …`.
- `tsc` clean, eslint clean, core-frontend suite 1539/1539.

## Note for existing users

Anyone who already added the server under the old key gets a second entry (`skills-tools-knowledge`) if they paste the new snippet; the old one keeps working and can be removed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the MCP server to Skills, Tools and Knowledge across every connection setup surface and adds an Add to ChatGPT button next to Add to Claude.

- The server key is now the shared slug `skills-tools-knowledge`, replacing the hosted `knowledge-base` and local `knowledge` keys.
- ChatGPT publishes no prefill link, so the new button opens its connector settings and the copy beside it shows the connector name and URL to paste.
- Existing users who already added the server under the old key will get a second entry if they paste the new snippet; the old one keeps working and can be removed by hand.

<sup>Written for commit ccaf2e0afdea87966db467d95841f6cb1bfd3f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

