### PR TITLE
A file's history is read-gated like the file

### DIFF
--- a/.changeset/history-reads-are-access-checked.md
+++ b/.changeset/history-reads-are-access-checked.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-backend': patch
+---
+
+The file-history endpoints (`workflow/changes`, `show-file`, `file-at-change`, `compare-file`) now enforce the same per-file `read:` verb as the content routes. A file's history is its content with a time axis; these routes previously required only an authenticated user, so a read-denied file's commit list, diffs, and full content at any commit were reachable by path.

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -401,6 +401,8 @@ export async function createCoreServer(
     core.workspaceService,
     core.authService,
     core.eventBus,
+    core.accessControl,
+    core.kbDirName,
   ));
   // SSE event-bus surface. The route owns its own auth gating via the
   // injected middleware (which accepts both Bearer and the `bevel_token`

--- a/packages/core-backend/src/modules/access-model/kb-read-filter.ts
+++ b/packages/core-backend/src/modules/access-model/kb-read-filter.ts
@@ -43,6 +43,28 @@ export function toKbRelative(p: string, kbDirName: string): string | null {
 }
 
 /**
+ * THE single-path read verdict every route module shares: may `userEmail`
+ * read the workspace-relative `wsPath`? Non-KB paths (outside `kbDirName`)
+ * carry no `read:` rules and pass; KB paths go through the FULL `canRead`
+ * (folder `access.md` chain + per-node frontmatter). Content, diff and
+ * history routes all gate through this one function so the rule cannot
+ * drift between the surfaces — a file's history and its diffs are its
+ * content, and must deny exactly where the content route denies. Throws
+ * whatever `canRead` throws: the caller decides how a verdict failure is
+ * reported, and MUST fail closed.
+ */
+export async function canReadWorkspacePath(
+  canRead: (workspaceId: string, userEmail: string, kbRelPath: string) => Promise<boolean>,
+  workspaceId: string,
+  userEmail: string,
+  kbDirName: string,
+  wsPath: string,
+): Promise<boolean> {
+  const rel = toKbRelative(wsPath, kbDirName);
+  return rel === null || (await canRead(workspaceId, userEmail, rel));
+}
+
+/**
  * Resolve read verdicts for a set of workspace-relative paths in ONE batched
  * access call. Non-KB paths (outside `kbDirName`) are always readable — they
  * carry no `read:` rules. KB paths are checked via `batchFn`. Returns a map

--- a/packages/core-backend/src/modules/diff/diff.routes.ts
+++ b/packages/core-backend/src/modules/diff/diff.routes.ts
@@ -3,7 +3,7 @@ import type { AuthUser, IWorkflowService } from '@bevel-software/platform-shared
 import type { IDiffService } from './diff.interface.js';
 import type { AuthService } from '../auth/auth.service.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
-import { toKbRelative, resolveReadableMap } from '../access-model/kb-read-filter.js';
+import { canReadWorkspacePath, toKbRelative, resolveReadableMap } from '../access-model/kb-read-filter.js';
 import { WorkflowDomainError, WorkflowValidationError } from '../../shared/domain-errors.js';
 import { LockingFilesystem } from '../kb-fs/locking-filesystem.js';
 import { branchForWorkspaceId } from '../../shared/workspace-id.js';
@@ -138,10 +138,14 @@ export function createDiffRoutes(
   }
 
   /** Read gate for a single change path (mirrors GET /review/file). Returns true to proceed. */
