### PR TITLE
Encrypt PII columns at the application layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,11 @@ ADMIN_PASSWORD=
 # Signs login sessions + OAuth state. Any long random string.
 JWT_SECRET=
 
-# Core secrets encryption: 32-byte key (base64 or hex) encrypting the secrets
-# vault values + MCP OAuth client secrets/tokens.
+# Core at-rest encryption: 32-byte key (base64 or hex) encrypting the secrets
+# vault values, MCP OAuth client secrets/tokens, and (via derived keys) the
+# PII columns in the database — emails, display names, change-request/review
+# text. Keep a copy outside the server: without it, backups of that data
+# cannot be read back.
 SECRETS_ENC_KEY=
 
 # Which release docker-compose runs — the image CI publishes per release

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,7 +31,9 @@ From 0.14, personal data in the database — emails, display names, and
 change-request/review text — is encrypted with a key derived from
 `SECRETS_ENC_KEY`, in addition to the secrets vault it already sealed. The
 first boot after the upgrade rewrites existing rows automatically; nothing
-to do.
+to do. Upgrade with a single app instance (the normal
+`docker compose pull app && up -d` flow already replaces the container) —
+don't run old and new versions against the same database side by side.
 
 What it changes for operations:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,6 +25,24 @@ after an upgrade can take a little longer.
 older app cannot read a newer database. To go back, restore the backup you
 took before upgrading.
 
+### PII encryption (0.14+)
+
+From 0.14, personal data in the database — emails, display names, and
+change-request/review text — is encrypted with a key derived from
+`SECRETS_ENC_KEY`, in addition to the secrets vault it already sealed. The
+first boot after the upgrade rewrites existing rows automatically; nothing
+to do.
+
+What it changes for operations:
+
+- **Losing `SECRETS_ENC_KEY` now loses this data too**, not just stored
+  credentials. Keep a copy of the key somewhere safe *outside* the server —
+  a database backup can only be read back with the key that was in `.env`
+  when it was taken.
+- Database dumps contain ciphertext for these columns; ad-hoc SQL against
+  them (looking up a user by email in `psql`, say) no longer works — use
+  the app or its API instead.
+
 ## Backups
 
 Everything that matters lives in Postgres and the named Docker volumes; the

--- a/packages/core-backend/migrations/0005_pii_encryption.sql
+++ b/packages/core-backend/migrations/0005_pii_encryption.sql
@@ -1,0 +1,14 @@
+-- PII column encryption: add the blind-index companion columns, NULLABLE and
+-- unconstrained. The columns are populated — and existing plaintext PII rows
+-- rewritten to AES-256-GCM ciphertext — by the programmatic backfill that runs
+-- right after the SQL migrations on every boot (`runPiiEncryptionBackfill` in
+-- migrate.ts). That same step then applies SET NOT NULL and swaps the unique
+-- constraints (`users_email_unique` → `users_email_bidx_unq`,
+-- `pr_file_approvals_unq` → `pr_file_approvals_bidx_unq`), because a unique
+-- index on a blind-index column can only go up once every row has one.
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "email_bidx" text;--> statement-breakpoint
+ALTER TABLE "pr_file_approvals" ADD COLUMN IF NOT EXISTS "approver_email_bidx" text;--> statement-breakpoint
+ALTER TABLE "pr_merge_log" ADD COLUMN IF NOT EXISTS "triggered_by_email_bidx" text;--> statement-breakpoint
+ALTER TABLE "pr_comments" ADD COLUMN IF NOT EXISTS "author_email_bidx" text;--> statement-breakpoint
+ALTER TABLE "change_requests" ADD COLUMN IF NOT EXISTS "author_email_bidx" text;--> statement-breakpoint
+ALTER TABLE "pending_commits" ADD COLUMN IF NOT EXISTS "author_email_bidx" text;

