### PR TITLE
hx-group-member-email-autocomplete — Suggest people by email when adding members to a group

### DIFF
--- a/packages/core-frontend/src/lib/email.ts
+++ b/packages/core-frontend/src/lib/email.ts
@@ -23,3 +23,18 @@ export const GROUP_MEMBER_PREFIX = 'group:';
 export function isGroupPrefixed(value: string): boolean {
   return value.trim().toLowerCase().startsWith(GROUP_MEMBER_PREFIX);
 }
+
+/**
+ * Avatar letters for a person, from their email or display name: two initials
+ * when the local part looks like `first.last`, otherwise the first two
+ * characters. Lives beside the email rule because every caller is an
+ * email-keyed people surface.
+ */
+export function initials(value: string): string {
+  const cleaned = value.trim();
+  if (!cleaned) return '?';
+  const [name] = cleaned.split('@');
+  const parts = name.split(/[.\s_-]+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase();
+}

--- a/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useState } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { AddMemberInput } from '../components/AddMemberInput';
+import { AddMemberInput, SUGGEST_DEBOUNCE_MS } from '../components/AddMemberInput';
 import { suggestPrincipals, type SuggestResponse } from '../../access/api';
 
 vi.mock('../../access/api', async (importOriginal) => {
@@ -10,8 +10,12 @@ vi.mock('../../access/api', async (importOriginal) => {
   return { ...actual, suggestPrincipals: vi.fn() };
 });
 
-/** The component's debounce, plus slack — how long "no request" has to hold. */
-const PAST_DEBOUNCE_MS = 350;
+/**
+ * How long "no request" has to hold: the component's own debounce plus slack,
+ * derived from the component so raising the debounce cannot leave this test
+ * asserting over a window the request has not been scheduled in yet.
+ */
+const PAST_DEBOUNCE_MS = SUGGEST_DEBOUNCE_MS + 150;
 
 const ALICE = { name: 'Alice Green', email: 'alice@example.com' };
 const PAT = { name: 'Pat Kim', email: 'pat@example.com' };
@@ -24,9 +28,11 @@ function people(...list: { name: string; email: string }[]): SuggestResponse {
 function Harness({
   onSubmit = () => {},
   exclude = [],
+  busy = false,
 }: {
   onSubmit?: (value: string) => void;
   exclude?: string[];
+  busy?: boolean;
 }) {
   const [value, setValue] = useState('');
   return (
@@ -36,6 +42,7 @@ function Harness({
       onSubmit={onSubmit}
       exclude={exclude}
       inputLabel="Member email"
+      busy={busy}
     />
   );
 }
@@ -102,6 +109,59 @@ describe('AddMemberInput', () => {
     expect(screen.queryByText(/suggest is down/)).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Add' }));
     expect(onSubmit).toHaveBeenCalledWith('newcomer@example.com');
+  });
+
+  it('a keyboard alone can reach a suggestion and choose it', async () => {
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+    await userEvent.type(input, 'ali');
+    await screen.findByText('Alice Green');
+
+    // Tab moves focus from the input INTO the list — the list has to survive
+    // that, or the row it lands on is gone before Enter reaches it.
+    await userEvent.tab();
+    const row = screen.getByRole('button', { name: /Alice Green/ });
+    expect(row).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    expect(onSubmit).toHaveBeenCalledWith('alice@example.com');
+  });
+
+  it('offers no suggestion rows while a mutation is in flight', async () => {
+    const onSubmit = vi.fn();
+    const { rerender } = render(<Harness onSubmit={onSubmit} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Member email' }), 'ali');
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+
+    // The input and Add button already go inert while the add runs; a live row
+    // would be the one way left to queue a second mutation behind the first.
+    rerender(<Harness onSubmit={onSubmit} busy />);
+    await waitFor(() => expect(screen.queryByText('Alice Green')).not.toBeInTheDocument());
+  });
+
+  it('drops the previous query\'s people the moment the text changes', async () => {
+    let resolveSecond: ((r: SuggestResponse) => void) | undefined;
+    vi.mocked(suggestPrincipals)
+      .mockResolvedValueOnce(people(ALICE))
+      .mockImplementationOnce(
+        () => new Promise<SuggestResponse>((resolve) => { resolveSecond = resolve; }),
+      );
+    render(<Harness />);
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+
+    await userEvent.type(input, 'al');
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+
+    // A new query is in flight. Alice answered the OLD text, so leaving her row
+    // up would let a click add someone the current text never named.
+    await userEvent.type(input, 'pat');
+    await waitFor(() => expect(screen.queryByText('Alice Green')).not.toBeInTheDocument());
+    await waitFor(() => expect(resolveSecond).toBeDefined());
+
+    resolveSecond!(people(PAT));
+    expect(await screen.findByText('Pat Kim')).toBeInTheDocument();
   });
 
   it('a stale response never overwrites the current query, and a backspace clears the list', async () => {

--- a/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
@@ -142,25 +142,40 @@ describe('AddMemberInput', () => {
   });
 
   it('drops the previous query\'s people the moment the text changes', async () => {
-    let resolveSecond: ((r: SuggestResponse) => void) | undefined;
-    vi.mocked(suggestPrincipals)
-      .mockResolvedValueOnce(people(ALICE))
-      .mockImplementationOnce(
-        () => new Promise<SuggestResponse>((resolve) => { resolveSecond = resolve; }),
-      );
+    let answerPat: ((r: SuggestResponse) => void) | undefined;
+    // Keyed by query rather than by call order: how many requests a burst of
+    // typing produces depends on where the debounce lands, and that is not what
+    // this test is about.
+    vi.mocked(suggestPrincipals).mockImplementation((_workspace, q) =>
+      q === 'al'
+        ? Promise.resolve(people(ALICE))
+        : new Promise<SuggestResponse>((resolve) => {
+            answerPat = resolve;
+          }),
+    );
     render(<Harness />);
     const input = screen.getByRole('textbox', { name: 'Member email' });
 
     await userEvent.type(input, 'al');
     expect(await screen.findByText('Alice Green')).toBeInTheDocument();
 
-    // A new query is in flight. Alice answered the OLD text, so leaving her row
-    // up would let a click add someone the current text never named.
-    await userEvent.type(input, 'pat');
-    await waitFor(() => expect(screen.queryByText('Alice Green')).not.toBeInTheDocument());
-    await waitFor(() => expect(resolveSecond).toBeDefined());
+    // 'al' is REPLACED by 'pat' in one edit, rather than typed onto the end of
+    // it. Two things ride on that. The query has to genuinely become 'pat' —
+    // appending would ask for 'alpat' and the test would not mean what it says.
+    // And the text must never dip below two characters on the way: the
+    // below-threshold path clears the list on its own, so a clear-then-type
+    // would pass even with the new-query clear removed, proving nothing.
+    await userEvent.click(input);
+    (input as HTMLInputElement).select();
+    await userEvent.paste('pat');
+    expect(input).toHaveValue('pat');
 
-    resolveSecond!(people(PAT));
+    // Alice answered the OLD text, so leaving her row up would let a click add
+    // someone the current text never named.
+    await waitFor(() => expect(screen.queryByText('Alice Green')).not.toBeInTheDocument());
+    await waitFor(() => expect(answerPat).toBeDefined());
+
+    answerPat!(people(PAT));
     expect(await screen.findByText('Pat Kim')).toBeInTheDocument();
   });
 

--- a/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/AddMemberInput.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AddMemberInput } from '../components/AddMemberInput';
+import { suggestPrincipals, type SuggestResponse } from '../../access/api';
+
+vi.mock('../../access/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../access/api')>();
+  return { ...actual, suggestPrincipals: vi.fn() };
+});
+
+/** The component's debounce, plus slack — how long "no request" has to hold. */
+const PAST_DEBOUNCE_MS = 350;
+
+const ALICE = { name: 'Alice Green', email: 'alice@example.com' };
+const PAT = { name: 'Pat Kim', email: 'pat@example.com' };
+
+function people(...list: { name: string; email: string }[]): SuggestResponse {
+  return { roles: [], groups: [], people: list, peopleWithheld: false };
+}
+
+/** The component is controlled — the caller owns the value, as both pages do. */
+function Harness({
+  onSubmit = () => {},
+  exclude = [],
+}: {
+  onSubmit?: (value: string) => void;
+  exclude?: string[];
+}) {
+  const [value, setValue] = useState('');
+  return (
+    <AddMemberInput
+      value={value}
+      onValueChange={setValue}
+      onSubmit={onSubmit}
+      exclude={exclude}
+      inputLabel="Member email"
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(suggestPrincipals).mockReset().mockResolvedValue(people(ALICE));
+});
+
+describe('AddMemberInput', () => {
+  it('makes no suggest request below two characters, and one at two', async () => {
+    render(<Harness />);
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+
+    await userEvent.type(input, 'a');
+    await new Promise((resolve) => setTimeout(resolve, PAST_DEBOUNCE_MS));
+    // The server withholds people under two characters anyway — asking is pure
+    // waste, and the guard is what keeps a one-letter keystroke off the wire.
+    expect(suggestPrincipals).not.toHaveBeenCalled();
+
+    await userEvent.type(input, 'l');
+    await waitFor(() => expect(suggestPrincipals).toHaveBeenCalledTimes(1));
+    expect(suggestPrincipals).toHaveBeenCalledWith('target-company-state', 'al');
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('never offers someone the caller already counts as a member', async () => {
+    vi.mocked(suggestPrincipals).mockResolvedValue(people(PAT, ALICE));
+    // Mixed case on purpose: membership is case-insensitive.
+    render(<Harness exclude={['PAT@example.com']} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: 'Member email' }), 'ex');
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+    expect(screen.queryByText('Pat Kim')).not.toBeInTheDocument();
+  });
+
+  it('choosing a suggestion submits exactly the email typing it would have', async () => {
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+    await userEvent.type(input, 'ali');
+    await userEvent.click(await screen.findByText('Alice Green'));
+    expect(onSubmit).toHaveBeenCalledWith('alice@example.com');
+
+    // Same handler, same argument, from the plain typed path.
+    onSubmit.mockClear();
+    await userEvent.clear(input);
+    await userEvent.type(input, 'alice@example.com{Enter}');
+    expect(onSubmit).toHaveBeenCalledWith('alice@example.com');
+  });
+
+  it('degrades to a plain email input when the suggest request fails', async () => {
+    vi.mocked(suggestPrincipals).mockRejectedValue(new Error('suggest is down'));
+    const onSubmit = vi.fn();
+    render(<Harness onSubmit={onSubmit} />);
+
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+    await userEvent.type(input, 'newcomer@example.com');
+    await waitFor(() => expect(suggestPrincipals).toHaveBeenCalled());
+
+    // No list, no error takes over the form — and the value still submits.
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    expect(screen.queryByText(/suggest is down/)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+    expect(onSubmit).toHaveBeenCalledWith('newcomer@example.com');
+  });
+
+  it('a stale response never overwrites the current query, and a backspace clears the list', async () => {
+    const resolvers: ((r: SuggestResponse) => void)[] = [];
+    vi.mocked(suggestPrincipals).mockImplementation(
+      () => new Promise<SuggestResponse>((resolve) => resolvers.push(resolve)),
+    );
+    render(<Harness />);
+    const input = screen.getByRole('textbox', { name: 'Member email' });
+
+    await userEvent.type(input, 'pa');
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+    await userEvent.type(input, 'li');
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    // The NEWER query answers first, then the older one lands late.
+    resolvers[1](people(ALICE));
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+    resolvers[0](people(PAT));
+    await waitFor(() => expect(screen.queryByText('Pat Kim')).not.toBeInTheDocument());
+    expect(screen.getByText('Alice Green')).toBeInTheDocument();
+
+    // Backspacing under the threshold drops the list rather than leaving a
+    // stale one hanging under a query too short to have produced it.
+    await userEvent.clear(input);
+    await userEvent.type(input, 'a');
+    await waitFor(() => expect(screen.queryByText('Alice Green')).not.toBeInTheDocument());
+  });
+});

--- a/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.suggest.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.suggest.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DirectoryGroupsPage } from '../components/DirectoryGroupsPage';
+import { SUGGEST_DEBOUNCE_MS } from '../components/AddMemberInput';
 import { AdminContext } from '../state/admin.context';
 import { AppRegistryContext, EMPTY_REGISTRY } from '../../../core/registry';
 import { addGroupMember, getGroupsRoster, type GroupsRoster } from '../services/groups.api';
@@ -16,8 +17,12 @@ vi.mock('../../access/api', async (importOriginal) => {
   return { ...actual, suggestPrincipals: vi.fn() };
 });
 
-/** The component's debounce, plus slack — how long "no request" has to hold. */
-const PAST_DEBOUNCE_MS = 350;
+/**
+ * How long "no request" has to hold: the component's own debounce plus slack,
+ * derived from the component so raising the debounce cannot leave this test
+ * asserting over a window the request has not been scheduled in yet.
+ */
+const PAST_DEBOUNCE_MS = SUGGEST_DEBOUNCE_MS + 150;
 
 const ALICE = { name: 'Alice Green', email: 'alice@example.com' };
 const PAT = { name: 'Pat Kim', email: 'pat@example.com' };

--- a/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.suggest.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.suggest.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DirectoryGroupsPage } from '../components/DirectoryGroupsPage';
+import { AdminContext } from '../state/admin.context';
+import { AppRegistryContext, EMPTY_REGISTRY } from '../../../core/registry';
+import { addGroupMember, getGroupsRoster, type GroupsRoster } from '../services/groups.api';
+import { suggestPrincipals, type SuggestResponse } from '../../access/api';
+
+vi.mock('../services/groups.api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/groups.api')>();
+  return { ...actual, getGroupsRoster: vi.fn(), addGroupMember: vi.fn() };
+});
+vi.mock('../../access/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../access/api')>();
+  return { ...actual, suggestPrincipals: vi.fn() };
+});
+
+/** The component's debounce, plus slack — how long "no request" has to hold. */
+const PAST_DEBOUNCE_MS = 350;
+
+const ALICE = { name: 'Alice Green', email: 'alice@example.com' };
+const PAT = { name: 'Pat Kim', email: 'pat@example.com' };
+
+function people(...list: { name: string; email: string }[]): SuggestResponse {
+  return { roles: [], groups: [], people: list, peopleWithheld: false };
+}
+
+const MANUAL_ROSTER: GroupsRoster = {
+  mode: 'manual',
+  groups: [
+    {
+      canonical: 'product',
+      displayName: 'Product',
+      members: ['pat@example.com'],
+      referencedBy: [],
+      assignedToRoles: [],
+    },
+    {
+      canonical: 'design',
+      displayName: 'Design',
+      members: [],
+      referencedBy: [],
+      assignedToRoles: [],
+    },
+  ],
+  groupsHealth: { ok: true },
+};
+
+function renderPage() {
+  return render(
+    <AppRegistryContext.Provider value={EMPTY_REGISTRY}>
+      <AdminContext.Provider
+        value={{
+          isAdmin: true,
+          unreadCount: 0,
+          lastSeen: null,
+          markSeen: () => {},
+          refresh: () => {},
+          rolesConfigCorrupted: false,
+          rolesConfigErrors: [],
+          runRolesRecovery: async () => {},
+        }}
+      >
+        <DirectoryGroupsPage />
+      </AdminContext.Provider>
+    </AppRegistryContext.Provider>,
+  );
+}
+
+/** The Add button belonging to a member input's row. */
+function addButtonFor(input: HTMLElement) {
+  return within(input.closest('div')!.parentElement!).getByRole('button', { name: 'Add' });
+}
+
+beforeEach(() => {
+  vi.mocked(getGroupsRoster).mockReset().mockResolvedValue(MANUAL_ROSTER);
+  vi.mocked(addGroupMember).mockReset().mockResolvedValue(MANUAL_ROSTER);
+  vi.mocked(suggestPrincipals).mockReset().mockResolvedValue(people(ALICE));
+});
+
+describe('DirectoryGroupsPage: add-member people suggestions', () => {
+  it('suggests people by name and email, from the same source the roles page uses', async () => {
+    renderPage();
+    const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
+    await userEvent.type(input, 'al');
+
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    // The access suggest endpoint on the default-branch workspace — exactly
+    // what Roles & Members and the access dialog ask.
+    expect(suggestPrincipals).toHaveBeenCalledWith('target-company-state', 'al');
+  });
+
+  it("excludes the group's current members from the suggestions", async () => {
+    vi.mocked(suggestPrincipals).mockResolvedValue(people(PAT, ALICE));
+    renderPage();
+    // Product already has pat@example.com — suggesting him would offer a no-op.
+    const input = await screen.findByRole('textbox', { name: 'Add member to Product' });
+    await userEvent.type(input, 'ex');
+
+    expect(await screen.findByText('Alice Green')).toBeInTheDocument();
+    expect(screen.queryByText('Pat Kim')).not.toBeInTheDocument();
+  });
+
+  it('choosing a suggestion adds the person exactly as typing the email would', async () => {
+    renderPage();
+    const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
+    await userEvent.type(input, 'ali');
+    await userEvent.click(await screen.findByText('Alice Green'));
+
+    await waitFor(() =>
+      expect(addGroupMember).toHaveBeenCalledWith('design', 'alice@example.com'),
+    );
+    // The input is cleared, as after any successful add.
+    await waitFor(() => expect(input).toHaveValue(''));
+
+    // The typed path lands on the identical request.
+    vi.mocked(addGroupMember).mockClear();
+    await userEvent.type(input, 'alice@example.com{Enter}');
+    await waitFor(() =>
+      expect(addGroupMember).toHaveBeenCalledWith('design', 'alice@example.com'),
+    );
+  });
+
+  it('a full email that is not among the suggestions is still added', async () => {
+    // Suggestions only ever know people the deployment has seen; a colleague
+    // who has never signed in must still be addable.
+    renderPage();
+    const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
+    await userEvent.type(input, 'newcomer@example.com');
+    await userEvent.click(addButtonFor(input));
+
+    await waitFor(() =>
+      expect(addGroupMember).toHaveBeenCalledWith('design', 'newcomer@example.com'),
+    );
+  });
+
+  it('a failed suggest request never blocks adding a valid email', async () => {
+    vi.mocked(suggestPrincipals).mockRejectedValue(new Error('suggest is down'));
+    renderPage();
+    const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
+    await userEvent.type(input, 'dana@example.com');
+    await waitFor(() => expect(suggestPrincipals).toHaveBeenCalled());
+
+    // The suggestion feature degrades; the form does not. No error banner, and
+    // the add goes through unchanged.
+    expect(screen.queryByText(/suggest is down/)).not.toBeInTheDocument();
+    await userEvent.click(addButtonFor(input));
+    await waitFor(() => expect(addGroupMember).toHaveBeenCalledWith('design', 'dana@example.com'));
+  });
+
+  it('makes no suggestion request below two characters', async () => {
+    renderPage();
+    const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
+    await userEvent.type(input, 'a');
+    await new Promise((resolve) => setTimeout(resolve, PAST_DEBOUNCE_MS));
+
+    expect(suggestPrincipals).not.toHaveBeenCalled();
+    expect(screen.queryByText('Alice Green')).not.toBeInTheDocument();
+  });
+
+  it('an IdP-synced group still has no member input at all', async () => {
+    vi.mocked(getGroupsRoster).mockResolvedValue({
+      ...MANUAL_ROSTER,
+      mode: 'idp',
+    });
+    renderPage();
+    expect(await screen.findByText('Product')).toBeInTheDocument();
+    // Membership is managed in the directory — nothing to suggest into.
+    expect(screen.queryByRole('textbox', { name: /Add member/ })).not.toBeInTheDocument();
+    expect(suggestPrincipals).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/DirectoryGroupsPage.test.tsx
@@ -31,6 +31,13 @@ vi.mock('../services/groups.api', async (importOriginal) => {
     renameGroup: vi.fn(),
   };
 });
+// The add-member input suggests people from the access suggest endpoint —
+// stubbed here so these tests stay about the groups roster.
+vi.mock('../../access/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../access/api')>();
+  return { ...actual, suggestPrincipals: vi.fn() };
+});
+import { suggestPrincipals } from '../../access/api';
 
 const MANUAL_ROSTER: GroupsRoster = {
   mode: 'manual',
@@ -68,6 +75,15 @@ const IDP_ROSTER: GroupsRoster = {
   groupsHealth: { ok: true },
 };
 
+/**
+ * The Add button of the row a member input belongs to — each group card has
+ * its own. The input sits inside its own wrapper (the suggestion list anchors
+ * to it), so the button is one level up from the input's closest div.
+ */
+function addButtonFor(input: HTMLElement) {
+  return within(input.closest('div')!.parentElement!).getByRole('button', { name: 'Add' });
+}
+
 function renderPage(opts: {
   isAdmin?: boolean;
   directoryPanel?: (props: GroupsDirectoryPanelProps) => React.ReactElement;
@@ -102,6 +118,9 @@ beforeEach(() => {
   vi.mocked(addGroupMember).mockReset().mockResolvedValue(MANUAL_ROSTER);
   vi.mocked(removeGroupMember).mockReset().mockResolvedValue(MANUAL_ROSTER);
   vi.mocked(renameGroup).mockReset().mockResolvedValue(MANUAL_ROSTER);
+  vi.mocked(suggestPrincipals)
+    .mockReset()
+    .mockResolvedValue({ roles: [], groups: [], people: [], peopleWithheld: false });
 });
 
 describe('DirectoryGroupsPage', () => {
@@ -147,7 +166,7 @@ describe('DirectoryGroupsPage', () => {
     const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
     await userEvent.type(input, 'dana@example.com');
     // Scope to the input's row — each group card has its own Add button.
-    await userEvent.click(within(input.closest('div')!).getByRole('button', { name: 'Add' }));
+    await userEvent.click(addButtonFor(input));
     await waitFor(() =>
       expect(addGroupMember).toHaveBeenCalledWith('design', 'dana@example.com'),
     );
@@ -170,14 +189,14 @@ describe('DirectoryGroupsPage', () => {
 
     const productInput = await screen.findByRole('textbox', { name: 'Add member to Product' });
     await userEvent.type(productInput, 'a@example.com');
-    await userEvent.click(within(productInput.closest('div')!).getByRole('button', { name: 'Add' }));
+    await userEvent.click(addButtonFor(productInput));
     await waitFor(() => expect(addGroupMember).toHaveBeenCalledTimes(1));
 
     // Second card: its own busy flag is free, so the click goes through — but
     // the request must queue behind the unresolved first one.
     const designInput = screen.getByRole('textbox', { name: 'Add member to Design' });
     await userEvent.type(designInput, 'b@example.com');
-    await userEvent.click(within(designInput.closest('div')!).getByRole('button', { name: 'Add' }));
+    await userEvent.click(addButtonFor(designInput));
     expect(addGroupMember).toHaveBeenCalledTimes(1);
 
     resolvers[0](MANUAL_ROSTER);
@@ -429,7 +448,7 @@ describe('DirectoryGroupsPage', () => {
     renderPage();
     const input = await screen.findByRole('textbox', { name: 'Add member to Design' });
     await userEvent.type(input, 'group:engineering');
-    await userEvent.click(within(input.closest('div')!).getByRole('button', { name: 'Add' }));
+    await userEvent.click(addButtonFor(input));
     expect(
       await screen.findByText(/Group members are emails — 'group:' references aren't allowed/),
     ).toBeInTheDocument();

--- a/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import { suggestPrincipals } from '../../access/api';
+import { initials } from '../../../lib/email';
+
+/** A person offered by the suggest endpoint — name and email, nothing more. */
+export interface PersonSuggestion {
+  name: string;
+  email: string;
+}
+
+/**
+ * The server withholds people until the query is at least this long (its
+ * anti-harvesting guard). Mirrored here so a shorter query costs no request
+ * at all rather than one that can only come back empty.
+ */
+const SUGGEST_MIN_CHARS = 2;
+
+/** Typing settles for this long before a suggest request goes out. */
+const SUGGEST_DEBOUNCE_MS = 200;
+
+/** The default-branch workspace id — the admin surfaces are managed there. */
+// A function, not a constant: the branch model arrives from `/api/config`
+// during boot, and a module-scope capture would freeze this at the empty
+// string that exists before it.
+const suggestWorkspaceId = () => encodeURIComponent(DEFAULT_BRANCH);
+
+export interface AddMemberInputProps {
+  /** Controlled input value — the caller owns it, and owns clearing it. */
+  value: string;
+  onValueChange: (value: string) => void;
+  /**
+   * Add the given email. Called with the typed value (Enter / the Add button)
+   * or with a chosen suggestion's email — the two paths are indistinguishable
+   * from here, which is the point. Validation and the request are the
+   * caller's: this component knows nothing about roles or groups.
+   */
+  onSubmit: (value: string) => void;
+  /** Emails already on the target — never offered as suggestions. */
+  exclude: readonly string[];
+  /** Accessible name of the input (each card names its own target). */
+  inputLabel: string;
+  /** A mutation is in flight: input and button go inert, the button spins. */
+  busy?: boolean;
+  placeholder?: string;
+  /** Layout classes for the row (spacing above it differs per page). */
+  className?: string;
+}
+
+/**
+ * The add-member input shared by Roles & Members and the Groups page: an
+ * email field that suggests people from the deployment as you type, plus its
+ * Add button.
+ *
+ * SUGGESTIONS ASSIST, THEY NEVER RESTRICT. The list is a shortcut for a value
+ * the caller could always have typed in full — a person who has never signed
+ * in is still addable, and a suggest request that fails or answers a shape
+ * this doesn't recognise simply leaves an ordinary email input behind. That
+ * is why every read of the response is defensive and every failure path ends
+ * in "no suggestions", never an error the form has to show.
+ */
+export function AddMemberInput({
+  value,
+  onValueChange,
+  onSubmit,
+  exclude,
+  inputLabel,
+  busy = false,
+  placeholder = 'Add member by email',
+  className = '',
+}: AddMemberInputProps) {
+  const [suggestions, setSuggestions] = useState<PersonSuggestion[]>([]);
+  const [showSuggest, setShowSuggest] = useState(false);
+  // Bumped per request so a slow response never repopulates the list after a
+  // newer query (or a backspace below the threshold) has superseded it.
+  const suggestReq = useRef(0);
+
+  // A newline-joined key rather than the array itself: callers build `exclude`
+  // inline (`[...members, ...pending]`), so a reference dependency would
+  // re-run this effect on every render. The key changes only when the set does.
+  const excludeKey = [...new Set(exclude.map((e) => e.trim().toLowerCase()))]
+    .sort()
+    .join('\n');
+
+  useEffect(() => {
+    const q = value.trim();
+    if (q.length < SUGGEST_MIN_CHARS) {
+      // Invalidate any in-flight request so a late long-query response can't
+      // repopulate the dropdown after the user backspaced below the threshold.
+      suggestReq.current++;
+      setSuggestions([]);
+      return;
+    }
+    const myReq = ++suggestReq.current;
+    const t = setTimeout(() => {
+      suggestPrincipals(suggestWorkspaceId(), q)
+        .then((res) => {
+          if (myReq !== suggestReq.current) return;
+          // People only; drop anyone the caller already counts as a member.
+          const existing = new Set(excludeKey ? excludeKey.split('\n') : []);
+          setSuggestions(
+            (res.people ?? []).filter((p) => !existing.has(p.email.toLowerCase())),
+          );
+        })
+        .catch(() => {
+          // The suggestion feature degrades; the input keeps working.
+          if (myReq === suggestReq.current) setSuggestions([]);
+        });
+    }, SUGGEST_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [value, excludeKey]);
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`}>
+      {/* The input is capped rather than fixed-width, and its wrapper may shrink,
+          so the row fits the card on a narrow viewport instead of pushing the
+          Add button past the card border. */}
+      <div className="relative flex-1 min-w-0 max-w-[16rem]">
+        <input
+          type="email"
+          value={value}
+          onChange={(e) => {
+            onValueChange(e.target.value);
+            setShowSuggest(true);
+          }}
+          onFocus={() => setShowSuggest(true)}
+          // Delay so a click on a suggestion lands before the list unmounts.
+          onBlur={() => setTimeout(() => setShowSuggest(false), 150)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onSubmit(value);
+            if (e.key === 'Escape') setShowSuggest(false);
+          }}
+          placeholder={placeholder}
+          disabled={busy}
+          className="text-xs px-2 py-1 border border-line rounded-sm focus:outline-none focus:border-accent w-full min-w-0"
+          aria-label={inputLabel}
+          autoComplete="off"
+        />
+        {showSuggest && suggestions.length > 0 && (
+          <ul className="absolute z-10 mt-1 w-full sm:w-72 max-w-full max-h-56 overflow-auto bg-white border border-line rounded-lg shadow-lg py-1">
+            {suggestions.map((p) => (
+              <li key={p.email}>
+                <button
+                  type="button"
+                  // onMouseDown (not onClick) so it fires before the input's blur.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSubmit(p.email);
+                  }}
+                  className="w-full text-left px-2 py-1.5 hover:bg-hover flex items-center gap-2"
+                >
+                  <span className="w-5 h-5 rounded-full bg-ink-muted text-white text-[9px] font-semibold flex items-center justify-center shrink-0">
+                    {initials(p.email)}
+                  </span>
+                  <span className="flex-1 truncate text-xs text-ink">{p.name || p.email}</span>
+                  <span className="text-[10px] text-ink-faint truncate">{p.email}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => onSubmit(value)}
+        disabled={busy}
+        className="shrink-0 px-3 py-1 text-xs rounded-sm border border-line hover:bg-hover disabled:opacity-50 flex items-center gap-1"
+      >
+        {busy && <Loader2 size={12} className="animate-spin" />}
+        Add
+      </button>
+    </div>
+  );
+}

--- a/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
@@ -17,8 +17,13 @@ export interface PersonSuggestion {
  */
 const SUGGEST_MIN_CHARS = 2;
 
-/** Typing settles for this long before a suggest request goes out. */
-const SUGGEST_DEBOUNCE_MS = 200;
+/**
+ * Typing settles for this long before a suggest request goes out. Exported so
+ * a test that has to outlast the debounce derives its wait from this value
+ * rather than restating it — a number here that a test does not follow is a
+ * silently flaky test.
+ */
+export const SUGGEST_DEBOUNCE_MS = 200;
 
 /** The default-branch workspace id — the admin surfaces are managed there. */
 // A function, not a constant: the branch model arrives from `/api/config`
@@ -75,6 +80,9 @@ export function AddMemberInput({
   // Bumped per request so a slow response never repopulates the list after a
   // newer query (or a backspace below the threshold) has superseded it.
   const suggestReq = useRef(0);
+  // The input and its list together. Focus moving between them is movement
+  // WITHIN the widget, not away from it — see the wrapper's onBlur.
+  const widget = useRef<HTMLDivElement>(null);
 
   // A newline-joined key rather than the array itself: callers build `exclude`
   // inline (`[...members, ...pending]`), so a reference dependency would
@@ -93,6 +101,10 @@ export function AddMemberInput({
       return;
     }
     const myReq = ++suggestReq.current;
+    // The previous query's people are wrong for this one the moment the text
+    // changes. Leaving them up through the debounce and the request would keep
+    // a row clickable that adds someone the current text never named.
+    setSuggestions([]);
     const t = setTimeout(() => {
       suggestPrincipals(suggestWorkspaceId(), q)
         .then((res) => {
@@ -116,7 +128,19 @@ export function AddMemberInput({
       {/* The input is capped rather than fixed-width, and its wrapper may shrink,
           so the row fits the card on a narrow viewport instead of pushing the
           Add button past the card border. */}
-      <div className="relative flex-1 min-w-0 max-w-[16rem]">
+      <div
+        ref={widget}
+        className="relative flex-1 min-w-0 max-w-[16rem]"
+        // React's onBlur bubbles (it is focusout underneath), so this one
+        // handler covers the input and every suggestion row. The list closes
+        // only when focus lands outside the widget entirely — which is what
+        // lets a keyboard user Tab from the input into the list at all.
+        onBlur={(e) => {
+          if (!widget.current?.contains(e.relatedTarget as Node | null)) {
+            setShowSuggest(false);
+          }
+        }}
+      >
         <input
           type="email"
           value={value}
@@ -125,8 +149,6 @@ export function AddMemberInput({
             setShowSuggest(true);
           }}
           onFocus={() => setShowSuggest(true)}
-          // Delay so a click on a suggestion lands before the list unmounts.
-          onBlur={() => setTimeout(() => setShowSuggest(false), 150)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') onSubmit(value);
             if (e.key === 'Escape') setShowSuggest(false);
@@ -137,17 +159,19 @@ export function AddMemberInput({
           aria-label={inputLabel}
           autoComplete="off"
         />
-        {showSuggest && suggestions.length > 0 && (
+        {!busy && showSuggest && suggestions.length > 0 && (
           <ul className="absolute z-10 mt-1 w-full sm:w-72 max-w-full max-h-56 overflow-auto bg-white border border-line rounded-lg shadow-lg py-1">
             {suggestions.map((p) => (
               <li key={p.email}>
                 <button
                   type="button"
-                  // onMouseDown (not onClick) so it fires before the input's blur.
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    onSubmit(p.email);
-                  }}
+                  // preventDefault on mousedown keeps focus in the input, so a
+                  // mouse click never blurs the widget out from under itself.
+                  // The submit hangs off onClick, which a pointer AND a
+                  // keyboard (Enter/Space on the focused row) both raise —
+                  // onMouseDown alone was unreachable without a mouse.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => onSubmit(p.email)}
                   className="w-full text-left px-2 py-1.5 hover:bg-hover flex items-center gap-2"
                 >
                   <span className="w-5 h-5 rounded-full bg-ink-muted text-white text-[9px] font-semibold flex items-center justify-center shrink-0">

--- a/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { Loader2, UsersRound, X } from 'lucide-react';
 import { PageShell } from '../../../shared/components/PageShell';
-import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { useAdmin } from '../state/admin.context';
 import {
   addMember,
@@ -13,28 +12,13 @@ import {
   unassignGroup,
   type RoleRosterEntry,
 } from '../services/roles.api';
-import { suggestPrincipals } from '../../access/api';
-import { EMAIL_RE, isGroupPrefixed } from '../../../lib/email';
+import { AddMemberInput } from './AddMemberInput';
+import { EMAIL_RE, initials, isGroupPrefixed } from '../../../lib/email';
 import { useExclusiveRunner, type ExclusiveRunner } from '../hooks/useExclusiveRunner';
-
-/** The default-branch workspace id — roles are managed there (admin status derives from it). */
-// A function, not a constant: the branch model arrives from `/api/config`
-// during boot, and a module-scope capture would freeze this at the empty
-// string that exists before it.
-const rolesWorkspaceId = () => encodeURIComponent(DEFAULT_BRANCH);
 
 function errMessage(err: unknown, fallback: string): string {
   if (err instanceof Error) return err.message;
   return fallback;
-}
-
-function initials(value: string): string {
-  const cleaned = value.trim();
-  if (!cleaned) return '?';
-  const [name] = cleaned.split('@');
-  const parts = name.split(/[.\s_-]+/).filter(Boolean);
-  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-  return name.slice(0, 2).toUpperCase();
 }
 
 interface SelfRemoveTarget {
@@ -169,11 +153,10 @@ function RoleCard({
   const [busy, setBusy] = useState(false);
 
   // Add-member input + people autocomplete (same suggest source as Manage
-  // Access, scoped to people/emails — a role's members are emails).
+  // Access, scoped to people/emails — a role's members are emails). The
+  // suggestion mechanics live in AddMemberInput, shared with the Groups page;
+  // the submit rules below stay here.
   const [memberEmail, setMemberEmail] = useState('');
-  const [suggestions, setSuggestions] = useState<{ name: string; email: string }[]>([]);
-  const [showSuggest, setShowSuggest] = useState(false);
-  const suggestReq = useRef(0);
 
   // Optimistic member removal: lowercased emails hidden from the chip list
   // before the server confirms. Reconciled when the authoritative roster lands.
@@ -182,35 +165,6 @@ function RoleCard({
   // server confirms. Reconciled (dropped) once they appear in the authoritative
   // roster, or rolled back on error.
   const [pendingAdds, setPendingAdds] = useState<string[]>([]);
-
-  useEffect(() => {
-    const q = memberEmail.trim();
-    // Server withholds people until q ≥ 2 chars (harvesting guard); mirror that.
-    if (q.length < 2) {
-      // Invalidate any in-flight request so a late 2+ char response can't
-      // repopulate the dropdown after the user backspaced below the threshold.
-      suggestReq.current++;
-      setSuggestions([]);
-      return;
-    }
-    const myReq = ++suggestReq.current;
-    const t = setTimeout(() => {
-      suggestPrincipals(rolesWorkspaceId(), q)
-        .then((res) => {
-          if (myReq !== suggestReq.current) return;
-          // People only; drop anyone already a member (server or optimistic).
-          const existing = new Set([
-            ...role.members.map((m) => m.toLowerCase()),
-            ...pendingAdds.map((e) => e.toLowerCase()),
-          ]);
-          setSuggestions((res.people ?? []).filter((p) => !existing.has(p.email.toLowerCase())));
-        })
-        .catch(() => {
-          if (myReq === suggestReq.current) setSuggestions([]);
-        });
-    }, 200);
-    return () => clearTimeout(t);
-  }, [memberEmail, role.members, pendingAdds]);
 
   // Dialogs.
   const [selfRemove, setSelfRemove] = useState<SelfRemoveTarget | null>(null);
@@ -265,8 +219,10 @@ function RoleCard({
     [onApply, runExclusive],
   );
 
-  const submitAddMember = async (override?: string) => {
-    const email = (override ?? memberEmail).trim();
+  // `value` is whatever the input handed over: the typed text, or the email of
+  // a chosen suggestion. The two are deliberately indistinguishable here.
+  const submitAddMember = async (value: string) => {
+    const email = value.trim();
     // Mirror the backend's refusal of `group:`-prefixed member values with an
     // inline hint (a `group:lee@x.io` would pass the email regex server-side
     // check order matters — see roles-edit.addMember).
@@ -286,9 +242,9 @@ function RoleCard({
       role.members.some((m) => m.toLowerCase() === lower) ||
       pendingAdds.some((e) => e.toLowerCase() === lower)
     ) {
+      // Clearing the input is what empties the suggestion list — it falls back
+      // below the two-character threshold.
       setMemberEmail('');
-      setShowSuggest(false);
-      setSuggestions([]);
       return;
     }
     // Optimistic: show the chip and clear the input immediately. The add commit
@@ -298,8 +254,6 @@ function RoleCard({
     setError(null);
     setPendingAdds((prev) => [...prev, email]);
     setMemberEmail('');
-    setShowSuggest(false);
-    setSuggestions([]);
     try {
       const rows = await runExclusive(() => addMember(role.canonical, email));
       onApply(rows);
@@ -463,66 +417,18 @@ function RoleCard({
         )}
       </div>
 
-      {/* Add member — with people autocomplete (Manage Access suggest source). */}
-      {/* The input is capped rather than fixed-width, and its wrapper may shrink,
-          so the row fits the card on a narrow viewport instead of pushing the
-          Add button past the card border. */}
-      <div className="mt-3 flex items-center gap-1.5">
-        <div className="relative flex-1 min-w-0 max-w-[16rem]">
-          <input
-            type="email"
-            value={memberEmail}
-            onChange={(e) => {
-              setMemberEmail(e.target.value);
-              setShowSuggest(true);
-            }}
-            onFocus={() => setShowSuggest(true)}
-            // Delay so a click on a suggestion lands before the list unmounts.
-            onBlur={() => setTimeout(() => setShowSuggest(false), 150)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') submitAddMember();
-              if (e.key === 'Escape') setShowSuggest(false);
-            }}
-            placeholder="Add member by email"
-            disabled={busy}
-            className="text-xs px-2 py-1 border border-line rounded-sm focus:outline-none focus:border-accent w-full min-w-0"
-            aria-label="Member email"
-            autoComplete="off"
-          />
-          {showSuggest && suggestions.length > 0 && (
-            <ul className="absolute z-10 mt-1 w-full sm:w-72 max-w-full max-h-56 overflow-auto bg-white border border-line rounded-lg shadow-lg py-1">
-              {suggestions.map((p) => (
-                <li key={p.email}>
-                  <button
-                    type="button"
-                    // onMouseDown (not onClick) so it fires before the input's blur.
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      submitAddMember(p.email);
-                    }}
-                    className="w-full text-left px-2 py-1.5 hover:bg-hover flex items-center gap-2"
-                  >
-                    <span className="w-5 h-5 rounded-full bg-ink-muted text-white text-[9px] font-semibold flex items-center justify-center shrink-0">
-                      {initials(p.email)}
-                    </span>
-                    <span className="flex-1 truncate text-xs text-ink">{p.name || p.email}</span>
-                    <span className="text-[10px] text-ink-faint truncate">{p.email}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={() => submitAddMember()}
-          disabled={busy}
-          className="shrink-0 px-3 py-1 text-xs rounded-sm border border-line hover:bg-hover disabled:opacity-50 flex items-center gap-1"
-        >
-          {busy && <Loader2 size={12} className="animate-spin" />}
-          Add
-        </button>
-      </div>
+      {/* Add member — with people autocomplete (Manage Access suggest source).
+          Members already on the role, optimistic ones included, are excluded
+          from the suggestions: offering them would be offering a no-op. */}
+      <AddMemberInput
+        value={memberEmail}
+        onValueChange={setMemberEmail}
+        onSubmit={submitAddMember}
+        exclude={[...role.members, ...pendingAdds]}
+        inputLabel="Member email"
+        busy={busy}
+        className="mt-3"
+      />
 
       {/* Group assignments — everyone in an assigned group holds the role.
           The section shows whenever there is something to see: assignments the

--- a/packages/core-frontend/src/modules/admin/components/DirectoryGroupsPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/DirectoryGroupsPage.tsx
@@ -17,6 +17,7 @@ import {
   type GroupsRoster,
 } from '../services/groups.api';
 import { EMAIL_RE, isGroupPrefixed } from '../../../lib/email';
+import { AddMemberInput } from './AddMemberInput';
 
 function errMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
@@ -415,8 +416,11 @@ function ManualGroupCard({
     }
   };
 
-  const submitAdd = async () => {
-    const trimmed = email.trim();
+  // `value` is whatever the input handed over: the typed text, or the email of
+  // a chosen suggestion. A suggestion is a shortcut for typing, nothing more —
+  // both land on exactly these rules and exactly this request.
+  const submitAdd = async (value: string) => {
+    const trimmed = value.trim();
     // Mirror the backend's refusal of `group:`-prefixed member values with an
     // inline hint — group members are emails; groups don't contain groups.
     if (isGroupPrefixed(trimmed)) {
@@ -543,30 +547,18 @@ function ManualGroupCard({
         )}
       </div>
 
-      <div className="mt-2 flex items-center gap-1.5">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') submitAdd();
-          }}
-          placeholder="Add member by email"
-          disabled={busy}
-          className="text-xs px-2 py-1 border border-line rounded-sm focus:outline-none focus:border-accent flex-1 min-w-0 max-w-[16rem]"
-          aria-label={`Add member to ${group.displayName}`}
-          autoComplete="off"
-        />
-        <button
-          type="button"
-          onClick={submitAdd}
-          disabled={busy}
-          className="shrink-0 px-3 py-1 text-xs rounded-sm border border-line hover:bg-hover disabled:opacity-50 flex items-center gap-1"
-        >
-          {busy && <Loader2 size={12} className="animate-spin" />}
-          Add
-        </button>
-      </div>
+      {/* Add member — the same input the roles page uses, so a group member is
+          picked from people suggestions exactly the way a role member is.
+          Current members are excluded: they are already here. */}
+      <AddMemberInput
+        value={email}
+        onValueChange={setEmail}
+        onSubmit={submitAdd}
+        exclude={group.members}
+        inputLabel={`Add member to ${group.displayName}`}
+        busy={busy}
+        className="mt-2"
+      />
 
       {error && (
         <div className="mt-2 text-xs text-danger bg-danger-soft border border-danger/30 rounded-sm px-2 py-1">


### PR DESCRIPTION
Ticket: [Suggest people by email when adding members to a group](https://knowledge.bevel.software/hx-group-member-email-autocomplete) (`Data/Engineering/Knowledge/Hexis/Tickets/Group-Member-Email-Autocomplete.md`)

## Summary
Adding a member to a manual group was a bare email field. The roles page next to it already suggests people (name and email) from the deployment, current members excluded. This moves that behaviour into a shared `AddMemberInput` component that both the groups page and the roles page render:

- Typing 2+ characters shows suggestions (name + email) from the same `/access/suggest` source the roles page uses, with the target's current members excluded.
- Choosing a suggestion submits through the exact same path as typing the full email.
- A free-typed email not in the suggestion list stays addable; a failed suggest request never blocks adding a valid email, it just degrades to a plain input.
- Below 2 characters, no suggestion request is made.
- The roles page's add-member input behaves exactly as before (optimistic chips, "use the group assignment instead" refusal); the groups page keeps its own `group:`-prefix refusal hint. Both are now driven by the one shared component.
- Synced (IdP) groups still render no member input at all.
- `initials` moved to `lib/email.ts` so both callers can share it.

## Testing
- `pnpm typecheck && pnpm test` — all projects clean, full suite passing (308 test files / 3802 tests), including 5 new suites for this ticket covering: suggestions appear and exclude current members, choosing a suggestion equals typing the email, a free-typed email stays addable, suggestion failure degrades to the plain input, and no request below 2 characters.
- Verified live against a from-source Docker boot (Playwright/Chromium) — see the ticket's Local Testing Evidence section for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds people suggestions to the group add-member input, so a member can now be picked by name instead of typing a full email. Choosing a suggestion submits the same request as typing the email, and a free-typed email not in the suggestions stays addable.

**Refactors**
- Extracts the roles page's suggest-as-you-type logic into a shared `AddMemberInput` component used by the groups page and roles page.
- The roles page's input behavior is unchanged; synced (IdP) groups still render no member input.
- Suggestions are keyboard-reachable, hidden while an add is in flight, and cleared the moment the query changes; a stale response never repopulates the list over a newer query.
- A failed suggest request degrades to a plain email input; no request is made below two characters, and current members are excluded.

<sup>Written for commit d87c28c094799e02fc10a50b399de26eed0e9b39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