-  async function canReadPath(workspaceId: string, email: string, pathParam: string): Promise<boolean> {
-    const rel = toKbRelative(pathParam, kbDirName);
-    // Non-KB paths (toKbRelative → null) carry no read rules and pass.
-    return rel === null || (await accessControl.canRead(workspaceId, email, rel));
+  function canReadPath(workspaceId: string, email: string, pathParam: string): Promise<boolean> {
+    return canReadWorkspacePath(
+      (w, e, p) => accessControl.canRead(w, e, p),
+      workspaceId,
+      email,
+      kbDirName,
+      pathParam,
+    );
   }
 
   router.get('/workspace/:id/review', async (req, res) => {

--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.history-read-gate.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.history-read-gate.test.ts
@@ -1,0 +1,112 @@
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { IWorkflowService } from '@bevel-software/platform-shared';
+import type { IAccessControl } from '../../access/access-control.interface.js';
+import type { AuthService } from '../../auth/auth.service.js';
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import type { WorkflowEventBus } from '../event-bus.js';
+import { createWorkflowRoutes } from '../workflow.routes.js';
+
+// A file's history is its content with a time axis: the same default-deny
+// read model that hides a file must hide its commit list, its diffs, and its
+// content at any commit. These routes used to require only "is authenticated".
+
+const USER = { id: 'u1', email: 'alice@example.com', name: 'Alice' };
+const WS = 'main';
+const KB = 'knowledge-base';
+const allow = (p: string) => !p.includes('Secret');
+
+interface Harness {
+  server: Server;
+  canRead: ReturnType<typeof vi.fn>;
+  workflow: {
+    listChangesForFile: ReturnType<typeof vi.fn>;
+    compareFile: ReturnType<typeof vi.fn>;
+    showFileAtChange: ReturnType<typeof vi.fn>;
+    fileAtChange: ReturnType<typeof vi.fn>;
+  };
+  baseUrl: string;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const canRead = vi.fn(async (_w: string, _e: string, p: string) => allow(p));
+  const accessControl = { canRead } as unknown as IAccessControl;
+  const workflow = {
+    listChangesForFile: vi.fn(async () => []),
+    compareFile: vi.fn(async () => ''),
+    showFileAtChange: vi.fn(async () => ''),
+    fileAtChange: vi.fn(async () => ({ baseline: null, current: 'x' })),
+  };
+  const authService = { getUserById: vi.fn(async () => USER) } as unknown as AuthService;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', (req, _res, next) => {
+    (req as unknown as { userId: string }).userId = USER.id;
+    next();
+  });
+  app.use(
+    '/api',
+    createWorkflowRoutes(
+      workflow as unknown as IWorkflowService,
+      {} as unknown as WorkspaceService,
+      authService,
+      { subscribe: vi.fn(), publish: vi.fn() } as unknown as WorkflowEventBus,
+      accessControl,
+      KB,
+    ),
+  );
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return { server, canRead, workflow, baseUrl: `http://127.0.0.1:${addr.port}` };
+}
+
+function close(s: Server): Promise<void> {
+  return new Promise((resolve, reject) => s.close((e) => (e ? reject(e) : resolve())));
+}
+
+const OPEN = encodeURIComponent(`${KB}/Open/a.md`);
+const SECRET = encodeURIComponent(`${KB}/Secret/x.md`);
+
+describe('history routes enforce the read model', () => {
+  let h: Harness | null = null;
+  afterEach(async () => {
+    if (h) await close(h.server);
+    h = null;
+  });
+  const get = (p: string) => fetch(`${h!.baseUrl}/api/workspace/${WS}/workflow${p}`);
+
+  it.each([
+    ['/changes?path=%s', 'listChangesForFile'],
+    ['/show-file?sha=abc&path=%s', 'showFileAtChange'],
+    ['/file-at-change?sha=abc&path=%s', 'fileAtChange'],
+    ['/compare-file?from=a&to=b&path=%s', 'compareFile'],
+  ] as const)('%s: readable → 200, denied → 403 and git is never consulted', async (route, method) => {
+    h = await makeHarness();
+    expect((await get(route.replace('%s', OPEN))).status).toBe(200);
+    expect((await get(route.replace('%s', SECRET))).status).toBe(403);
+    // The denial happened BEFORE the service — nothing read the repository.
+    const calls = h.workflow[method].mock.calls as unknown[][];
+    expect(calls.length).toBe(1);
+    expect(String(calls[0][1])).toContain('Open');
+  });
+
+  it('a non-KB path carries no read rules and passes without consulting canRead', async () => {
+    h = await makeHarness();
+    const res = await get(`/changes?path=${encodeURIComponent('scratch/notes.txt')}`);
+    expect(res.status).toBe(200);
+    expect(h.canRead).not.toHaveBeenCalled();
+  });
+
+  it('an access-model error fails closed, not open', async () => {
+    h = await makeHarness();
+    h.canRead.mockRejectedValueOnce(new Error('access tree unreadable'));
+    const res = await get(`/changes?path=${OPEN}`);
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(h.workflow.listChangesForFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -26,6 +26,8 @@ import type {
   PostChangeRequestCommentInput,
 } from '@bevel-software/platform-shared';
 import type { AuthService } from '../auth/auth.service.js';
+import type { IAccessControl } from '../access/access-control.interface.js';
+import { toKbRelative } from '../access-model/kb-read-filter.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { branchForWorkspaceId } from '../../shared/workspace-id.js';
 import type { WorkflowEventBus } from './event-bus.js';
@@ -60,6 +62,8 @@ export function createWorkflowRoutes(
   workspaceService: WorkspaceService,
   authService: AuthService,
   events: WorkflowEventBus,
+  accessControl: IAccessControl,
+  kbDirName: string,
 ): express.Router {
   const router = express.Router({ mergeParams: true });
 
@@ -91,6 +95,43 @@ export function createWorkflowRoutes(
       res.status(500).json({ error: 'Internal server error' });
       return null;
     }
+  }
+
+  /**
+   * Gate a history read on the same `read:` verb the content routes enforce.
+   * The history endpoints below serve a file's past — its commit list, its
+   * diffs, its full content at a commit — and a file's past IS its content,
+   * with a time axis. They used to check only "is authenticated", so any
+   * logged-in user could pull a read-denied file's history by path, straight
+   * past the default-deny read model that hides the file everywhere else.
+   * Same rules as the content read (`workspace.routes` /
+   * `diff.routes.canReadPath`): the FULL `canRead` (per-node frontmatter
+   * honoured), non-KB paths ungated (they carry no `read:` rules), and both
+   * denial and any error fail closed with the content route's 403.
+   */
+  async function requireReadPermission(
+    req: express.Request,
+    res: express.Response,
+    workspaceId: string,
+    relativePath: string,
+  ): Promise<boolean> {
+    const user = await requireUser(req, res);
+    if (!user) return false;
+    const repoRelative = toKbRelative(relativePath, kbDirName);
+    if (repoRelative === null) return true; // non-KB path — no read rules apply
+    let allowed: boolean;
+    try {
+      allowed = await accessControl.canRead(workspaceId, user.email, repoRelative);
+    } catch (err) {
+      const { status, body } = toHttpError(err);
+      res.status(status).json(body);
+      return false;
+    }
+    if (!allowed) {
+      res.status(403).json({ error: `You don't have permission to read "${relativePath}".` });
+      return false;
+    }
+    return true;
   }
 
   // ── Branches ──────────────────────────────────────────────────────────────
@@ -250,12 +291,12 @@ export function createWorkflowRoutes(
   });
 
   router.get('/workspace/:id/workflow/changes', async (req, res) => {
-    if (!(await requireUser(req, res))) return;
     const pathParam = typeof req.query.path === 'string' ? req.query.path : '';
     if (!pathParam) {
       res.status(400).json({ error: 'path is required' });
       return;
     }
+    if (!(await requireReadPermission(req, res, req.params.id, pathParam))) return;
     const rawLimit = Number.parseInt(String(req.query.limit ?? '20'), 10);
     const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 100)) : 20;
     try {
@@ -267,7 +308,6 @@ export function createWorkflowRoutes(
   });
 
   router.get('/workspace/:id/workflow/compare-file', async (req, res) => {
-    if (!(await requireUser(req, res))) return;
     const pathParam = typeof req.query.path === 'string' ? req.query.path : '';
     const fromBranch = typeof req.query.from === 'string' ? req.query.from : '';
     const toBranch = typeof req.query.to === 'string' ? req.query.to : '';
@@ -275,6 +315,7 @@ export function createWorkflowRoutes(
       res.status(400).json({ error: 'path, from, and to are required' });
       return;
     }
+    if (!(await requireReadPermission(req, res, req.params.id, pathParam))) return;
     try {
       const diff = await workflow.compareFile(req.params.id, pathParam, fromBranch, toBranch);
       res.json({ diff });
@@ -285,13 +326,13 @@ export function createWorkflowRoutes(
   });
 
   router.get('/workspace/:id/workflow/show-file', async (req, res) => {
-    if (!(await requireUser(req, res))) return;
     const pathParam = typeof req.query.path === 'string' ? req.query.path : '';
     const sha = typeof req.query.sha === 'string' ? req.query.sha : '';
     if (!pathParam || !sha) {
       res.status(400).json({ error: 'path and sha are required' });
       return;
     }
+    if (!(await requireReadPermission(req, res, req.params.id, pathParam))) return;
     try {
       const diff = await workflow.showFileAtChange(req.params.id, pathParam, sha);
       res.json({ diff });
@@ -302,13 +343,13 @@ export function createWorkflowRoutes(
   });
 
   router.get('/workspace/:id/workflow/file-at-change', async (req, res) => {
-    if (!(await requireUser(req, res))) return;
     const pathParam = typeof req.query.path === 'string' ? req.query.path : '';
     const sha = typeof req.query.sha === 'string' ? req.query.sha : '';
     if (!pathParam || !sha) {
       res.status(400).json({ error: 'path and sha are required' });
       return;
     }
+    if (!(await requireReadPermission(req, res, req.params.id, pathParam))) return;
     try {
       const { baseline, current } = await workflow.fileAtChange(req.params.id, pathParam, sha);
       res.json({ baseline, current });

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -27,7 +27,7 @@ import type {
 } from '@bevel-software/platform-shared';
 import type { AuthService } from '../auth/auth.service.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
-import { toKbRelative } from '../access-model/kb-read-filter.js';
+import { canReadWorkspacePath } from '../access-model/kb-read-filter.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { branchForWorkspaceId } from '../../shared/workspace-id.js';
 import type { WorkflowEventBus } from './event-bus.js';
@@ -117,11 +117,15 @@ export function createWorkflowRoutes(
   ): Promise<boolean> {
     const user = await requireUser(req, res);
     if (!user) return false;
-    const repoRelative = toKbRelative(relativePath, kbDirName);
-    if (repoRelative === null) return true; // non-KB path — no read rules apply
     let allowed: boolean;
     try {
-      allowed = await accessControl.canRead(workspaceId, user.email, repoRelative);
+      allowed = await canReadWorkspacePath(
+        (w, e, p) => accessControl.canRead(w, e, p),
+        workspaceId,
+        user.email,
+        kbDirName,
+        relativePath,
+      );
     } catch (err) {
       const { status, body } = toHttpError(err);
       res.status(status).json(body);

--- a/packages/core-backend/src/modules/workspace/workspace.routes.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.routes.ts
@@ -18,7 +18,7 @@ import { branchForWorkspaceId } from '../../shared/workspace-id.js';
 import type { WorkspaceService } from './workspace.service.js';
 import type { AuthService } from '../auth/auth.service.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
-import { resolveReadableMap, toKbRelative } from '../access-model/kb-read-filter.js';
+import { canReadWorkspacePath, resolveReadableMap, toKbRelative } from '../access-model/kb-read-filter.js';
 import type { ICreatorAccess } from '../access-model/creator.js';
 import { isRolesYamlPath, assertRolesYamlParsable } from '../access-model/roles-yaml-guard.js';
 import type { WorkflowEventBus } from '../workflow/event-bus.js';
@@ -426,11 +426,15 @@ export function createWorkspaceRoutes(
   ): Promise<boolean> {
     const user = await requireUser(req, res);
     if (!user) return false;
-    const repoRelative = toKbRelative(relativePath, kbDirName);
-    if (repoRelative === null) return true; // non-KB path — no read rules apply
     let allowed: boolean;
     try {
-      allowed = await accessControl.canRead(workspaceId, user.email, repoRelative);
+      allowed = await canReadWorkspacePath(
+        (w, e, p) => accessControl.canRead(w, e, p),
+        workspaceId,
+        user.email,
+        kbDirName,
+        relativePath,
+      );
     } catch (err) {
       sendError(res, err);
       return false;


### PR DESCRIPTION
Found while answering "is version history visible to read-only users?" — the UI answer is yes and is correct, but the backend was more permissive than the read model.

## The gap

`GET /workspace/:id/workflow/changes | show-file | file-at-change | compare-file` checked only *is authenticated* and then called straight into git. The knowledge base's `read:` verb is default-deny — a folder can be hidden from a user entirely — yet any logged-in user who knew (or guessed) a path could pull that file's commit list, its per-commit diffs, and its **full content at any commit** (`file-at-change`). The frontend never offers this (a page you can't read never renders), but the API answered. A file's history is its content with a time axis; it must be gated like the content.

## The fix

`requireReadPermission` in the workflow routes, the same shape the content route (`workspace.routes`) and the diff routes already use: full `canRead` (folder `access.md` chain + per-node frontmatter), non-KB paths ungated (they carry no `read:` rules — same as agent tools and diff routes), denial → the content route's 403, and an access-model error fails closed. The four routes call it before touching the service.

`createWorkflowRoutes` gains `accessControl` + `kbDirName`; the one call site passes them.

## Verification

- New route-level tests (mirroring `diff.routes.read-gate.test.ts`): for each of the four endpoints — readable → 200, denied → **403 with git never consulted**; a non-KB path passes without consulting `canRead`; an access-model error fails closed.
- Full core-backend suite: 1953 passed / 3 skipped; `tsc` and `eslint` clean.
- Changeset: patch on `platform-core-backend`.

Touches the access-control enforcement path, so per the review policy this escalates to the tech lead regardless of verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the four file-history endpoints (`workflow/changes`, `show-file`, `file-at-change`, `compare-file`) on the same per-file `read:` verb as the content routes. They previously required only an authenticated user, so any logged-in user could pull a read-denied file's commit list, diffs, and full content at any commit by path. Denial now returns 403 before git is consulted, non-KB paths stay ungated, and access-model errors fail closed.

- Consolidates the read verdict into a shared `canReadWorkspacePath`; content, diff, and history routes all delegate to it so the rule cannot drift between surfaces.
- `createWorkflowRoutes` now receives `accessControl` and `kbDirName`.

<sup>Written for commit 65032c0d85295338d1b8fd5ce16546a9e62da092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