--- a/packages/core-backend/migrations/meta/0005_snapshot.json
+++ b/packages/core-backend/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1608 @@
+{
+  "id": "0a729cb5-a59a-4e06-9347-5aa868b16e74",
+  "prevId": "16b22a96-7e97-4951-afd7-6bd2dcfd8ec7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.change_requests": {
+      "name": "change_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "change_requests_number_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "merged_sha": {
+          "name": "merged_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email_bidx": {
+          "name": "author_email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "change_requests_number_unq": {
+          "name": "change_requests_number_unq",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_open_pair_unq": {
+          "name": "change_requests_open_pair_unq",
+          "columns": [
+            {
+              "expression": "source_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_branch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"change_requests\".\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "change_requests_by_state": {
+          "name": "change_requests_by_state",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "change_requests_state_check": {
+          "name": "change_requests_state_check",
+          "value": "\"change_requests\".\"state\" IN ('open', 'merged', 'closed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_settings_updated_by_users_id_fk": {
+          "name": "deployment_settings_updated_by_users_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_tokens_by_user": {
+          "name": "api_tokens_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_hash_unique": {
+          "name": "api_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_locks": {
+      "name": "file_locks",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_user_id": {
+          "name": "holder_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'edit'"
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_locks_by_expiry": {
+          "name": "file_locks_by_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_locks_by_holder": {
+          "name": "file_locks_by_holder",
+          "columns": [
+            {
+              "expression": "holder_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_locks_holder_user_id_users_id_fk": {
+          "name": "file_locks_holder_user_id_users_id_fk",
+          "tableFrom": "file_locks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "holder_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_locks_workspace_id_branch_path_pk": {
+          "name": "file_locks_workspace_id_branch_path_pk",
+          "columns": [
+            "workspace_id",
+            "branch",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_locks_mode": {
+          "name": "file_locks_mode",
+          "value": "\"file_locks\".\"mode\" IN ('edit', 'coordination')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_auth_codes": {
+      "name": "oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_auth_codes_by_expiry": {
+          "name": "oauth_auth_codes_by_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_auth_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_auth_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_auth_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_auth_codes_user_id_users_id_fk": {
+          "name": "oauth_auth_codes_user_id_users_id_fk",
+          "tableFrom": "oauth_auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_auth_codes_code_hash_unique": {
+          "name": "oauth_auth_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret_expires_at": {
+          "name": "client_secret_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "access_token_hash": {
+          "name": "access_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_expires_at": {
+          "name": "refresh_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_tokens_by_user": {
+          "name": "oauth_tokens_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_tokens_by_expiry": {
+          "name": "oauth_tokens_by_expiry",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_tokens_access_token_hash_unique": {
+          "name": "oauth_tokens_access_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token_hash"
+          ]
+        },
+        "oauth_tokens_refresh_token_hash_unique": {
+          "name": "oauth_tokens_refresh_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_commits": {
+      "name": "pending_commits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recovery_agent_runs": {
+          "name": "recovery_agent_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempted_at": {
+          "name": "last_attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email_bidx": {
+          "name": "author_email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_commits_by_workspace_queued": {
+          "name": "pending_commits_by_workspace_queued",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "queued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_commits_by_status": {
+          "name": "pending_commits_by_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_commits_by_status_only": {
+          "name": "pending_commits_by_status_only",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pending_commits_status": {
+          "name": "pending_commits_status",
+          "value": "\"pending_commits\".\"status\" IN ('pending', 'running', 'needs_attention')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pr_comments": {
+      "name": "pr_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_email": {
+          "name": "author_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_email_bidx": {
+          "name": "author_email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_comments_by_pr": {
+          "name": "pr_comments_by_pr",
+          "columns": [
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pr_comments_by_thread": {
+          "name": "pr_comments_by_thread",
+          "columns": [
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_file_approvals": {
+      "name": "pr_file_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver_email": {
+          "name": "approver_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approver_name": {
+          "name": "approver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approver_email_bidx": {
+          "name": "approver_email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_file_approvals_by_pr": {
+          "name": "pr_file_approvals_by_pr",
+          "columns": [
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pr_file_approvals_bidx_unq": {
+          "name": "pr_file_approvals_bidx_unq",
+          "columns": [
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approver_email_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_merge_log": {
+      "name": "pr_merge_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_email": {
+          "name": "triggered_by_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_name": {
+          "name": "triggered_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha_at_merge": {
+          "name": "head_sha_at_merge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merge_method": {
+          "name": "merge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_email_bidx": {
+          "name": "triggered_by_email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_merge_log_by_pr": {
+          "name": "pr_merge_log_by_pr",
+          "columns": [
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'static'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_meta": {
+          "name": "oauth_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secrets_by_user": {
+          "name": "secrets_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_user_key_unq": {
+          "name": "secrets_user_key_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secrets_shared_key_unq": {
+          "name": "secrets_shared_key_unq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"secrets\".\"user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secrets_user_id_users_id_fk": {
+          "name": "secrets_user_id_users_id_fk",
+          "tableFrom": "secrets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_ontology_touches": {
+      "name": "session_ontology_touches",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ontology": {
+          "name": "ontology",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "touched_at": {
+          "name": "touched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_ontology_touches_by_touched_at": {
+          "name": "session_ontology_touches_by_touched_at",
+          "columns": [
+            {
+              "expression": "touched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "session_ontology_touches_session_id_ontology_pk": {
+          "name": "session_ontology_touches_session_id_ontology_pk",
+          "columns": [
+            "session_id",
+            "ontology"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email_bidx": {
+          "name": "email_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_email_bidx_unq": {
+          "name": "users_email_bidx_unq",
+          "columns": [
+            {
+              "expression": "email_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core-backend/migrations/meta/_journal.json
+++ b/packages/core-backend/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1787191920033,
       "tag": "0004_file_lock_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788359464311,
+      "tag": "0005_pii_encryption",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core-backend/src/core-config.ts
+++ b/packages/core-backend/src/core-config.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defaultKbTemplateDir } from './assets.js';
 import { assertKeyDecodesTo32Bytes } from './shared/token-crypto.js';
+import { initColumnCrypto } from './shared/column-crypto.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
@@ -357,6 +358,11 @@ export class CoreConfig {
     // SECRETS_ENC_KEY by default, which is only certainly right because a bad
     // key never gets past this line.
     assertKeyDecodesTo32Bytes(this.secretsEncKey, secretsKeySource);
+    // Install the derived PII column-encryption + blind-index keys the moment
+    // the secrets key is known to be valid. The schema module's encryptedText
+    // columns read this module-level state, so it must be in place before the
+    // first query — config construction always is.
+    initColumnCrypto(this.secretsEncKey);
     this.internalTokenSecret = (process.env.INTERNAL_TOKEN_SECRET || '').trim();
     // Setting DOMAIN declares "the bundled Caddy `https` profile fronts this
     // deployment" — one proxy hop, and the public origin IS that domain. The

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -9,7 +9,7 @@ import {
 } from '@bevel-software/platform-shared';
 import { CoreConfig } from '../core-config.js';
 import { getDb, type Database } from '../modules/database/connection.js';
-import { runCoreMigrations } from '../modules/database/migrate.js';
+import { runCoreMigrations, runPiiEncryptionBackfill } from '../modules/database/migrate.js';
 import { coreMigrationsDir } from '../assets.js';
 import { WorkspaceService } from '../modules/workspace/workspace.service.js';
 import { RoutineWritePolicyService } from '../modules/workspace/routine-write-policy.js';
@@ -215,6 +215,10 @@ export async function createCoreServices(
   // `migrations/` folder, tracked in `__drizzle_migrations_core`. An
   // enterprise overlay runs its own history AFTER this (see migrate.ts).
   await runCoreMigrations(db, coreMigrationsDir());
+  // Seal any pre-encryption plaintext PII rows and swap the unique constraints
+  // onto the blind-index columns (see migrate.ts). Idempotent; must complete
+  // before any service reads or writes a PII column.
+  await runPiiEncryptionBackfill(db);
 
   // Deployment settings come next, before ANY service is built: the KB remote
   // is resolved through them, and a fresh install has none of it in the

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -31,8 +31,22 @@ export { coreMigrationsDir, defaultKbTemplateDir } from './assets.js';
 export {
   runCoreMigrations,
   runEnterpriseMigrations,
+  runPiiEncryptionBackfill,
 } from './modules/database/migrate.js';
 export { getDb, type Database } from './modules/database/connection.js';
+
+// PII column encryption (see shared/column-crypto.ts). `encryptedText` and
+// `blindIndex` are exported so an enterprise overlay can seal its own schema's
+// PII columns with the same keys; `initColumnCrypto` for entry points that
+// build a Database without constructing CoreConfig.
+export {
+  initColumnCrypto,
+  encryptedText,
+  blindIndex,
+  encryptPii,
+  decryptPii,
+  isEncryptedBlob,
+} from './shared/column-crypto.js';
 
 // Build identity surfaced by GET /api/health.
 export { GIT_SHA, resolveGitSha } from './version.js';

--- a/packages/core-backend/src/modules/access/directory-sync-bot.ts
+++ b/packages/core-backend/src/modules/access/directory-sync-bot.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import type { AuthUser } from '@bevel-software/platform-shared';
 import type { Database } from '../database/connection.js';
 import { users } from '../database/core-schema.js';
+import { blindIndex } from '../../shared/column-crypto.js';
 
 /**
  * Synthetic identity for the synced-groups materializer's commits: every
@@ -23,8 +24,12 @@ export const DIRECTORY_SYNC_BOT_NAME = 'Directory Sync Bot';
 export async function ensureDirectorySyncBot(db: Database): Promise<AuthUser> {
   const inserted = await db
     .insert(users)
-    .values({ email: DIRECTORY_SYNC_BOT_EMAIL, name: DIRECTORY_SYNC_BOT_NAME })
-    .onConflictDoNothing({ target: users.email })
+    .values({
+      email: DIRECTORY_SYNC_BOT_EMAIL,
+      emailBidx: blindIndex(DIRECTORY_SYNC_BOT_EMAIL),
+      name: DIRECTORY_SYNC_BOT_NAME,
+    })
+    .onConflictDoNothing({ target: users.emailBidx })
     .returning();
   if (inserted.length > 0) {
     const row = inserted[0];
@@ -34,7 +39,7 @@ export async function ensureDirectorySyncBot(db: Database): Promise<AuthUser> {
   const [row] = await db
     .select()
     .from(users)
-    .where(eq(users.email, DIRECTORY_SYNC_BOT_EMAIL))
+    .where(eq(users.emailBidx, blindIndex(DIRECTORY_SYNC_BOT_EMAIL)))
     .limit(1);
   if (!row) {
     throw new Error(

--- a/packages/core-backend/src/modules/auth/account-erasure.service.ts
+++ b/packages/core-backend/src/modules/auth/account-erasure.service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { blindIndex } from '../../shared/column-crypto.js';
+import { blindIndex, isEncryptedBlob } from '../../shared/column-crypto.js';
 import type { Database } from '../database/connection.js';
 import {
   changeRequests,
@@ -111,6 +111,20 @@ export class AccountErasureService implements IAccountErasureService {
   async eraseUser(userId: string): Promise<boolean> {
     const [user] = await this.db.select().from(users).where(eq(users.id, userId)).limit(1);
     if (!user) return false;
+
+    // Fail CLOSED on an undecryptable email. The encrypted column's read
+    // fallback returns the raw ciphertext blob when the configured key cannot
+    // open it (a rotated/wrong SECRETS_ENC_KEY); hashing that blob would make
+    // every email-keyed audit anonymization below match zero rows while the
+    // user delete still committed — an erasure that silently left the PII
+    // behind. Refuse instead: nothing is deleted until the key is fixed.
+    if (isEncryptedBlob(user.email)) {
+      throw new Error(
+        `account-erasure: cannot decrypt the stored email for user id=${userId} with the ` +
+          'configured SECRETS_ENC_KEY — refusing to erase, because the email-keyed audit rows ' +
+          'could not be anonymized. Restore the correct key, then retry.',
+      );
+    }
 
     const target: ErasureTarget = {
       userId,

--- a/packages/core-backend/src/modules/auth/account-erasure.service.ts
+++ b/packages/core-backend/src/modules/auth/account-erasure.service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
+import { blindIndex } from '../../shared/column-crypto.js';
 import type { Database } from '../database/connection.js';
 import {
   changeRequests,
@@ -97,11 +98,14 @@ export class AccountErasureService implements IAccountErasureService {
   ) {}
 
   async listUsers(): Promise<AdminUserView[]> {
+    // Sorted in-process: `email` is ciphertext in the DB, so ORDER BY would
+    // sort by IV noise. One row per team member — negligible.
     const rows = await this.db
       .select({ id: users.id, email: users.email, name: users.name, createdAt: users.createdAt })
-      .from(users)
-      .orderBy(users.email);
-    return rows.map((r) => ({ ...r, createdAt: r.createdAt.getTime() }));
+      .from(users);
+    return rows
+      .map((r) => ({ ...r, createdAt: r.createdAt.getTime() }))
+      .sort((a, b) => a.email.localeCompare(b.email));
   }
 
   async eraseUser(userId: string): Promise<boolean> {
@@ -134,30 +138,55 @@ export class AccountErasureService implements IAccountErasureService {
       // Personal-data rows the core owns.
       await tx.delete(fileLocks).where(eq(fileLocks.holderUserId, userId));
 
-      // Audit rows: anonymize in place (no user FK on these; they key by email).
+      // Audit rows: anonymize in place (no user FK on these; they key by
+      // email). Matched via the blind index — the email columns are randomized
+      // ciphertext — and the bidx is rewritten to the placeholder's too, so no
+      // residual value keyed to the erased address survives the erasure.
+      const emailBidx = blindIndex(target.email);
+      const erasedBidx = blindIndex(target.erasedEmail);
       await tx
         .update(prFileApprovals)
-        .set({ approverEmail: target.erasedEmail, approverName: target.erasedName })
-        .where(eq(prFileApprovals.approverEmail, target.email));
+        .set({
+          approverEmail: target.erasedEmail,
+          approverEmailBidx: erasedBidx,
+          approverName: target.erasedName,
+        })
+        .where(eq(prFileApprovals.approverEmailBidx, emailBidx));
       await tx
         .update(prMergeLog)
-        .set({ triggeredByEmail: target.erasedEmail, triggeredByName: target.erasedName })
-        .where(eq(prMergeLog.triggeredByEmail, target.email));
+        .set({
+          triggeredByEmail: target.erasedEmail,
+          triggeredByEmailBidx: erasedBidx,
+          triggeredByName: target.erasedName,
+        })
+        .where(eq(prMergeLog.triggeredByEmailBidx, emailBidx));
       await tx
         .update(prComments)
-        .set({ authorEmail: target.erasedEmail, authorName: target.erasedName })
-        .where(eq(prComments.authorEmail, target.email));
+        .set({
+          authorEmail: target.erasedEmail,
+          authorEmailBidx: erasedBidx,
+          authorName: target.erasedName,
+        })
+        .where(eq(prComments.authorEmailBidx, emailBidx));
       await tx
         .update(changeRequests)
-        .set({ authorEmail: target.erasedEmail, authorName: target.erasedName })
-        .where(eq(changeRequests.authorEmail, target.email));
+        .set({
+          authorEmail: target.erasedEmail,
+          authorEmailBidx: erasedBidx,
+          authorName: target.erasedName,
+        })
+        .where(eq(changeRequests.authorEmailBidx, emailBidx));
       // Queued-but-uncommitted saves: the eventual git commit is authored with
       // the placeholder instead of the erased identity. The file content still
       // lands — erasing an account must not lose other people's KB state.
       await tx
         .update(pendingCommits)
-        .set({ authorEmail: target.erasedEmail, authorName: target.erasedName })
-        .where(eq(pendingCommits.authorEmail, target.email));
+        .set({
+          authorEmail: target.erasedEmail,
+          authorEmailBidx: erasedBidx,
+          authorName: target.erasedName,
+        })
+        .where(eq(pendingCommits.authorEmailBidx, emailBidx));
 
       // Module-owned rows, before the users delete so FKs onto users are
       // still satisfiable — and so a participant that MISSES rows makes the

--- a/packages/core-backend/src/modules/auth/auth.service.ts
+++ b/packages/core-backend/src/modules/auth/auth.service.ts
@@ -5,6 +5,7 @@ import type { CoreConfig } from '../../core-config.js';
 import { users } from '../database/schema.js';
 import type { AuthUser } from '@bevel-software/platform-shared';
 import { hashEmail } from '../../shared/hash-email.js';
+import { blindIndex } from '../../shared/column-crypto.js';
 import {
   hashPassword,
   verifyPassword,
@@ -107,10 +108,11 @@ export class AuthService {
       return { token: this.signToken(user.id, user.email), user: toAuthUser(user) };
     }
 
+    // Lookup goes through the blind index — `email` is randomized ciphertext.
     const [user] = await this.db
       .select()
       .from(users)
-      .where(eq(users.email, normalizedEmail))
+      .where(eq(users.emailBidx, blindIndex(normalizedEmail)))
       .limit(1);
     // Always run one scrypt verification — against the stored hash when there
     // is one, against the decoy otherwise — so unknown emails and
@@ -170,9 +172,14 @@ export class AuthService {
     // fallback. `returning()` yields the authoritative row either way.
     const [row] = await this.db
       .insert(users)
-      .values({ email: normalizedEmail, name: displayName, passwordHash })
+      .values({
+        email: normalizedEmail,
+        emailBidx: blindIndex(normalizedEmail),
+        name: displayName,
+        passwordHash,
+      })
       .onConflictDoUpdate({
-        target: users.email,
+        target: users.emailBidx,
         set: suppliedName
           ? { passwordHash, name: suppliedName, updatedAt: new Date() }
           : { passwordHash, updatedAt: new Date() },
@@ -211,14 +218,18 @@ export class AuthService {
   async listAccounts(): Promise<
     Array<{ id: string; email: string; name: string; hasPassword: boolean; createdAt: Date }>
   > {
-    const rows = await this.db.select().from(users).orderBy(users.email);
-    return rows.map((row) => ({
-      id: row.id,
-      email: row.email,
-      name: row.name,
-      hasPassword: row.passwordHash != null,
-      createdAt: row.createdAt,
-    }));
+    // Sorted in-process: `email` is ciphertext in the DB, so ORDER BY would
+    // sort by IV noise. The table is one row per team member — negligible.
+    const rows = await this.db.select().from(users);
+    return rows
+      .map((row) => ({
+        id: row.id,
+        email: row.email,
+        name: row.name,
+        hasPassword: row.passwordHash != null,
+        createdAt: row.createdAt,
+      }))
+      .sort((a, b) => a.email.localeCompare(b.email));
   }
 
   private assertPasswordPolicy(password: string): void {
@@ -253,8 +264,8 @@ export class AuthService {
   private async upsertUserByEmail(email: string, name: string) {
     const [user] = await this.db
       .insert(users)
-      .values({ email, name })
-      .onConflictDoUpdate({ target: users.email, set: { updatedAt: new Date() } })
+      .values({ email, emailBidx: blindIndex(email), name })
+      .onConflictDoUpdate({ target: users.emailBidx, set: { updatedAt: new Date() } })
       .returning();
     return user;
   }

--- a/packages/core-backend/src/modules/database/core-schema.ts
+++ b/packages/core-backend/src/modules/database/core-schema.ts
@@ -9,15 +9,30 @@
  * `enterprise-schema.ts`, which imports the FK targets (`users`,
  * `externalApiKeys`) from here. `schema.ts` re-exports both, so existing
  * imports keep working unchanged.
+ *
+ * PII columns (emails, display names, change-request/comment text) are
+ * `encryptedText` — AES-256-GCM ciphertext in the database, transparently
+ * decrypted on read (see `shared/column-crypto.ts`). Because the ciphertext is
+ * randomized, equality lookups and unique constraints on those columns go
+ * through their deterministic `*_bidx` companions (HMAC-SHA256 blind indexes)
+ * — never `eq()` an encrypted column directly.
  */
 import { sql } from 'drizzle-orm';
 import { boolean, check, index, integer, jsonb, pgTable, primaryKey, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { encryptedText } from '../../shared/column-crypto.js';
 
 export const users = pgTable('users', {
   id: uuid('id').defaultRandom().primaryKey(),
-  email: text('email').notNull().unique(),
-  name: text('name').notNull(),
-  avatarUrl: text('avatar_url'),
+  email: encryptedText('email').notNull(),
+  /**
+   * Blind index of the lowercased email — carries the uniqueness constraint
+   * and every lookup-by-email (login, upsert conflict target), which the
+   * randomized `email` ciphertext cannot. Populate with `blindIndex(email)`
+   * on every insert.
+   */
+  emailBidx: text('email_bidx').notNull(),
+  name: encryptedText('name').notNull(),
+  avatarUrl: encryptedText('avatar_url'),
   /**
    * scrypt hash for password login (see auth/password-hash.ts). NULL for
    * accounts that only ever signed in via SSO — password login refuses them
@@ -39,7 +54,9 @@ export const users = pgTable('users', {
   onboardingDone: boolean('onboarding_done').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
-});
+}, (t) => ({
+  emailBidxUnq: uniqueIndex('users_email_bidx_unq').on(t.emailBidx),
+}));
 
 /**
  * Per-file owner approvals on a PR. A PR is mergeable-in-Bevel when every
@@ -56,15 +73,18 @@ export const prFileApprovals = pgTable('pr_file_approvals', {
   id: uuid('id').defaultRandom().primaryKey(),
   prNumber: integer('pr_number').notNull(),
   path: text('path').notNull(),
-  approverEmail: text('approver_email').notNull(),  // lowercased at insert
-  approverName: text('approver_name').notNull(),
+  approverEmail: encryptedText('approver_email').notNull(),  // lowercased at insert
+  /** Blind index of `approver_email` — the uniqueness key and eq() lookup. */
+  approverEmailBidx: text('approver_email_bidx').notNull(),
+  approverName: encryptedText('approver_name').notNull(),
   headSha: text('head_sha').notNull(),
   approvedAt: timestamp('approved_at').defaultNow().notNull(),
 }, (t) => ({
   // Idempotency: approving the same path on the same SHA twice must be a no-op,
-  // not a duplicate row. Unique on the (PR, path, approver, headSha) tuple.
-  unq: uniqueIndex('pr_file_approvals_unq')
-    .on(t.prNumber, t.path, t.approverEmail, t.headSha),
+  // not a duplicate row. Unique on the (PR, path, approver, headSha) tuple —
+  // via the blind index, because the encrypted email is randomized.
+  unq: uniqueIndex('pr_file_approvals_bidx_unq')
+    .on(t.prNumber, t.path, t.approverEmailBidx, t.headSha),
   byPr: index('pr_file_approvals_by_pr').on(t.prNumber),
 }));
 
@@ -78,12 +98,15 @@ export const prFileApprovals = pgTable('pr_file_approvals', {
 export const prMergeLog = pgTable('pr_merge_log', {
   id: uuid('id').defaultRandom().primaryKey(),
   prNumber: integer('pr_number').notNull(),
-  triggeredByEmail: text('triggered_by_email').notNull(),
-  triggeredByName: text('triggered_by_name').notNull(),
+  triggeredByEmail: encryptedText('triggered_by_email').notNull(),
+  /** Blind index of `triggered_by_email` — GDPR-erasure lookup. */
+  triggeredByEmailBidx: text('triggered_by_email_bidx').notNull(),
+  triggeredByName: encryptedText('triggered_by_name').notNull(),
   headShaAtMerge: text('head_sha_at_merge').notNull(),
   mergeMethod: text('merge_method').notNull(),
   succeeded: boolean('succeeded').notNull(),
-  error: text('error'),
+  // Encrypted: merge failure output can quote author identities and CR text.
+  error: encryptedText('error'),
   startedAt: timestamp('started_at').defaultNow().notNull(),
   completedAt: timestamp('completed_at'),
 }, (t) => ({
@@ -107,12 +130,15 @@ export const prMergeLog = pgTable('pr_merge_log', {
 export const prComments = pgTable('pr_comments', {
   id: uuid('id').defaultRandom().primaryKey(),
   prNumber: integer('pr_number').notNull(),
-  authorEmail: text('author_email').notNull(),
-  authorName: text('author_name').notNull(),
+  authorEmail: encryptedText('author_email').notNull(),
+  /** Blind index of `author_email` — GDPR-erasure lookup. */
+  authorEmailBidx: text('author_email_bidx').notNull(),
+  authorName: encryptedText('author_name').notNull(),
   path: text('path'),
   line: integer('line'),
   headSha: text('head_sha').notNull(),
-  body: text('body').notNull(),
+  // Encrypted: review conversation exists only in this DB (never on GitHub).
+  body: encryptedText('body').notNull(),
   parentId: uuid('parent_id'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at'),
@@ -141,10 +167,13 @@ export const changeRequests = pgTable('change_requests', {
   number: integer('number').generatedAlwaysAsIdentity(),
   sourceBranch: text('source_branch').notNull(),
   targetBranch: text('target_branch').notNull(),
-  title: text('title').notNull(),
-  body: text('body').notNull().default(''),
-  authorEmail: text('author_email').notNull(), // lowercased at insert
-  authorName: text('author_name').notNull(),
+  // Encrypted: CR title/body exist only in this DB (the remote sees branches).
+  title: encryptedText('title').notNull(),
+  body: encryptedText('body').notNull().default(''),
+  authorEmail: encryptedText('author_email').notNull(), // lowercased at insert
+  /** Blind index of `author_email` — GDPR-erasure lookup. */
+  authorEmailBidx: text('author_email_bidx').notNull(),
+  authorName: encryptedText('author_name').notNull(),
   state: text('state').notNull().default('open'), // 'open' | 'merged' | 'closed'
   mergedSha: text('merged_sha'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -210,7 +239,7 @@ export const fileLocks = pgTable('file_locks', {
   branch: text('branch').notNull(),
   path: text('path').notNull(),
   holderUserId: uuid('holder_user_id').notNull().references(() => users.id),
-  holderName: text('holder_name').notNull(),
+  holderName: encryptedText('holder_name').notNull(),
   // How the lock was acquired. 'edit' (the default) is a normal write hold —
   // the holder is editing and the release publishes their bytes.
   // 'coordination' is a pure-mutex hold (see IWorkflowService.acquireLock)
@@ -271,8 +300,10 @@ export const pendingCommits = pgTable('pending_commits', {
   // Author attribution captured at enqueue. The denormalised name/email pair
   // lands on the eventual `git commit --author=` so the commit history shows
   // the human who triggered the save, not the worker.
-  authorEmail: text('author_email').notNull(),  // lowercased at insert
-  authorName: text('author_name').notNull(),
+  authorEmail: encryptedText('author_email').notNull(),  // lowercased at insert
+  /** Blind index of `author_email` — GDPR-erasure lookup. */
+  authorEmailBidx: text('author_email_bidx').notNull(),
+  authorName: encryptedText('author_name').notNull(),
   queuedAt: timestamp('queued_at').defaultNow().notNull(),
   // `running` is set while the worker is mid-commit so a second worker
   // (e.g. after a restart with another instance still draining) doesn't
@@ -285,7 +316,8 @@ export const pendingCommits = pgTable('pending_commits', {
   // `needs_attention` + feedback notice instead of looping forever.
   recoveryAgentRuns: integer('recovery_agent_runs').notNull().default(0),
   lastAttemptedAt: timestamp('last_attempted_at'),
-  lastError: text('last_error'),
+  // Encrypted: git/agent failure output can quote author identities and paths.
+  lastError: encryptedText('last_error'),
 }, (t) => ({
   // Primary read pattern: drain in queued order, scoped to a workspace.
   byWorkspaceQueued: index('pending_commits_by_workspace_queued').on(t.workspaceId, t.queuedAt),

--- a/packages/core-backend/src/modules/database/core-schema.ts
+++ b/packages/core-backend/src/modules/database/core-schema.ts
@@ -168,6 +168,9 @@ export const changeRequests = pgTable('change_requests', {
   sourceBranch: text('source_branch').notNull(),
   targetBranch: text('target_branch').notNull(),
   // Encrypted: CR title/body exist only in this DB (the remote sees branches).
+  // The DB-level default '' bypasses toDriver, which is fine: the empty string
+  // is deliberately stored unencrypted (see encryptPii), so a defaulted row
+  // and an app-written empty body hold the identical representation.
   title: encryptedText('title').notNull(),
   body: encryptedText('body').notNull().default(''),
   authorEmail: encryptedText('author_email').notNull(), // lowercased at insert

--- a/packages/core-backend/src/modules/database/migrate.ts
+++ b/packages/core-backend/src/modules/database/migrate.ts
@@ -1,5 +1,7 @@
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { sql } from 'drizzle-orm';
 import type { Database } from './connection.js';
+import { blindIndex, decryptPii, encryptPii, isEncryptedBlob } from '../../shared/column-crypto.js';
 
 /*
  * ── Per-tier migration folders ──────────────────────────────────────────────
@@ -40,4 +42,107 @@ export async function runEnterpriseMigrations(db: Database, folder: string): Pro
   console.log('Running enterprise database migrations...');
   await migrate(db, { migrationsFolder: folder, migrationsTable: '__drizzle_migrations_enterprise' });
   console.log('Enterprise migrations complete.');
+}
+
+/*
+ * ── PII column encryption backfill ──────────────────────────────────────────
+ *
+ * Migration 0005 adds the `*_bidx` columns; the DATA change — rewriting
+ * pre-existing plaintext PII to AES-256-GCM ciphertext and filling the blind
+ * indexes — happens here, programmatically, because it needs the key from the
+ * environment (SQL migrations cannot encrypt). Runs on every boot right after
+ * `runCoreMigrations` and is idempotent: ciphertext rows are recognised by
+ * shape (`iv:tag:ct`) and skipped, so a completed backfill degenerates to one
+ * read-only scan per table.
+ *
+ * Once every row is sealed, the same pass applies the constraints that could
+ * not ship in the SQL migration: SET NOT NULL on the bidx columns and the
+ * unique-index swap (`users_email_unique` on the now-randomized ciphertext is
+ * meaningless, `users_email_bidx_unq` takes over; same for
+ * `pr_file_approvals_unq` → `pr_file_approvals_bidx_unq`). The new unique
+ * index goes up BEFORE the old one is dropped so duplicate protection never
+ * has a gap. All statements are IF-EXISTS-guarded — re-running is a no-op.
+ */
+
+interface PiiBackfillTable {
+  table: string;
+  /** Columns that uniquely identify a row for the write-back UPDATE. */
+  key: string[];
+  /** Columns whose plaintext values get rewritten as ciphertext. */
+  encrypted: string[];
+  /** Blind-index column to fill from the plaintext of `source`. */
+  bidx?: { source: string; column: string };
+}
+
+const PII_BACKFILL_TABLES: PiiBackfillTable[] = [
+  { table: 'users', key: ['id'], encrypted: ['email', 'name', 'avatar_url'], bidx: { source: 'email', column: 'email_bidx' } },
+  { table: 'pr_file_approvals', key: ['id'], encrypted: ['approver_email', 'approver_name'], bidx: { source: 'approver_email', column: 'approver_email_bidx' } },
+  { table: 'pr_merge_log', key: ['id'], encrypted: ['triggered_by_email', 'triggered_by_name', 'error'], bidx: { source: 'triggered_by_email', column: 'triggered_by_email_bidx' } },
+  { table: 'pr_comments', key: ['id'], encrypted: ['author_email', 'author_name', 'body'], bidx: { source: 'author_email', column: 'author_email_bidx' } },
+  { table: 'change_requests', key: ['id'], encrypted: ['author_email', 'author_name', 'title', 'body'], bidx: { source: 'author_email', column: 'author_email_bidx' } },
+  { table: 'pending_commits', key: ['id'], encrypted: ['author_email', 'author_name', 'last_error'], bidx: { source: 'author_email', column: 'author_email_bidx' } },
+  { table: 'file_locks', key: ['workspace_id', 'branch', 'path'], encrypted: ['holder_name'] },
+];
+
+const ident = (name: string) => sql.raw(`"${name}"`);
+
+async function backfillTable(db: Database, t: PiiBackfillTable): Promise<number> {
+  const cols = [...t.key, ...t.encrypted, ...(t.bidx ? [t.bidx.column] : [])];
+  const result = await db.execute(
+    sql`SELECT ${sql.join(cols.map(ident), sql`, `)} FROM ${ident(t.table)}`,
+  );
+  let rewritten = 0;
+  for (const row of result.rows as Array<Record<string, unknown>>) {
+    const sets = [];
+    for (const col of t.encrypted) {
+      const value = row[col];
+      if (typeof value === 'string' && value !== '' && !isEncryptedBlob(value)) {
+        sets.push(sql`${ident(col)} = ${encryptPii(value)}`);
+      }
+    }
+    if (t.bidx && row[t.bidx.column] == null) {
+      // The source may already be ciphertext (a partial earlier run) — the
+      // blind index is always computed over the plaintext.
+      const source = row[t.bidx.source];
+      const plain = typeof source === 'string' ? decryptPii(source) : '';
+      sets.push(sql`${ident(t.bidx.column)} = ${blindIndex(plain)}`);
+    }
+    if (sets.length === 0) continue;
+    const where = t.key.map((k) => sql`${ident(k)} = ${row[k]}`);
+    await db.execute(
+      sql`UPDATE ${ident(t.table)} SET ${sql.join(sets, sql`, `)} WHERE ${sql.join(where, sql` AND `)}`,
+    );
+    rewritten += 1;
+  }
+  return rewritten;
+}
+
+const PII_FINALIZE_STATEMENTS = [
+  'ALTER TABLE "users" ALTER COLUMN "email_bidx" SET NOT NULL',
+  'CREATE UNIQUE INDEX IF NOT EXISTS "users_email_bidx_unq" ON "users" ("email_bidx")',
+  'ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_email_unique"',
+  'ALTER TABLE "pr_file_approvals" ALTER COLUMN "approver_email_bidx" SET NOT NULL',
+  'CREATE UNIQUE INDEX IF NOT EXISTS "pr_file_approvals_bidx_unq" ON "pr_file_approvals" ("pr_number","path","approver_email_bidx","head_sha")',
+  'DROP INDEX IF EXISTS "pr_file_approvals_unq"',
+  'ALTER TABLE "pr_merge_log" ALTER COLUMN "triggered_by_email_bidx" SET NOT NULL',
+  'ALTER TABLE "pr_comments" ALTER COLUMN "author_email_bidx" SET NOT NULL',
+  'ALTER TABLE "change_requests" ALTER COLUMN "author_email_bidx" SET NOT NULL',
+  'ALTER TABLE "pending_commits" ALTER COLUMN "author_email_bidx" SET NOT NULL',
+];
+
+/**
+ * Encrypt pre-existing plaintext PII rows, fill the blind-index columns, and
+ * apply the constraints migration 0005 deferred. Idempotent; run on every
+ * boot immediately after {@link runCoreMigrations}. Requires
+ * `initColumnCrypto` to have run (CoreConfig's constructor does).
+ */
+export async function runPiiEncryptionBackfill(db: Database): Promise<void> {
+  let rewritten = 0;
+  for (const t of PII_BACKFILL_TABLES) {
+    rewritten += await backfillTable(db, t);
+  }
+  if (rewritten > 0) console.log(`PII encryption backfill: rewrote ${rewritten} row(s).`);
+  for (const statement of PII_FINALIZE_STATEMENTS) {
+    await db.execute(sql.raw(statement));
+  }
 }

--- a/packages/core-backend/src/modules/database/migrate.ts
+++ b/packages/core-backend/src/modules/database/migrate.ts
@@ -1,7 +1,7 @@
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { sql } from 'drizzle-orm';
 import type { Database } from './connection.js';
-import { blindIndex, decryptPii, encryptPii, isEncryptedBlob } from '../../shared/column-crypto.js';
+import { PII_CIPHERTEXT_PREFIX, blindIndex, decryptPii, encryptPii, isEncryptedBlob } from '../../shared/column-crypto.js';
 
 /*
  * ── Per-tier migration folders ──────────────────────────────────────────────
@@ -51,17 +51,33 @@ export async function runEnterpriseMigrations(db: Database, folder: string): Pro
  * pre-existing plaintext PII to AES-256-GCM ciphertext and filling the blind
  * indexes — happens here, programmatically, because it needs the key from the
  * environment (SQL migrations cannot encrypt). Runs on every boot right after
- * `runCoreMigrations` and is idempotent: ciphertext rows are recognised by
- * shape (`iv:tag:ct`) and skipped, so a completed backfill degenerates to one
- * read-only scan per table.
+ * `runCoreMigrations` and is idempotent: sealed rows carry the
+ * `PII_CIPHERTEXT_PREFIX` marker and are excluded by the SELECT's own WHERE
+ * clause, so a completed backfill degenerates to one cheap, empty-result
+ * query per table.
  *
- * Once every row is sealed, the same pass applies the constraints that could
- * not ship in the SQL migration: SET NOT NULL on the bidx columns and the
- * unique-index swap (`users_email_unique` on the now-randomized ciphertext is
- * meaningless, `users_email_bidx_unq` takes over; same for
+ * Concurrency: the whole pass runs in ONE transaction that opens by taking
+ * `pg_advisory_xact_lock` on a constant key, so two instances booting at once
+ * serialize instead of interleaving. Each UPDATE is also compare-and-swap —
+ * the WHERE clause pins every value the row was read with — so a writer that
+ * slips in between the scan and the write (an old-version instance in a
+ * mixed-version window) loses nothing: the CAS update matches zero rows and
+ * the next boot's pass seals whatever that writer left behind. Deployments
+ * should still stop the old app before starting the new one (see
+ * UPGRADING.md); the lock and CAS make the failure mode of not doing so
+ * "unsealed until next boot", never "silently overwritten".
+ *
+ * Once every row is sealed, the same transaction applies the constraints that
+ * could not ship in the SQL migration: SET NOT NULL on the bidx columns and
+ * the unique-index swap (`users_email_unique` on the now-randomized
+ * ciphertext is meaningless, `users_email_bidx_unq` takes over; same for
  * `pr_file_approvals_unq` → `pr_file_approvals_bidx_unq`). The new unique
  * index goes up BEFORE the old one is dropped so duplicate protection never
- * has a gap. All statements are IF-EXISTS-guarded — re-running is a no-op.
+ * has a gap. Legacy rows that collide under the normalized blind index are
+ * handled first: duplicate approval rows (same logical approval, case-variant
+ * email) are collapsed; duplicate USERS are a genuine account conflict and
+ * abort the boot with the row ids so an operator can merge them deliberately.
+ * All statements are IF-EXISTS-guarded — re-running is a no-op.
  */
 
 interface PiiBackfillTable {
@@ -86,18 +102,43 @@ const PII_BACKFILL_TABLES: PiiBackfillTable[] = [
 
 const ident = (name: string) => sql.raw(`"${name}"`);
 
-async function backfillTable(db: Database, t: PiiBackfillTable): Promise<number> {
+/** What the backfill needs from a drizzle client — the db or a transaction. */
+type Executor = Pick<Database, 'execute'>;
+
+/**
+ * Constant key for `pg_advisory_xact_lock` serializing concurrent backfills.
+ * Arbitrary but stable — never reuse it for another lock.
+ */
+const PII_BACKFILL_LOCK_KEY = 7_458_392_017;
+
+/** A column "needs sealing" when it holds non-empty text without the prefix. */
+function needsSealing(col: string) {
+  return sql`(${ident(col)} IS NOT NULL AND ${ident(col)} <> '' AND ${ident(col)} NOT LIKE ${`${PII_CIPHERTEXT_PREFIX}%`})`;
+}
+
+async function backfillTable(tx: Executor, t: PiiBackfillTable): Promise<number> {
   const cols = [...t.key, ...t.encrypted, ...(t.bidx ? [t.bidx.column] : [])];
-  const result = await db.execute(
-    sql`SELECT ${sql.join(cols.map(ident), sql`, `)} FROM ${ident(t.table)}`,
+  // Only rows with work left: the ciphertext prefix makes "unsealed" a plain
+  // SQL predicate, so a fully-sealed table costs one empty-result query.
+  const pending = [
+    ...t.encrypted.map(needsSealing),
+    ...(t.bidx ? [sql`${ident(t.bidx.column)} IS NULL`] : []),
+  ];
+  const result = await tx.execute(
+    sql`SELECT ${sql.join(cols.map(ident), sql`, `)} FROM ${ident(t.table)} WHERE ${sql.join(pending, sql` OR `)}`,
   );
   let rewritten = 0;
   for (const row of result.rows as Array<Record<string, unknown>>) {
     const sets = [];
+    // Compare-and-swap: pin every value this row was read with, so a write
+    // that lands between scan and update makes this UPDATE match zero rows
+    // instead of clobbering the newer value.
+    const where = t.key.map((k) => sql`${ident(k)} = ${row[k]}`);
     for (const col of t.encrypted) {
       const value = row[col];
       if (typeof value === 'string' && value !== '' && !isEncryptedBlob(value)) {
         sets.push(sql`${ident(col)} = ${encryptPii(value)}`);
+        where.push(sql`${ident(col)} = ${value}`);
       }
     }
     if (t.bidx && row[t.bidx.column] == null) {
@@ -106,15 +147,43 @@ async function backfillTable(db: Database, t: PiiBackfillTable): Promise<number>
       const source = row[t.bidx.source];
       const plain = typeof source === 'string' ? decryptPii(source) : '';
       sets.push(sql`${ident(t.bidx.column)} = ${blindIndex(plain)}`);
+      where.push(sql`${ident(t.bidx.column)} IS NULL`);
     }
     if (sets.length === 0) continue;
-    const where = t.key.map((k) => sql`${ident(k)} = ${row[k]}`);
-    await db.execute(
+    const updated = await tx.execute(
       sql`UPDATE ${ident(t.table)} SET ${sql.join(sets, sql`, `)} WHERE ${sql.join(where, sql` AND `)}`,
     );
-    rewritten += 1;
+    rewritten += updated.rowCount ?? 0;
   }
   return rewritten;
+}
+
+/**
+ * Legacy uniqueness was on the RAW email, so rows differing only by case or
+ * whitespace could coexist; under the normalized blind index they collide and
+ * the unique-index creation below would abort the boot. Approval rows are the
+ * same logical approval — collapse them, keeping the earliest. Colliding USER
+ * rows are distinct accounts; refuse loudly with the ids so an operator
+ * resolves the conflict deliberately instead of the upgrade guessing.
+ */
+async function resolveBidxCollisions(tx: Executor): Promise<void> {
+  await tx.execute(sql.raw(`
+    DELETE FROM "pr_file_approvals" a USING "pr_file_approvals" b
+    WHERE a."pr_number" = b."pr_number" AND a."path" = b."path"
+      AND a."approver_email_bidx" = b."approver_email_bidx" AND a."head_sha" = b."head_sha"
+      AND (a."approved_at" > b."approved_at" OR (a."approved_at" = b."approved_at" AND a."id" > b."id"))
+  `));
+  const dupes = await tx.execute(sql.raw(`
+    SELECT array_agg("id") AS ids FROM "users" GROUP BY "email_bidx" HAVING count(*) > 1
+  `));
+  if (dupes.rows.length > 0) {
+    const groups = (dupes.rows as Array<{ ids: string[] }>).map((r) => r.ids.join(', '));
+    throw new Error(
+      'PII encryption backfill: multiple user rows share the same email after normalization ' +
+        '(case/whitespace variants of one address). Merge or delete the duplicates, then restart. ' +
+        `Conflicting user ids: [${groups.join('], [')}]`,
+    );
+  }
 }
 
 const PII_FINALIZE_STATEMENTS = [
@@ -137,12 +206,19 @@ const PII_FINALIZE_STATEMENTS = [
  * `initColumnCrypto` to have run (CoreConfig's constructor does).
  */
 export async function runPiiEncryptionBackfill(db: Database): Promise<void> {
-  let rewritten = 0;
-  for (const t of PII_BACKFILL_TABLES) {
-    rewritten += await backfillTable(db, t);
-  }
-  if (rewritten > 0) console.log(`PII encryption backfill: rewrote ${rewritten} row(s).`);
-  for (const statement of PII_FINALIZE_STATEMENTS) {
-    await db.execute(sql.raw(statement));
-  }
+  await db.transaction(async (tx) => {
+    // One backfill at a time, released at commit/rollback. Transaction-scoped
+    // (not session-scoped) because the pool hands each statement its own
+    // connection outside a transaction.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(${sql.raw(String(PII_BACKFILL_LOCK_KEY))})`);
+    let rewritten = 0;
+    for (const t of PII_BACKFILL_TABLES) {
+      rewritten += await backfillTable(tx, t);
+    }
+    if (rewritten > 0) console.log(`PII encryption backfill: rewrote ${rewritten} row(s).`);
+    await resolveBidxCollisions(tx);
+    for (const statement of PII_FINALIZE_STATEMENTS) {
+      await tx.execute(sql.raw(statement));
+    }
+  });
 }

--- a/packages/core-backend/src/modules/database/migrate.ts
+++ b/packages/core-backend/src/modules/database/migrate.ts
@@ -111,9 +111,21 @@ type Executor = Pick<Database, 'execute'>;
  */
 const PII_BACKFILL_LOCK_KEY = 7_458_392_017;
 
-/** A column "needs sealing" when it holds non-empty text without the prefix. */
+/**
+ * SQL approximation of `isEncryptedBlob`: the version prefix followed by
+ * base64 segments with the exact widths GCM produces (12-byte IV → 16 chars,
+ * 16-byte tag → 22 chars + `==`). Deliberately a NEGATIVE filter: anything
+ * failing it — including plaintext that merely BEGINS with the prefix — is
+ * selected and re-examined app-side by `isEncryptedBlob`, so only values
+ * byte-for-byte indistinguishable from a well-formed blob are trusted as
+ * sealed. Sealed rows all match, keeping the steady-state scan an
+ * empty-result query.
+ */
+const SEALED_SHAPE_REGEX = `^${PII_CIPHERTEXT_PREFIX}[A-Za-z0-9+/]{16}:[A-Za-z0-9+/]{22}==:[A-Za-z0-9+/]+={0,2}$`;
+
+/** A column "needs sealing" when it holds non-empty text that isn't a blob. */
 function needsSealing(col: string) {
-  return sql`(${ident(col)} IS NOT NULL AND ${ident(col)} <> '' AND ${ident(col)} NOT LIKE ${`${PII_CIPHERTEXT_PREFIX}%`})`;
+  return sql`(${ident(col)} IS NOT NULL AND ${ident(col)} <> '' AND ${ident(col)} !~ ${SEALED_SHAPE_REGEX})`;
 }
 
 async function backfillTable(tx: Executor, t: PiiBackfillTable): Promise<number> {
@@ -143,11 +155,25 @@ async function backfillTable(tx: Executor, t: PiiBackfillTable): Promise<number>
     }
     if (t.bidx && row[t.bidx.column] == null) {
       // The source may already be ciphertext (a partial earlier run) — the
-      // blind index is always computed over the plaintext.
+      // blind index is always computed over the plaintext. If the source is
+      // ciphertext the configured key cannot open, refuse rather than derive
+      // a blind index from ciphertext (it would never match a real lookup).
       const source = row[t.bidx.source];
-      const plain = typeof source === 'string' ? decryptPii(source) : '';
+      const raw = typeof source === 'string' ? source : '';
+      const plain = decryptPii(raw);
+      if (isEncryptedBlob(plain)) {
+        throw new Error(
+          `PII encryption backfill: ${t.table}.${t.bidx.source} cannot be decrypted with the ` +
+            'configured SECRETS_ENC_KEY — refusing to derive a blind index from ciphertext. ' +
+            'Restore the key that sealed it, then restart.',
+        );
+      }
       sets.push(sql`${ident(t.bidx.column)} = ${blindIndex(plain)}`);
       where.push(sql`${ident(t.bidx.column)} IS NULL`);
+      // Pin the source too: if a concurrent writer replaces the email between
+      // scan and write, the CAS must not attach the OLD email's blind index
+      // to the NEW value.
+      where.push(sql`${ident(t.bidx.source)} IS NOT DISTINCT FROM ${source ?? null}`);
     }
     if (sets.length === 0) continue;
     const updated = await tx.execute(

--- a/packages/core-backend/src/modules/workflow/pending-commits.service.ts
+++ b/packages/core-backend/src/modules/workflow/pending-commits.service.ts
@@ -37,6 +37,7 @@
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import type { Database } from '../database/connection.js';
 import { pendingCommits } from '../database/schema.js';
+import { blindIndex } from '../../shared/column-crypto.js';
 
 /**
  * Transient-failure budget per recovery cycle. After this many consecutive
@@ -191,6 +192,7 @@ export class PendingCommitsService {
       .set({
         queuedAt: new Date(),
         authorEmail: email,
+        authorEmailBidx: blindIndex(email),
         authorName: input.authorName,
         // Reset transient counters — this is effectively a fresh enqueue.
         attempts: 0,
@@ -212,6 +214,7 @@ export class PendingCommitsService {
       branch: input.branch,
       path: input.path,
       authorEmail: email,
+      authorEmailBidx: blindIndex(email),
       authorName: input.authorName,
     });
   }
@@ -245,11 +248,13 @@ export class PendingCommitsService {
         ),
       );
     if ((rows[0]?.count ?? 0) > 0) return false;
+    const email = input.authorEmail.trim().toLowerCase();
     await this.db.insert(pendingCommits).values({
       workspaceId,
       branch: input.branch,
       path: input.path,
-      authorEmail: input.authorEmail.trim().toLowerCase(),
+      authorEmail: email,
+      authorEmailBidx: blindIndex(email),
       authorName: input.authorName,
     });
     return true;

--- a/packages/core-backend/src/modules/workflow/recovery-bot.ts
+++ b/packages/core-backend/src/modules/workflow/recovery-bot.ts
@@ -20,6 +20,7 @@ import { eq } from 'drizzle-orm';
 import type { AuthUser } from '@bevel-software/platform-shared';
 import type { Database } from '../database/connection.js';
 import { users } from '../database/schema.js';
+import { blindIndex } from '../../shared/column-crypto.js';
 
 export const RECOVERY_BOT_EMAIL = (
   process.env.RECOVERY_BOT_EMAIL ?? 'recovery-bot@bevel.local'
@@ -38,8 +39,12 @@ export const RECOVERY_BOT_NAME = 'Bevel Recovery Bot';
 export async function ensureRecoveryBotUser(db: Database): Promise<AuthUser> {
   const inserted = await db
     .insert(users)
-    .values({ email: RECOVERY_BOT_EMAIL, name: RECOVERY_BOT_NAME })
-    .onConflictDoNothing({ target: users.email })
+    .values({
+      email: RECOVERY_BOT_EMAIL,
+      emailBidx: blindIndex(RECOVERY_BOT_EMAIL),
+      name: RECOVERY_BOT_NAME,
+    })
+    .onConflictDoNothing({ target: users.emailBidx })
     .returning();
   if (inserted.length > 0) {
     const row = inserted[0];
@@ -54,7 +59,7 @@ export async function ensureRecoveryBotUser(db: Database): Promise<AuthUser> {
   const [row] = await db
     .select()
     .from(users)
-    .where(eq(users.email, RECOVERY_BOT_EMAIL))
+    .where(eq(users.emailBidx, blindIndex(RECOVERY_BOT_EMAIL)))
     .limit(1);
   if (!row) {
     // Vanishingly unlikely: the row exists for the conflict to fire but is

--- a/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/review-workflow/review-workflow.service.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../shared/domain-errors.js';
 import type { WorkspaceService } from '../../workspace/workspace.service.js';
 import { hashEmail } from '../../../shared/hash-email.js';
+import { blindIndex } from '../../../shared/column-crypto.js';
 import type {
   IReviewWorkflowService,
   MergeGateInput,
@@ -271,6 +272,7 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
       .values({
         prNumber,
         authorEmail: user.email.trim().toLowerCase(),
+        authorEmailBidx: blindIndex(user.email),
         authorName: user.name,
         path: input.path ?? null,
         line: input.line ?? null,
@@ -493,7 +495,7 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
     if (!canApprove) throw new ApprovalAuthError('not-eligible');
     const callerEmail = user.email.trim().toLowerCase();
 
-    // Unique index on (prNumber, path, approverEmail, headSha) makes this
+    // Unique index on (prNumber, path, approverEmailBidx, headSha) makes this
     // idempotent — `onConflictDoNothing` turns a double-click into a no-op.
     await this.db
       .insert(prFileApprovals)
@@ -501,6 +503,7 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
         prNumber,
         path,
         approverEmail: callerEmail,
+        approverEmailBidx: blindIndex(callerEmail),
         approverName: user.name,
         headSha,
       })
@@ -620,6 +623,7 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
       .values({
         prNumber,
         triggeredByEmail,
+        triggeredByEmailBidx: blindIndex(triggeredByEmail),
         triggeredByName: user.name,
         headShaAtMerge: headSha,
         mergeMethod: MERGE_METHOD,
@@ -799,15 +803,15 @@ export class ReviewWorkflowService implements IReviewWorkflowService {
     const callerEmail = user.email.trim().toLowerCase();
 
     // Only revoke the caller's OWN approval — never someone else's. Filter on
-    // (PR, path, approverEmail) without pinning the SHA so a user revoking
-    // after a force-push can drop their stale row in one click.
+    // (PR, path, approver blind index) without pinning the SHA so a user
+    // revoking after a force-push can drop their stale row in one click.
     await this.db
       .delete(prFileApprovals)
       .where(
         and(
           eq(prFileApprovals.prNumber, prNumber),
           eq(prFileApprovals.path, path),
-          eq(prFileApprovals.approverEmail, callerEmail),
+          eq(prFileApprovals.approverEmailBidx, blindIndex(callerEmail)),
         ),
       );
 

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -59,6 +59,7 @@ import type { FileChangeNotifier } from '../kb-fs/file-change-notifier.js';
 import { WorkflowHooks } from './workflow-hooks.js';
 import { WorkspaceMutex } from '../kb-fs/mutex.js';
 import { hashEmail } from '../../shared/hash-email.js';
+import { blindIndex } from '../../shared/column-crypto.js';
 import {
   ChangeRequestConflictsError,
   DuplicateChangeRequestError,
@@ -1450,6 +1451,7 @@ export class WorkflowService implements IWorkflowService {
           title: input.title.trim(),
           body,
           authorEmail: user.email.trim().toLowerCase(),
+          authorEmailBidx: blindIndex(user.email),
           authorName: user.name,
         })
         .returning({ number: changeRequests.number });

--- a/packages/core-backend/src/shared/__tests__/column-crypto.test.ts
+++ b/packages/core-backend/src/shared/__tests__/column-crypto.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import {
+  blindIndex,
+  decryptPii,
+  encryptPii,
+  initColumnCrypto,
+  isEncryptedBlob,
+} from '../column-crypto.js';
+
+const KEY = randomBytes(32).toString('base64');
+
+beforeAll(() => {
+  initColumnCrypto(KEY);
+});
+
+describe('encryptPii / decryptPii', () => {
+  it('round-trips a value through ciphertext', () => {
+    const sealed = encryptPii('razvan@bevel.software');
+    expect(sealed).not.toContain('razvan');
+    expect(isEncryptedBlob(sealed)).toBe(true);
+    expect(decryptPii(sealed)).toBe('razvan@bevel.software');
+  });
+
+  it('is randomized — the same plaintext never encrypts to the same blob', () => {
+    expect(encryptPii('alice')).not.toBe(encryptPii('alice'));
+  });
+
+  it('passes legacy plaintext through unchanged (pre-backfill rows)', () => {
+    expect(decryptPii('plain old email@example.com')).toBe('plain old email@example.com');
+    expect(decryptPii('')).toBe('');
+  });
+
+  it('passes through a colon-y plaintext that merely resembles the blob shape', () => {
+    // Three base64-ish segments but wrong decoded lengths → not a blob.
+    const impostor = 'abc:def:ghi';
+    expect(isEncryptedBlob(impostor)).toBe(false);
+    expect(decryptPii(impostor)).toBe(impostor);
+  });
+
+  it('domain-separates from the raw secrets key: a different init decrypts nothing', () => {
+    const sealed = encryptPii('secret-person@example.com');
+    initColumnCrypto(randomBytes(32).toString('base64'));
+    // Wrong key → GCM auth failure → plaintext fallback returns the blob as-is.
+    expect(decryptPii(sealed)).toBe(sealed);
+    initColumnCrypto(KEY);
+    expect(decryptPii(sealed)).toBe('secret-person@example.com');
+  });
+});
+
+describe('blindIndex', () => {
+  it('is deterministic and case/whitespace-insensitive', () => {
+    expect(blindIndex('Alice@Example.com ')).toBe(blindIndex('alice@example.com'));
+    expect(blindIndex('alice@example.com')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('differs across values', () => {
+    expect(blindIndex('a@example.com')).not.toBe(blindIndex('b@example.com'));
+  });
+
+  it('differs across keys', () => {
+    const first = blindIndex('a@example.com');
+    initColumnCrypto(randomBytes(32).toString('base64'));
+    expect(blindIndex('a@example.com')).not.toBe(first);
+    initColumnCrypto(KEY);
+  });
+});

--- a/packages/core-backend/src/shared/__tests__/column-crypto.test.ts
+++ b/packages/core-backend/src/shared/__tests__/column-crypto.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import { randomBytes } from 'node:crypto';
 import {
+  PII_CIPHERTEXT_PREFIX,
   blindIndex,
   decryptPii,
   encryptPii,
   initColumnCrypto,
   isEncryptedBlob,
 } from '../column-crypto.js';
+import { TokenCrypto } from '../token-crypto.js';
 
 const KEY = randomBytes(32).toString('base64');
 
@@ -18,8 +20,15 @@ describe('encryptPii / decryptPii', () => {
   it('round-trips a value through ciphertext', () => {
     const sealed = encryptPii('razvan@bevel.software');
     expect(sealed).not.toContain('razvan');
+    expect(sealed.startsWith(PII_CIPHERTEXT_PREFIX)).toBe(true);
     expect(isEncryptedBlob(sealed)).toBe(true);
     expect(decryptPii(sealed)).toBe('razvan@bevel.software');
+  });
+
+  it('stores the empty string as itself (no unparseable empty-ciphertext blob)', () => {
+    expect(encryptPii('')).toBe('');
+    expect(decryptPii('')).toBe('');
+    expect(isEncryptedBlob('')).toBe(false);
   });
 
   it('is randomized — the same plaintext never encrypts to the same blob', () => {
@@ -31,20 +40,32 @@ describe('encryptPii / decryptPii', () => {
     expect(decryptPii('')).toBe('');
   });
 
-  it('passes through a colon-y plaintext that merely resembles the blob shape', () => {
-    // Three base64-ish segments but wrong decoded lengths → not a blob.
-    const impostor = 'abc:def:ghi';
+  it('passes through plaintext that merely resembles ciphertext', () => {
+    // Blob-shaped but unprefixed (the legacy TokenCrypto shape) → plaintext.
+    const shapeOnly = new TokenCrypto(KEY).encrypt('not-a-pii-blob');
+    expect(isEncryptedBlob(shapeOnly)).toBe(false);
+    expect(decryptPii(shapeOnly)).toBe(shapeOnly);
+    // Prefixed but malformed → still not a blob.
+    const impostor = `${PII_CIPHERTEXT_PREFIX}abc:def:ghi`;
     expect(isEncryptedBlob(impostor)).toBe(false);
     expect(decryptPii(impostor)).toBe(impostor);
   });
 
-  it('domain-separates from the raw secrets key: a different init decrypts nothing', () => {
+  it('a re-init with a different key cannot decrypt: fallback returns the blob', () => {
     const sealed = encryptPii('secret-person@example.com');
     initColumnCrypto(randomBytes(32).toString('base64'));
     // Wrong key → GCM auth failure → plaintext fallback returns the blob as-is.
     expect(decryptPii(sealed)).toBe(sealed);
     initColumnCrypto(KEY);
     expect(decryptPii(sealed)).toBe('secret-person@example.com');
+  });
+
+  it('domain-separates from the raw secrets key via HKDF', () => {
+    // The column key is DERIVED from KEY — a TokenCrypto built from the raw
+    // KEY itself must not be able to open a PII blob's body.
+    const sealed = encryptPii('secret-person@example.com');
+    const body = sealed.slice(PII_CIPHERTEXT_PREFIX.length);
+    expect(() => new TokenCrypto(KEY).decrypt(body)).toThrow();
   });
 });
 

--- a/packages/core-backend/src/shared/column-crypto.ts
+++ b/packages/core-backend/src/shared/column-crypto.ts
@@ -43,12 +43,24 @@ function requireCrypto(): TokenCrypto {
 }
 
 /**
- * Whether `value` has the `iv:tag:ct` shape TokenCrypto produces (12-byte IV,
- * 16-byte tag, base64 parts). Used to tell ciphertext from legacy plaintext
- * during the backfill and in {@link decryptPii}'s fallback.
+ * Every PII ciphertext starts with this marker. An explicit prefix — rather
+ * than recognising ciphertext by its `iv:tag:ct` shape — means legacy
+ * plaintext can never be mistaken for ciphertext (and silently skipped by the
+ * backfill), and lets the backfill find unsealed rows with a plain SQL
+ * `NOT LIKE 'pii:v1:%'` instead of scanning every row in the app. Bump the
+ * version segment if the format ever changes.
+ */
+export const PII_CIPHERTEXT_PREFIX = 'pii:v1:';
+
+/**
+ * Whether `value` is a PII ciphertext blob: the version prefix followed by
+ * TokenCrypto's `iv:tag:ct` (12-byte IV, 16-byte tag, base64 parts). Used to
+ * tell ciphertext from legacy plaintext during the backfill and in
+ * {@link decryptPii}'s fallback.
  */
 export function isEncryptedBlob(value: string): boolean {
-  const parts = value.split(':');
+  if (!value.startsWith(PII_CIPHERTEXT_PREFIX)) return false;
+  const parts = value.slice(PII_CIPHERTEXT_PREFIX.length).split(':');
   if (parts.length !== 3) return false;
   const [iv, tag, ct] = parts;
   if (!iv || !tag || !ct) return false;
@@ -57,20 +69,30 @@ export function isEncryptedBlob(value: string): boolean {
   return Buffer.from(iv, 'base64').length === 12 && Buffer.from(tag, 'base64').length === 16;
 }
 
-/** Encrypt a PII value for storage (fresh random IV — NOT equality-comparable). */
+/**
+ * Encrypt a PII value for storage (fresh random IV — NOT equality-comparable).
+ *
+ * The empty string is stored as itself: it carries no personal data, GCM of an
+ * empty plaintext would produce an empty ciphertext segment the blob parser
+ * cannot represent, and columns with a DB-level `DEFAULT ''` (which bypasses
+ * this function entirely) then hold exactly the same representation as an
+ * app-written empty value.
+ */
 export function encryptPii(value: string): string {
-  return requireCrypto().encrypt(value);
+  if (value === '') return '';
+  return PII_CIPHERTEXT_PREFIX + requireCrypto().encrypt(value);
 }
 
 /**
- * Decrypt a stored PII value. A value that does not look like ciphertext — or
- * fails to decrypt — is returned as-is: rows written before the encryption
- * release stay readable until the boot-time backfill rewrites them.
+ * Decrypt a stored PII value. A value that does not carry the ciphertext
+ * prefix — or fails to decrypt (a different key) — is returned as-is: rows
+ * written before the encryption release stay readable until the boot-time
+ * backfill rewrites them.
  */
 export function decryptPii(value: string): string {
   if (!isEncryptedBlob(value)) return value;
   try {
-    return requireCrypto().decrypt(value);
+    return requireCrypto().decrypt(value.slice(PII_CIPHERTEXT_PREFIX.length));
   } catch {
     return value;
   }

--- a/packages/core-backend/src/shared/column-crypto.ts
+++ b/packages/core-backend/src/shared/column-crypto.ts
@@ -1,0 +1,111 @@
+import { createHmac, hkdfSync } from 'node:crypto';
+import { customType } from 'drizzle-orm/pg-core';
+import { TokenCrypto, assertKeyDecodesTo32Bytes } from './token-crypto.js';
+
+/**
+ * Application-layer encryption for PII columns. Personal data (emails, names,
+ * change-request text) is AES-256-GCM ciphertext in Postgres, so a leaked
+ * dump, an injected query, or a compromised DB credential yields no personal
+ * data — the key lives only in the app's environment. Disk-level encryption
+ * still carries the blanket at-rest claim (git refs, WAL, logs); this layer is
+ * the DB-specific control on top.
+ *
+ * Both keys are HKDF-derived from `SECRETS_ENC_KEY` with distinct info
+ * strings, so PII ciphertext and blind indexes are domain-separated from the
+ * secrets-vault key without asking operators to provision a second variable.
+ *
+ * Module-level state rather than DI, deliberately: the drizzle column type
+ * below is referenced from the schema module, which is imported long before
+ * any composition root runs. {@link initColumnCrypto} must therefore be called
+ * before the first query — `CoreConfig`'s constructor does it the moment the
+ * key is validated, so anything that can reach a database has already passed
+ * through it.
+ */
+
+let columnCrypto: TokenCrypto | null = null;
+let bidxKey: Buffer | null = null;
+
+/** Derive and install the PII column + blind-index keys. Idempotent. */
+export function initColumnCrypto(secretsEncKey: string): void {
+  const ikm = assertKeyDecodesTo32Bytes(secretsEncKey, 'SECRETS_ENC_KEY');
+  const columnKey = Buffer.from(hkdfSync('sha256', ikm, Buffer.alloc(0), 'bevel-pii-column-v1', 32));
+  bidxKey = Buffer.from(hkdfSync('sha256', ikm, Buffer.alloc(0), 'bevel-pii-bidx-v1', 32));
+  columnCrypto = new TokenCrypto(columnKey.toString('base64'));
+}
+
+function requireCrypto(): TokenCrypto {
+  if (!columnCrypto) {
+    throw new Error(
+      'PII column crypto used before initColumnCrypto() — construct CoreConfig (or call initColumnCrypto) before touching the database.',
+    );
+  }
+  return columnCrypto;
+}
+
+/**
+ * Whether `value` has the `iv:tag:ct` shape TokenCrypto produces (12-byte IV,
+ * 16-byte tag, base64 parts). Used to tell ciphertext from legacy plaintext
+ * during the backfill and in {@link decryptPii}'s fallback.
+ */
+export function isEncryptedBlob(value: string): boolean {
+  const parts = value.split(':');
+  if (parts.length !== 3) return false;
+  const [iv, tag, ct] = parts;
+  if (!iv || !tag || !ct) return false;
+  const b64 = /^[A-Za-z0-9+/]+={0,2}$/;
+  if (!b64.test(iv) || !b64.test(tag) || !b64.test(ct)) return false;
+  return Buffer.from(iv, 'base64').length === 12 && Buffer.from(tag, 'base64').length === 16;
+}
+
+/** Encrypt a PII value for storage (fresh random IV — NOT equality-comparable). */
+export function encryptPii(value: string): string {
+  return requireCrypto().encrypt(value);
+}
+
+/**
+ * Decrypt a stored PII value. A value that does not look like ciphertext — or
+ * fails to decrypt — is returned as-is: rows written before the encryption
+ * release stay readable until the boot-time backfill rewrites them.
+ */
+export function decryptPii(value: string): string {
+  if (!isEncryptedBlob(value)) return value;
+  try {
+    return requireCrypto().decrypt(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Blind index for equality lookups on encrypted columns: HMAC-SHA256 of the
+ * trimmed, lower-cased value, hex-encoded. Deterministic, so a `*_bidx`
+ * column can carry the unique constraints and `eq()` lookups that randomized
+ * ciphertext cannot. Reveals only equality, never content.
+ */
+export function blindIndex(value: string): string {
+  if (!bidxKey) {
+    throw new Error(
+      'PII blind-index key used before initColumnCrypto() — construct CoreConfig (or call initColumnCrypto) before touching the database.',
+    );
+  }
+  return createHmac('sha256', bidxKey).update(value.trim().toLowerCase()).digest('hex');
+}
+
+/**
+ * Drizzle column type for encrypted PII text: services read and write
+ * plaintext, the database only ever sees ciphertext. NEVER use an
+ * `encryptedText` column in a WHERE clause or conflict target — the fresh IV
+ * per write means `eq(column, plaintext)` silently matches nothing. Equality
+ * goes through the column's `*_bidx` companion and {@link blindIndex}.
+ */
+export const encryptedText = customType<{ data: string; driverData: string }>({
+  dataType() {
+    return 'text';
+  },
+  toDriver(value: string): string {
+    return encryptPii(value);
+  },
+  fromDriver(value: string): string {
+    return decryptPii(value);
+  },
+});

--- a/packages/core-backend/src/test-setup.ts
+++ b/packages/core-backend/src/test-setup.ts
@@ -1,4 +1,6 @@
+import { randomBytes } from 'node:crypto';
 import { branchModelFromEnv, configureBranchModel } from '@bevel-software/platform-shared';
+import { initColumnCrypto } from './shared/column-crypto.js';
 
 /**
  * Apply the branch model before any suite imports something that reads it.
@@ -16,3 +18,12 @@ import { branchModelFromEnv, configureBranchModel } from '@bevel-software/platfo
  * place the historical two-branch pair is written.
  */
 configureBranchModel(branchModelFromEnv());
+
+/**
+ * Same reasoning for the PII column crypto: production initializes it in
+ * `CoreConfig`'s constructor, which most suites never run. Services call
+ * `blindIndex`/`encryptPii` on their write paths, so an uninitialized key
+ * would fail every such test. A random per-run key is deliberate — nothing
+ * in a unit test may depend on a specific ciphertext.
+ */
+initColumnCrypto(randomBytes(32).toString('base64'));

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -367,8 +367,11 @@ describe('SkillPage', () => {
     expect(await screen.findByRole('heading', { name: 'newsletter' })).toBeInTheDocument();
     expect(apiMock.getSkill).toHaveBeenCalledWith('newsletter');
 
-    // Needed integration derived from allowed-tools, with its connection state.
-    expect(screen.getByText('slack')).toBeInTheDocument();
+    // Needed integration derived from allowed-tools, with its connection
+    // state. AWAITED: the integrations section hangs off its own fetch, so on
+    // a slow runner it lands after the heading — the sync getByText here was
+    // the CI flake.
+    expect(await screen.findByText('slack')).toBeInTheDocument();
     expect(screen.getByText('Needs your sign-in')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Connect/ })).toBeInTheDocument();
 


### PR DESCRIPTION
## What

Personal data in the database is now AES-256-GCM ciphertext: emails, display names, avatar URLs (including the denormalized author/approver/holder copies on `pr_file_approvals`, `pr_merge_log`, `pr_comments`, `change_requests`, `pending_commits`, `file_locks`), change-request titles/bodies, review comment bodies, and merge/queue error text. A leaked dump, an injected query, or a compromised DB credential yields no personal data — the key lives only in the app environment. Disk encryption still carries the blanket at-rest claim; this is the DB-specific control on top of it (DPA work).

## How

- **`shared/column-crypto.ts`** — two subkeys HKDF-derived from the existing `SECRETS_ENC_KEY` (no new env var): an `encryptedText` drizzle column type (randomized ciphertext on write, transparent decrypt on read, plaintext fallback for pre-upgrade rows) and a deterministic HMAC `blindIndex` for equality.
- **Blind-index companions** — randomized ciphertext can't back `eq()` or unique constraints, so six `*_bidx` columns carry them: login lookup, user upserts (conflict target moves from `users.email` to `users.email_bidx`), bot ensures, approval insert/revoke idempotency, and GDPR erasure — which also re-keys the bidx to the placeholder so nothing linkable to the erased address survives.
- **Migration 0005 + boot backfill** — the SQL migration only adds nullable columns; `runPiiEncryptionBackfill` (runs right after core migrations on every boot, idempotent) seals existing plaintext rows, fills the blind indexes, then swaps the unique constraints (`users_email_unique` → `users_email_bidx_unq`, `pr_file_approvals_unq` → `pr_file_approvals_bidx_unq`; the new index goes up before the old drops).
- **Init** — `initColumnCrypto` runs in `CoreConfig`'s constructor (and the vitest setup), so keys exist before anything touches the database.
- Everything is exported from the package (`encryptedText`, `blindIndex`, `runPiiEncryptionBackfill`, …) so the enterprise overlay can seal its own schema's columns the same way in a follow-up.

Deliberately plaintext: branch/path/workspace columns (SQL keys, and duplicated as plaintext git refs/URLs/logs on the same host — disk encryption covers them), hashes, statuses, non-PII jsonb.

## Ops note

From this version, losing `SECRETS_ENC_KEY` loses the PII columns, not just stored credentials — UPGRADING.md and `.env.example` now say to escrow the key outside the server.

## Verification

- Typecheck clean; full suite green (2033 tests, incl. new `column-crypto` unit tests).
- End-to-end against a real Postgres 18: fresh migrate → seeded pre-upgrade plaintext rows → backfill seals them (raw SQL shows only ciphertext, `email_bidx = blindIndex(email)`) → constraint swap verified in `pg_catalog` → login/upsert/erasure through blind indexes → second backfill pass is a byte-identical no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encrypts PII columns at the application layer — emails, display names, avatar URLs (including denormalized author/approver/holder copies), change-request titles/bodies, review comment bodies, and merge/queue error text are now AES-256-GCM ciphertext in Postgres. A leaked dump, injected query, or compromised DB credential no longer yields personal data; disk encryption still covers the blanket at-rest claim. Also fixes a CI flake in the SkillPage load test by awaiting the integrations section.

**Migration**
- Keys are HKDF-derived from `SECRETS_ENC_KEY` with no new env var; losing that key now loses these columns too, so escrow a copy outside the server.
- First boot seals existing plaintext rows, collapses near-duplicate approvals, and swaps unique constraints onto the blind-index columns; upgrade with a single app instance.
- Ad-hoc SQL equality against these columns (looking up a user by email in `psql`) no longer works — use the app or API.

**How it works**
- Randomized ciphertext can't back `eq()` or unique constraints, so six `*_bidx` HMAC blind indexes carry login lookups, user upserts, bot ensures, approval idempotency, and GDPR erasure.
- The boot backfill runs in one transaction under an advisory lock; a strict sealed-row check catches plaintext that merely resembles ciphertext, and compare-and-swap updates mean concurrent or mixed-version boots may delay sealing but never overwrite newer data or pair a blind index with a value it wasn't read with.
- GDPR erasure fails closed if the stored email can't be decrypted with the configured key, then re-keys the blind index to the placeholder.

<sup>Written for commit dcaee86eaf25fa61b2cb8a1345a3a1608864a61e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

