### PR TITLE
Skills root, linked plugins, compiled marketplace, customer dialect

### DIFF
--- a/.changeset/skills-root-linked-plugins.md
+++ b/.changeset/skills-root-linked-plugins.md
@@ -1,0 +1,11 @@
+---
+'@bevel-software/platform-core-backend': minor
+'@bevel-software/platform-core-frontend': minor
+'@bevel-software/platform-shared': minor
+---
+
+Skills have a home of their own, and plugins link to them instead of holding a copy. A new `Skills/` root stores shared skills organised by who owns them; a plugin lists the skills it uses in its manifest, so one skill can ship in many plugins. Who may read a skill comes from the skill's own access rules, and a plugin's members can be granted anywhere as `plugin/<Name>/read`, `plugin/<Name>/write` or `plugin/<Name>/owner`, the way a group is. Linking, requesting write access to a skill, and repairing a link all happen from the plugin and skill pages.
+
+Skills also reach agents as native plugins: every user can clone a git remote from the external-agent access page that holds a plugin marketplace compiled from exactly what they may read, with a one-command install for Claude Code and Codex and a flat layout for the skills CLI. The knowledge base's MCP endpoint ships inside it.
+
+A knowledge base laid out by someone else can be read in place: the three root folder names are settings, and plugins described by a `plugin.bundle.json` with an MCP registry are read read-only. On the first start after the upgrade, `Skills/` is created and every legacy plugin folder gets its manifest; nothing needs doing by hand.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,12 @@ Database migrations and the knowledge-base maintenance phase run
 automatically while the app boots — no manual steps, but the first start
 after an upgrade can take a little longer.
 
+The maintenance phase commits to the knowledge base on every branch when a
+release needs it. The current steps: rename a legacy `Groups/` root to
+`Plugins/`; create the `Skills/` root and hide it from the Knowledge tree
+like `Plugins/`; write a `plugin.json` into every plugin folder that predates
+the manifest. Each is idempotent, so a second start writes nothing.
+
 **Downgrading is not supported** once a version's migrations have run: an
 older app cannot read a newer database. To go back, restore the backup you
 took before upgrading.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ pin in `.env` cannot be changed out from under you in the UI.
 | `LOGIN_PASSWORD` | no | `false` hides password login and rejects the endpoint |
 | `PORT` | no | Backend port (default 3001) |
 | `KB_DIR_NAME` | no | Directory name of the KB clone inside each workspace |
+| `KB_KNOWLEDGE_BASE_DIR` / `KB_SKILLS_DIR` / `KB_PLUGINS_DIR` | setup screen | The three top-level folders of the repository (defaults `KnowledgeBase`, `Skills`, `Plugins`). Rename them to read a repository laid out by someone else; the three must differ. Restart to apply |
 | `TENANT_ID` | no | Slug branding credential prefixes (default `bevel`) |
 | `KB_TEMPLATE_DIR` | no | Overrides the packaged KB seed template |
 | `ONTOLOGY_SESSION_BLOCK` | no | Ontology-session touch tracking toggle (default on) |

--- a/packages/core-backend/kb-template/.bevelignore
+++ b/packages/core-backend/kb-template/.bevelignore
@@ -22,6 +22,6 @@ CLAUDE.md
 **/access.md
 roles.yaml
 
-Plugins/
-# The shared-skills root is rendered by the Skills & Tools app, like Plugins/.
-Skills/
+{{pluginsDir}}/
+# The shared-skills root is rendered by the Skills & Tools app, like {{pluginsDir}}/.
+{{skillsDir}}/

--- a/packages/core-backend/kb-template/.bevelignore
+++ b/packages/core-backend/kb-template/.bevelignore
@@ -23,3 +23,5 @@ CLAUDE.md
 roles.yaml
 
 Plugins/
+# The shared-skills root is rendered by the Skills & Tools app, like Plugins/.
+Skills/

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -6,7 +6,7 @@ maintaining it.
 > **This file is managed by the platform.** Every server restart replaces it
 > with the current template, so edits made here are overwritten. Deployment- or
 > team-specific conventions belong in files of your own — anywhere under
-> `KnowledgeBase/`, linked from wherever they are needed.
+> `{{knowledgeBaseDir}}/`, linked from wherever they are needed.
 
 **There is no required format for knowledge.** Write markdown the way the
 subject wants to be written: prose, tables, checklists, diagrams, whatever
@@ -20,44 +20,44 @@ change them.
 
 ```text
 knowledge-base/
-├── KnowledgeBase/        ← the knowledge itself; organise it however suits you
-├── Skills/               ← shared skills, organised by who owns them
-├── Plugins/              ← one folder per plugin: its tools, and links to skills
+├── {{knowledgeBaseDir}}/        ← the knowledge itself; organise it however suits you
+├── {{skillsDir}}/               ← shared skills, organised by who owns them
+├── {{pluginsDir}}/              ← one folder per plugin: its tools, and links to skills
 ├── roles.yaml            ← identity → role mapping (Admin-only edits)
 └── access.md             ← repo-root access-control rules
 ```
 
-(A deployment may have renamed these three roots in its setup screen; the
-names above are the defaults. `list_files` at the workspace root shows the
-real ones.)
+(The three root names above are this deployment's own — a deployment may
+rename them in its setup screen, and this guide is rendered with the names in
+effect each time it is written.)
 
 Tool paths are workspace-relative, and the workspace root holds this
 repository as the `knowledge-base/` folder: a file in it is
-`knowledge-base/KnowledgeBase/Foo.md`, never `KnowledgeBase/Foo.md`. A path
+`knowledge-base/{{knowledgeBaseDir}}/Foo.md`, never `{{knowledgeBaseDir}}/Foo.md`. A path
 without that prefix is refused, because it would land beside the repository
 where git never sees it.
 
-Only those three folders are structural. `Skills/` holds shared skills at any
+Only those three folders are structural. `{{skillsDir}}/` holds shared skills at any
 depth — the folder that holds a `SKILL.md` is the skill, and everything above
-it is ownership (`Skills/<scope>/…/<skill>/SKILL.md`, with an `access.md` in
-any scope folder that needs its own rules). `Plugins/` has a layout the
+it is ownership (`{{skillsDir}}/<scope>/…/<skill>/SKILL.md`, with an `access.md` in
+any scope folder that needs its own rules). `{{pluginsDir}}/` has a layout the
 platform reads:
 
 ```text
-Plugins/<Plugin>/plugin.json                  the manifest (Agent Plugins) — what makes the folder a plugin
-Plugins/<Plugin>/skills/<skill>/SKILL.md      a skill that lives inside the plugin
-Plugins/<Plugin>/mcp.json                     MCP servers (authoritative)
-Plugins/<Plugin>/software.bevel.hexis/tools/  `.tool` manuals
-Plugins/<Plugin>/access.md                    who can read/write the plugin
-Plugins/personal-<user-id>/…                  one per person: private
+{{pluginsDir}}/<Plugin>/plugin.json                  the manifest (Agent Plugins) — what makes the folder a plugin
+{{pluginsDir}}/<Plugin>/skills/<skill>/SKILL.md      a skill that lives inside the plugin
+{{pluginsDir}}/<Plugin>/mcp.json                     MCP servers (authoritative)
+{{pluginsDir}}/<Plugin>/software.bevel.hexis/tools/  `.tool` manuals
+{{pluginsDir}}/<Plugin>/access.md                    who can read/write the plugin
+{{pluginsDir}}/personal-<user-id>/…                  one per person: private
 ```
 
 **A plugin LINKS shared skills rather than containing them.** Its manifest
 lists skill paths under `extensions["software.bevel.hexis"].skills` — each
-entry is one skill folder or a folder of skills under `Skills/`:
+entry is one skill folder or a folder of skills under `{{skillsDir}}/`:
 
 ```json
-{ "extensions": { "software.bevel.hexis": { "skills": ["Skills/Engineering/deploy", "Skills/Sales"] } } }
+{ "extensions": { "software.bevel.hexis": { "skills": ["{{skillsDir}}/Engineering/deploy", "{{skillsDir}}/Sales"] } } }
 ```
 
 One skill, stored once, can be listed by many plugins. A plugin's effective
@@ -73,7 +73,7 @@ skill's readability comes from the `access.md` rules on its own folder and
 the scopes above it. A plugin that links a skill someone cannot read simply
 does not show it to them.
 
-**Symlinks are not supported anywhere under `Plugins/`.** Access control
+**Symlinks are not supported anywhere under `{{pluginsDir}}/`.** Access control
 resolves rules by path, and a symlink is a second path to the same content —
 the two can disagree about who may read what. The platform never creates
 them and ignores any it finds (they can only arrive via a direct git push).
@@ -118,19 +118,19 @@ to interpret and which other clients ignore by design.
 **Plugin folders are made through the app, not by writing files.** A folder
 is a plugin exactly when it carries a `plugin.json` (the platform writes one
 into every legacy plugin folder at startup), and it is LISTED only when it
-also carries an `access.md` — a bare directory under `Plugins/` is neither.
-Plugins may sit at any depth under `Plugins/`; a folder that holds plugins
+also carries an `access.md` — a bare directory under `{{pluginsDir}}/` is neither.
+Plugins may sit at any depth under `{{pluginsDir}}/`; a folder that holds plugins
 deeper down is a grouping folder, not a plugin. A new plugin needs an
 `access.md` naming who runs it, and the write gate refuses a plain write
 into an unused name there — so do not try to create a plugin by writing a
-skill into `Plugins/<new-name>/…`; it will be denied. Send the user to the app's **New plugin** button (or its
+skill into `{{pluginsDir}}/<new-name>/…`; it will be denied. Send the user to the app's **New plugin** button (or its
 `POST /api/plugins` endpoint), then write into the folder it made. Names
 starting with `personal-` are reserved: one such folder exists per person,
 created automatically with their first personal skill, readable only by its
 owner and never listed as a plugin — a signed-in user's own skills belong
 there, and move into a plugin by moving the skill's folder.
 
-Everything under `KnowledgeBase/` is yours to arrange. Subfolders, naming,
+Everything under `{{knowledgeBaseDir}}/` is yours to arrange. Subfolders, naming,
 whether a topic is one file or twenty — all of it is a judgement call about
 what the next reader needs, not a rule the platform enforces.
 
@@ -192,10 +192,10 @@ File-level write access decides how a change lands on the default branch:
   review flow — and prefer a change request when in doubt, when the change is
   large, or when it touches content the user does not own.
 
-## Skills (`Skills/<scope>/…/<skill>/SKILL.md`, or `Plugins/<Plugin>/skills/<skill>/SKILL.md`)
+## Skills (`{{skillsDir}}/<scope>/…/<skill>/SKILL.md`, or `{{pluginsDir}}/<Plugin>/skills/<skill>/SKILL.md`)
 
 A skill is a folder holding a `SKILL.md` and whatever files it needs. Shared
-skills live under `Skills/`, organised by ownership; a skill that belongs to
+skills live under `{{skillsDir}}/`, organised by ownership; a skill that belongs to
 exactly one plugin may live inside that plugin's `skills/` folder instead.
 Skill names are unique across the whole catalog, whichever home they have.
 The frontmatter names it, declares which tools it may use, and may carry a
@@ -226,7 +226,7 @@ exactly the skills they may read — one plugin per plugin here, a
 `skills-and-knowledge` plugin for the rest plus this knowledge base's MCP
 server, and a `hexis-all` bundle that installs everything.
 
-## Tool Manuals (`Plugins/<Plugin>/software.bevel.hexis/tools/*.tool`)
+## Tool Manuals (`{{pluginsDir}}/<Plugin>/software.bevel.hexis/tools/*.tool`)
 
 Each plugin folder holds `*.tool` files — reusable **tool manuals** that let agents call external APIs. They are **not part of the knowledge graph** (never modelled as nodes) and are access-controlled like any other file via `access.md`. Any user who can *read* a `.tool` can use its tools; anyone who can *write* it sets its shared (admin) secrets (see below). Put each manual in the plugin's `software.bevel.hexis/tools/` directory, beside
 the skills that use it. The same integration may exist in several plugins as
@@ -425,7 +425,7 @@ merely correct.
 
 ## Finding things
 
-- `grep` for keywords across `KnowledgeBase/`.
+- `grep` for keywords across `{{knowledgeBaseDir}}/`.
 - Follow markdown links: when you read `[Some Page](relative/path/Some Page.md)`,
   that path is relative to the file you are reading.
 - `list_files` to see the shape of a folder before assuming where something

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -21,10 +21,15 @@ change them.
 ```text
 knowledge-base/
 ├── KnowledgeBase/        ← the knowledge itself; organise it however suits you
-├── Plugins/              ← one folder per plugin: its skills AND its tools
+├── Skills/               ← shared skills, organised by who owns them
+├── Plugins/              ← one folder per plugin: its tools, and links to skills
 ├── roles.yaml            ← identity → role mapping (Admin-only edits)
 └── access.md             ← repo-root access-control rules
 ```
+
+(A deployment may have renamed these three roots in its setup screen; the
+names above are the defaults. `list_files` at the workspace root shows the
+real ones.)
 
 Tool paths are workspace-relative, and the workspace root holds this
 repository as the `knowledge-base/` folder: a file in it is
@@ -32,20 +37,41 @@ repository as the `knowledge-base/` folder: a file in it is
 without that prefix is refused, because it would land beside the repository
 where git never sees it.
 
-Only those two folders are structural, and only `Plugins/` has a layout the
+Only those three folders are structural. `Skills/` holds shared skills at any
+depth — the folder that holds a `SKILL.md` is the skill, and everything above
+it is ownership (`Skills/<scope>/…/<skill>/SKILL.md`, with an `access.md` in
+any scope folder that needs its own rules). `Plugins/` has a layout the
 platform reads:
 
 ```text
-Plugins/<Plugin>/plugin.json                  the manifest (Agent Plugins)
-Plugins/<Plugin>/skills/<skill>/SKILL.md      a skill
+Plugins/<Plugin>/plugin.json                  the manifest (Agent Plugins) — what makes the folder a plugin
+Plugins/<Plugin>/skills/<skill>/SKILL.md      a skill that lives inside the plugin
 Plugins/<Plugin>/mcp.json                     MCP servers (authoritative)
 Plugins/<Plugin>/software.bevel.hexis/tools/  `.tool` manuals
 Plugins/<Plugin>/access.md                    who can read/write the plugin
 Plugins/personal-<user-id>/…                  one per person: private
 ```
 
-Skills and tools live TOGETHER in a plugin because they share one access
-boundary: a tool a plugin cannot read is a skill that plugin cannot run.
+**A plugin LINKS shared skills rather than containing them.** Its manifest
+lists skill paths under `extensions["software.bevel.hexis"].skills` — each
+entry is one skill folder or a folder of skills under `Skills/`:
+
+```json
+{ "extensions": { "software.bevel.hexis": { "skills": ["Skills/Engineering/deploy", "Skills/Sales"] } } }
+```
+
+One skill, stored once, can be listed by many plugins. A plugin's effective
+skills are the ones inside its folder plus everything its links resolve to.
+Do not edit that list by hand: linking is done from the plugin's page in the
+app, because it is two edits at once — the manifest entry AND a grant on the
+skill (see *Access control* below). A manifest entry without the grant lists
+a skill the plugin's members cannot read; the app shows such a link as
+needing setup and offers Repair.
+
+**Ownership decides who may read a skill, never the plugin.** A shared
+skill's readability comes from the `access.md` rules on its own folder and
+the scopes above it. A plugin that links a skill someone cannot read simply
+does not show it to them.
 
 **Symlinks are not supported anywhere under `Plugins/`.** Access control
 resolves rules by path, and a symlink is a second path to the same content —
@@ -89,13 +115,15 @@ answer to that — and `mcp.json` carries only where a server is, never a
 under `extensions["software.bevel.hexis"].mcpServers[<name>]`, which is ours
 to interpret and which other clients ignore by design.
 
-**Plugin folders are made through the app, not by writing files.** A plugin
-exists exactly when its folder carries an `access.md` — a bare directory
-under `Plugins/` is not a plugin and is never listed. A new
-direct child of `Plugins/` needs an `access.md` naming who runs it, and the
-write gate refuses a plain write into an unused name there — so do not try to
-create a plugin by writing a skill into `Plugins/<new-name>/…`; it will be
-denied. Send the user to the app's **New plugin** button (or its
+**Plugin folders are made through the app, not by writing files.** A folder
+is a plugin exactly when it carries a `plugin.json` (the platform writes one
+into every legacy plugin folder at startup), and it is LISTED only when it
+also carries an `access.md` — a bare directory under `Plugins/` is neither.
+Plugins may sit at any depth under `Plugins/`; a folder that holds plugins
+deeper down is a grouping folder, not a plugin. A new plugin needs an
+`access.md` naming who runs it, and the write gate refuses a plain write
+into an unused name there — so do not try to create a plugin by writing a
+skill into `Plugins/<new-name>/…`; it will be denied. Send the user to the app's **New plugin** button (or its
 `POST /api/plugins` endpoint), then write into the folder it made. Names
 starting with `personal-` are reserved: one such folder exists per person,
 created automatically with their first personal skill, readable only by its
@@ -118,7 +146,16 @@ Write access to any path is governed by `roles.yaml` (who has which role) and
 
 - **Roles** in `roles.yaml` map a role name to a list of emails. Role names are
   case- and whitespace-insensitive (`Admin` = `admin` = `ADMIN`; `Product Team`
-  = `product team`). The reserved name `deny` cannot be used.
+  = `product team`). The reserved name `deny` cannot be used, and neither can
+  names starting with `role/` or `plugin/` — those spellings are tokens in
+  access entries (below).
+- **Plugins are grantable principals.** `plugin/<Name>/read`,
+  `plugin/<Name>/write` and `plugin/<Name>/owner` in any access file mean
+  everyone who currently holds that verb on the plugin `<Name>`, derived live
+  from the plugin's own `access.md`. This is how a shared skill is made
+  visible to a plugin's members: `read: plugin/GTM/read` on the skill's folder.
+  Adding or removing someone on the plugin changes what they can read
+  everywhere the token is granted, with no copying.
 - **Access rules** live in `access.md` files, which carry **two blocks with two
   scopes**: the body declares the rules for the folder the file sits in, and the
   frontmatter declares who may read and write that `access.md` itself. Each
@@ -155,22 +192,39 @@ File-level write access decides how a change lands on the default branch:
   review flow — and prefer a change request when in doubt, when the change is
   large, or when it touches content the user does not own.
 
-## Skills (`Plugins/<Plugin>/skills/<skill>/SKILL.md`)
+## Skills (`Skills/<scope>/…/<skill>/SKILL.md`, or `Plugins/<Plugin>/skills/<skill>/SKILL.md`)
 
-A skill is a folder holding a `SKILL.md` and whatever files it needs. The
-frontmatter names it and declares which tools it may use:
+A skill is a folder holding a `SKILL.md` and whatever files it needs. Shared
+skills live under `Skills/`, organised by ownership; a skill that belongs to
+exactly one plugin may live inside that plugin's `skills/` folder instead.
+Skill names are unique across the whole catalog, whichever home they have.
+The frontmatter names it, declares which tools it may use, and may carry a
+governance record:
 
 ```yaml
 ---
 name: weekly-newsletter
 description: Drafts the Friday newsletter for review.
 allowed-tools: [slack_post_message]
+metadata:
+  version: "1.4.0"
+  owner: "GTM"
+  lifecycle: active
 ---
 ```
 
 The body is the instructions, in plain markdown. `allowed-tools` entries are
-tool names from the `.tool` manuals in the same plugin — a skill can only reach
-tools its plugin can read.
+tool names from the `.tool` manuals and MCP servers of the plugins that hold
+the skill. `metadata.version` is semver; `metadata.lifecycle` is `active`,
+`deprecated` (still served, flagged in the library) or `retired` (kept for
+its owners, never distributed to agents).
+
+**How skills reach agents.** Through the MCP server (`list_skills`,
+`get_skill`), or as native plugins: every user can clone a git remote from
+the app's external-agent page that holds a plugin marketplace compiled from
+exactly the skills they may read — one plugin per plugin here, a
+`skills-and-knowledge` plugin for the rest plus this knowledge base's MCP
+server, and a `hexis-all` bundle that installs everything.
 
 ## Tool Manuals (`Plugins/<Plugin>/software.bevel.hexis/tools/*.tool`)
 

--- a/packages/core-backend/src/__tests__/kb-layout-config.test.ts
+++ b/packages/core-backend/src/__tests__/kb-layout-config.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, afterEach } from 'vitest';
+import {
+  DEFAULT_KB_LAYOUT,
+  KNOWLEDGE_BASE_DIR,
+  PLUGINS_DIR,
+  SKILLS_DIR,
+  configureKbLayout,
+  currentKbLayout,
+  ontologyRoots,
+  pluginOfPath,
+  reservedRootDirNames,
+  validateKbLayout,
+  validateKbRootName,
+} from '@bevel-software/platform-shared';
+
+/**
+ * The KB layout is module state shared by every test in the process, so each
+ * test that reconfigures it puts the defaults back — exactly what a deployment
+ * that names nothing runs with.
+ */
+afterEach(() => configureKbLayout({ ...DEFAULT_KB_LAYOUT }));
+
+describe('KB layout — validation', () => {
+  test('accepts the defaults and any three distinct plain folder names', () => {
+    expect(validateKbLayout({ ...DEFAULT_KB_LAYOUT })).toBeNull();
+    expect(
+      validateKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' }),
+    ).toBeNull();
+  });
+
+  test('refuses a root that could escape the repository or hide from the scanners', () => {
+    expect(validateKbRootName('')).not.toBeNull();
+    expect(validateKbRootName('a/b')).not.toBeNull();
+    expect(validateKbRootName('a\\b')).not.toBeNull();
+    expect(validateKbRootName('..')).not.toBeNull();
+    expect(validateKbRootName('.git')).not.toBeNull();
+    expect(validateKbRootName('.hidden')).not.toBeNull();
+    expect(validateKbRootName('bad\nname')).not.toBeNull();
+    expect(validateKbRootName('Skills')).toBeNull();
+  });
+
+  test('refuses two roots sharing a name, case-insensitively — one folder on a case-insensitive disk', () => {
+    expect(
+      validateKbLayout({ knowledgeBaseDir: 'KnowledgeBase', skillsDir: 'skills', pluginsDir: 'Skills' }),
+    ).toMatch(/three different names/);
+  });
+});
+
+describe('KB layout — configuration', () => {
+  test('applies the names to the live bindings every consumer reads', () => {
+    configureKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+    expect(KNOWLEDGE_BASE_DIR).toBe('docs');
+    expect(SKILLS_DIR).toBe('skills');
+    expect(PLUGINS_DIR).toBe('plugins');
+    expect(currentKbLayout()).toEqual({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+  });
+
+  test('the derived sets follow the configured names rather than snapshotting the defaults', () => {
+    configureKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+    expect(ontologyRoots()).toEqual(['docs', 'Data']);
+    expect(reservedRootDirNames().has('plugins')).toBe(true);
+    expect(reservedRootDirNames().has('Plugins')).toBe(false);
+    // Path rules read the live name too.
+    expect(pluginOfPath('plugins/GTM/skills/x/SKILL.md')).toBe('GTM');
+    expect(pluginOfPath('Plugins/GTM/skills/x/SKILL.md')).toBeNull();
+  });
+
+  test('throws on an invalid layout and leaves the current one untouched', () => {
+    expect(() =>
+      configureKbLayout({ knowledgeBaseDir: 'a', skillsDir: 'a', pluginsDir: 'b' }),
+    ).toThrow(/three different names/);
+    expect(currentKbLayout()).toEqual(DEFAULT_KB_LAYOUT);
+  });
+
+  test('trims what it applies', () => {
+    configureKbLayout({ knowledgeBaseDir: ' docs ', skillsDir: 'skills', pluginsDir: 'plugins' });
+    expect(KNOWLEDGE_BASE_DIR).toBe('docs');
+  });
+});

--- a/packages/core-backend/src/__tests__/kb-layout-config.test.ts
+++ b/packages/core-backend/src/__tests__/kb-layout-config.test.ts
@@ -8,6 +8,7 @@ import {
   currentKbLayout,
   ontologyRoots,
   pluginOfPath,
+  renderKbLayoutPlaceholders,
   reservedRootDirNames,
   validateKbLayout,
   validateKbRootName,
@@ -37,6 +38,19 @@ describe('KB layout — validation', () => {
     expect(validateKbRootName('.hidden')).not.toBeNull();
     expect(validateKbRootName('bad\nname')).not.toBeNull();
     expect(validateKbRootName('Skills')).toBeNull();
+  });
+
+  test('refuses a configurable root that takes a fixed reserved name', () => {
+    expect(
+      validateKbLayout({ knowledgeBaseDir: 'KnowledgeBase', skillsDir: 'data', pluginsDir: 'Plugins' }),
+    ).toMatch(/reserved folder name/);
+  });
+
+  test('renders placeholders without interpreting $-patterns in a folder name', () => {
+    expect(
+      renderKbLayoutPlaceholders('a {{skillsDir}} b', { knowledgeBaseDir: 'K', skillsDir: 'Sales$&', pluginsDir: 'P' }),
+    ).toBe('a Sales$& b');
+    expect(renderKbLayoutPlaceholders('no placeholders', DEFAULT_KB_LAYOUT)).toBe('no placeholders');
   });
 
   test('refuses two roots sharing a name, case-insensitively — one folder on a case-insensitive disk', () => {

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -20,7 +20,7 @@ import {
 import { registerWorkflowTools } from '../modules/workflow/agent-tools/workflow.tools.js';
 import { registerWorkspaceTools } from '../modules/workspace/workspace.tools.js';
 import { RECOVERY_BOT_EMAIL } from '../modules/workflow/recovery-bot.js';
-import { registerSkillsTools, createSkillsRoutes } from '../modules/skills/index.js';
+import { registerSkillsTools, createSkillsRoutes, createSkillAccessRequestRoutes } from '../modules/skills/index.js';
 import { createPluginsRoutes } from '../modules/plugins/index.js';
 import type { SessionOntologyGate } from '../modules/workspace/session-ontology.gate.js';
 import {
@@ -437,7 +437,23 @@ export async function createCoreServer(
   app.use(
     '/api',
     core.authMiddleware,
-    createSkillsRoutes(core.skillService, core.pendingSkillsService),
+    createSkillsRoutes(core.skillService, core.pendingSkillsService, core.pluginLinkIndex),
+  );
+  // Asking for write on a shared skill — the join-request machinery pointed
+  // at a skill folder. Same JWT gate, same fail-closed shape.
+  app.use(
+    '/api',
+    core.authMiddleware,
+    createSkillAccessRequestRoutes({
+      skillService: core.skillService,
+      accessControl: core.accessControl,
+      workflow: core.workflowService,
+      workspaceService: core.workspaceService,
+      joinRequests: core.joinRequestsService,
+      kbDirName: core.kbDirName,
+      resolveUser: async (req) =>
+        req.userId ? ((await core.authService.getUserById(req.userId)) ?? null) : null,
+    }),
   );
   // Plugin enumeration + join requests. Browser-only (JWT), and fail-closed
   // like every other read surface: plugins the caller cannot access (member,
@@ -452,6 +468,7 @@ export async function createCoreServer(
     core.pluginProvisionService,
     core.kbDirName,
     async (req) => (req.userId ? ((await core.authService.getUserById(req.userId)) ?? null) : null),
+    core.pluginLinksService,
   ));
   // Admin-status resolver (CORE — see the note in admin-access.routes.ts;
   // the full admin router is an enterprise `ext.authed` extension).

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -33,6 +33,7 @@ import { createGroupsAdminRoutes } from '../modules/access/groups-admin.routes.j
 import { createUpdateCheckRoutes } from '../modules/update-check/update-check.routes.js';
 import { createAccountRoutes } from '../modules/auth/account.routes.js';
 import { createSetupRoutes } from '../modules/settings/setup.routes.js';
+import { createMarketplaceGitRoutes } from '../modules/marketplace/index.js';
 import { DEFAULT_BRANCH, PROTECTED_BRANCHES, currentKbLayout, type AuthUser } from '@bevel-software/platform-shared';
 import { GIT_SHA } from '../version.js';
 import type { CoreServices } from './create-core-services.js';
@@ -178,6 +179,9 @@ export async function createCoreServer(
   const mcpResourceUrl = new URL('/api/mcp', core.config.publicBackendUrl);
   mcpResourceUrl.username = '';
   mcpResourceUrl.password = '';
+  const marketplaceGitUrl = new URL(`/git/${core.marketplaceRepo.repoName}`, core.config.publicBackendUrl);
+  marketplaceGitUrl.username = '';
+  marketplaceGitUrl.password = '';
 
   /**
    * The handful of facts the browser needs BEFORE it can render anything, and
@@ -206,6 +210,12 @@ export async function createCoreServer(
        */
       kbLayout: currentKbLayout(),
       /**
+       * The per-user marketplace git remote (see modules/marketplace). Same
+       * derivation as `mcpUrl`: our address, userinfo stripped — the caller
+       * adds their own connection key.
+       */
+      marketplaceGitUrl: marketplaceGitUrl.toString(),
+      /**
        * The same value the OAuth metadata publishes (see `mcpResourceUrl`).
        *
        * The frontend used to build this from `window.location.origin`, which
@@ -222,6 +232,19 @@ export async function createCoreServer(
       mcpUrl: mcpResourceUrl.toString(),
     });
   });
+
+  // The per-user marketplace as a git remote. Outside `/api` and ahead of
+  // every JWT mount: it authenticates with a connection key in HTTP Basic
+  // (what `git clone https://key:<k>@…` sends), and git's own http-backend
+  // serves the protocol. See modules/marketplace.
+  app.use(
+    '/git',
+    createMarketplaceGitRoutes({
+      repo: core.marketplaceRepo,
+      keys: core.externalApiKeyService,
+      mountPath: '/git',
+    }),
+  );
 
   // Overlay boot-time side effects (startup reconciles, periodic sweeps).
   await ext.onBoot?.(core);

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -460,7 +460,7 @@ export async function createCoreServer(
   app.use(
     '/api',
     core.authMiddleware,
-    createSkillsRoutes(core.skillService, core.pendingSkillsService, core.pluginLinkIndex),
+    createSkillsRoutes(core.skillService, core.pendingSkillsService, core.pluginLinkIndex, core.accessControl),
   );
   // Asking for write on a shared skill — the join-request machinery pointed
   // at a skill folder. Same JWT gate, same fail-closed shape.

--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -33,7 +33,7 @@ import { createGroupsAdminRoutes } from '../modules/access/groups-admin.routes.j
 import { createUpdateCheckRoutes } from '../modules/update-check/update-check.routes.js';
 import { createAccountRoutes } from '../modules/auth/account.routes.js';
 import { createSetupRoutes } from '../modules/settings/setup.routes.js';
-import { DEFAULT_BRANCH, PROTECTED_BRANCHES, type AuthUser } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, PROTECTED_BRANCHES, currentKbLayout, type AuthUser } from '@bevel-software/platform-shared';
 import { GIT_SHA } from '../version.js';
 import type { CoreServices } from './create-core-services.js';
 
@@ -199,6 +199,12 @@ export async function createCoreServer(
         defaultBranch: DEFAULT_BRANCH,
         protectedBranches: [...PROTECTED_BRANCHES],
       },
+      /**
+       * The three renameable KB roots, for the same reason as the branch
+       * model: the file tree, the library router and every path rule read
+       * them, and they used to be compile-time constants.
+       */
+      kbLayout: currentKbLayout(),
       /**
        * The same value the OAuth metadata publishes (see `mcpResourceUrl`).
        *

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -18,6 +18,7 @@ import { WorkspaceService } from '../modules/workspace/workspace.service.js';
 import { RoutineWritePolicyService } from '../modules/workspace/routine-write-policy.js';
 import { KbStartupRunner } from '../modules/workspace/startup/kb-startup-runner.js';
 import { GroupsToPluginsStep } from '../modules/workspace/startup/steps/groups-to-plugins.step.js';
+import { PluginManifestsStep } from '../modules/workspace/startup/steps/plugin-manifests.step.js';
 import { TemplateFilesStep } from '../modules/workspace/startup/steps/template-files.step.js';
 import { RolesYamlStep } from '../modules/workspace/startup/steps/roles-yaml.step.js';
 import { buildSeedTree } from '../modules/workspace/startup/steps/seed-tree.js';
@@ -302,6 +303,7 @@ export async function createCoreServices(
   // whatever the distribution appends.
   const kbStartupSteps = [
     new GroupsToPluginsStep(),
+    new PluginManifestsStep(),
     new TemplateFilesStep(extraDirs),
     new RolesYamlStep([config.adminEmail]),
     ...(ports.kbStartupSteps ?? []),

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -42,7 +42,13 @@ import { GroupsAdminService } from '../modules/access/groups-admin.service.js';
 import { PendingSkillsService, SkillService } from '../modules/skills/index.js';
 import { ToolManualService } from '../modules/tool-manuals/index.js';
 import { McpServerEditService } from '../modules/tool-manuals/mcp-server-edit.service.js';
-import { PluginIndexService, PluginProvisionService, JoinRequestsService } from '../modules/plugins/index.js';
+import {
+  PluginIndexService,
+  PluginProvisionService,
+  JoinRequestsService,
+  PluginLinkIndex,
+  PluginLinksService,
+} from '../modules/plugins/index.js';
 import {
   DbSecretsVaultService,
   McpOAuthDiscoveryService,
@@ -130,6 +136,10 @@ export interface CoreServices {
   pluginIndexService: PluginIndexService;
   pluginProvisionService: PluginProvisionService;
   joinRequestsService: JoinRequestsService;
+  /** Which plugins hold which skills (inline or linked) — see `PluginLinkIndex`. */
+  pluginLinkIndex: PluginLinkIndex;
+  /** Link / unlink / repair shared skills into plugins. */
+  pluginLinksService: PluginLinksService;
   authService: AuthService;
   authMiddleware: ReturnType<typeof createAuthMiddleware>;
   accountErasureService: AccountErasureService;
@@ -336,12 +346,17 @@ export async function createCoreServices(
   // team's skills AND the tools they need. Enumerated for EVERY authenticated
   // caller — a plugin they cannot read still exists for them, as a locked one —
   // with the counts read off the two catalogs above rather than a second scan.
+  // The link index resolves manifests against the released catalog, and the
+  // plugin index counts through it (inline + linked), so it comes first.
+  const pluginLinkIndex = new PluginLinkIndex(workspaceService, skillService, accessControl, kbDirName);
   const pluginIndexService = new PluginIndexService(
     workspaceService,
     accessControl,
     skillService,
     toolManualService,
     kbDirName,
+    Date.now,
+    pluginLinkIndex,
   );
   // Auth service — resolves identities for login, PR author attribution, and
   // access lookups. (Change requests now store the author email directly, so
@@ -457,6 +472,18 @@ export async function createCoreServices(
   // only needs to read files at refs and to close a request whose proposals
   // have all landed.
   const joinRequestsService = new JoinRequestsService(workspaceService, workflowService);
+  // Links land as ordinary default-branch commits and change what the plugin
+  // index counts, so a link drops that cache too.
+  const pluginLinksService = new PluginLinksService(
+    workspaceService,
+    workflowService,
+    accessControl,
+    skillService,
+    pluginLinkIndex,
+    kbDirName,
+    eventBus,
+    () => pluginIndexService.invalidate(),
+  );
   // Server-scoped MCP editing — the tool page's edit form. One server's truth
   // spans a plugin's mcp.json AND plugin.json extensions block, and this is
   // the ONE writer that rewrites both entries and commits them together (see
@@ -514,6 +541,7 @@ export async function createCoreServices(
       toolManualService.invalidate();
       skillService.invalidate();
       pluginIndexService.invalidate();
+      pluginLinkIndex.invalidate();
     }
 
   });
@@ -532,6 +560,7 @@ export async function createCoreServices(
     toolManualService.invalidate();
     skillService.invalidate();
     pluginIndexService.invalidate();
+    pluginLinkIndex.invalidate();
   });
 
   // Admin = `Admin` role in roles.yaml, resolved through the access model on the
@@ -835,6 +864,8 @@ export async function createCoreServices(
     pluginIndexService,
     pluginProvisionService,
     joinRequestsService,
+    pluginLinkIndex,
+    pluginLinksService,
     authService,
     authMiddleware,
     accountErasureService,

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -6,6 +6,8 @@ import {
   validateBranchModel,
   PROTECTED_BRANCHES,
   PLUGINS_DIR,
+  SKILLS_DIR,
+  configureKbLayout,
 } from '@bevel-software/platform-shared';
 import { CoreConfig } from '../core-config.js';
 import { getDb, type Database } from '../modules/database/connection.js';
@@ -242,6 +244,11 @@ export async function createCoreServices(
     protectedBranches: settings.resolve('protectedBranches'),
   };
   if (!validateBranchModel(branchModel)) configureBranchModel(branchModel);
+  // The KB layout — the three renameable roots — applied the same way and at
+  // the same moment, before any service captures a root name. Unlike the
+  // branch model it always resolves (every root has a default), so an invalid
+  // value is a real misconfiguration and stops the boot.
+  configureKbLayout(settings.resolveKbLayout());
   // A token supplied through the setup screen has to reach the credential
   // helper, which reads `$GITHUB_TOKEN` at call time.
   settings.syncGitTokenEnv();
@@ -495,12 +502,14 @@ export async function createCoreServices(
   // caches are independent, so the split preserves behavior.)
   fileChangeNotifier.onFilesChanged(({ branch, paths }) => {
     if (branch !== DEFAULT_BRANCH) return;
-    // Skills, tools and the plugin index all live under `Plugins/`, so one
-    // touch check drives all three caches. An access grant lands as a
-    // default-branch change to `Plugins/<plugin>/access.md`, so this is also
-    // what makes a newly-granted plugin unlock within one round-trip instead
-    // of one TTL.
-    const touched = paths.some((p) => p.startsWith(`${kbDirName}/${PLUGINS_DIR}/`));
+    // Skills, tools and the plugin index all live under `Plugins/` or
+    // `Skills/`, so one touch check drives all three caches. An access grant
+    // lands as a default-branch change to `Plugins/<plugin>/access.md`, so
+    // this is also what makes a newly-granted plugin unlock within one
+    // round-trip instead of one TTL.
+    const touched = paths.some(
+      (p) => p.startsWith(`${kbDirName}/${PLUGINS_DIR}/`) || p.startsWith(`${kbDirName}/${SKILLS_DIR}/`),
+    );
     if (touched) {
       toolManualService.invalidate();
       skillService.invalidate();

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { AuthProviderPlugin } from '../modules/auth/auth.routes.js';
 import type { AuthUser } from '@bevel-software/platform-shared';
 import {
@@ -50,6 +51,7 @@ import {
   PluginLinksService,
   MarketplaceCompilerService,
 } from '../modules/plugins/index.js';
+import { MarketplaceRepoService } from '../modules/marketplace/index.js';
 import {
   DbSecretsVaultService,
   McpOAuthDiscoveryService,
@@ -143,6 +145,8 @@ export interface CoreServices {
   pluginLinksService: PluginLinksService;
   /** Source layout → distribution layout, for one audience. */
   marketplaceCompiler: MarketplaceCompilerService;
+  /** The bare repository the per-user marketplace git endpoint serves from. */
+  marketplaceRepo: MarketplaceRepoService;
   authService: AuthService;
   authMiddleware: ReturnType<typeof createAuthMiddleware>;
   accountErasureService: AccountErasureService;
@@ -496,6 +500,12 @@ export async function createCoreServices(
     pluginLinkIndex,
     kbDirName,
     { name: 'hexis', owner: 'Hexis', description: 'Skills and plugins from this knowledge base' },
+  );
+  // Sibling of the workspaces root, like the spill store: one bare repo, one
+  // git namespace per caller (see marketplace-repo.service.ts).
+  const marketplaceRepo = new MarketplaceRepoService(
+    path.resolve(config.workspacesRoot, '..', 'marketplace.git'),
+    marketplaceCompiler,
   );
   // Server-scoped MCP editing — the tool page's edit form. One server's truth
   // spans a plugin's mcp.json AND plugin.json extensions block, and this is
@@ -880,6 +890,7 @@ export async function createCoreServices(
     pluginLinkIndex,
     pluginLinksService,
     marketplaceCompiler,
+    marketplaceRepo,
     authService,
     authMiddleware,
     accountErasureService,

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -58,10 +58,7 @@ import {
   PluginLinkIndex,
   PluginLinksService,
   MarketplaceCompilerService,
-  NativePluginSource,
-  BundlePluginSource,
-  DEFAULT_REGISTRY_PATH,
-  type PluginSource,
+  KbPluginSource,
 } from '../modules/plugins/index.js';
 import { MarketplaceRepoService } from '../modules/marketplace/index.js';
 import {
@@ -360,17 +357,10 @@ export async function createCoreServices(
   // Tool manuals: user-authored `*.tool` files under `Plugins/` in the default
   // branch — access-controlled like Skills, served to external agents via
   // `GET /api/agent/all-tools` and registered on the MCP proxy's UTCP client.
-  // Where plugins come from: the native layout, or a customer dialect chosen
-  // on the setup screen (see modules/plugins/discovery). One switch, one arm
-  // per dialect — deleting a dialect is deleting its arm.
-  const pluginSource: PluginSource = (() => {
-    switch (settings.resolve('pluginDialect') || 'native') {
-      case 'bundle':
-        return new BundlePluginSource(settings.resolve('mcpRegistryPath') || DEFAULT_REGISTRY_PATH);
-      default:
-        return new NativePluginSource();
-    }
-  })();
+  // Where plugins come from: one walk of the plugins root that reads every
+  // plugin folder in whichever file shape it carries (see
+  // modules/plugins/discovery). Nothing to configure, nothing to document.
+  const pluginSource = new KbPluginSource();
   const toolManualService = new ToolManualService(workspaceService, accessControl, kbDirName, Date.now, pluginSource);
   // Plugins: the folders under `Plugins/` that carry a
   // team's skills AND the tools they need. Enumerated for EVERY authenticated

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -48,6 +48,7 @@ import {
   JoinRequestsService,
   PluginLinkIndex,
   PluginLinksService,
+  MarketplaceCompilerService,
 } from '../modules/plugins/index.js';
 import {
   DbSecretsVaultService,
@@ -140,6 +141,8 @@ export interface CoreServices {
   pluginLinkIndex: PluginLinkIndex;
   /** Link / unlink / repair shared skills into plugins. */
   pluginLinksService: PluginLinksService;
+  /** Source layout → distribution layout, for one audience. */
+  marketplaceCompiler: MarketplaceCompilerService;
   authService: AuthService;
   authMiddleware: ReturnType<typeof createAuthMiddleware>;
   accountErasureService: AccountErasureService;
@@ -483,6 +486,16 @@ export async function createCoreServices(
     kbDirName,
     eventBus,
     () => pluginIndexService.invalidate(),
+  );
+  // Source → distribution. The marketplace's identity is fixed for now; the
+  // per-user git endpoint and any mirror both compile through this.
+  const marketplaceCompiler = new MarketplaceCompilerService(
+    workspaceService,
+    accessControl,
+    skillService,
+    pluginLinkIndex,
+    kbDirName,
+    { name: 'hexis', owner: 'Hexis', description: 'Skills and plugins from this knowledge base' },
   );
   // Server-scoped MCP editing — the tool page's edit form. One server's truth
   // spans a plugin's mcp.json AND plugin.json extensions block, and this is
@@ -866,6 +879,7 @@ export async function createCoreServices(
     joinRequestsService,
     pluginLinkIndex,
     pluginLinksService,
+    marketplaceCompiler,
     authService,
     authMiddleware,
     accountErasureService,

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -23,6 +23,14 @@ import { RolesYamlStep } from '../modules/workspace/startup/steps/roles-yaml.ste
 import { buildSeedTree } from '../modules/workspace/startup/steps/seed-tree.js';
 import { DeploymentSettingsService } from '../modules/settings/deployment-settings.service.js';
 
+/** The hosted MCP endpoint at a deployment address, with any userinfo stripped. */
+function mcpEndpointUrl(publicBackendUrl: string): string {
+  const url = new URL('/api/mcp', publicBackendUrl);
+  url.username = '';
+  url.password = '';
+  return url.toString();
+}
+
 /** `a.com, b.com` → `['a.com','b.com']`, tolerating a leading `@` or `.`. */
 function parseDomainList(raw: string): string[] {
   return raw
@@ -515,7 +523,16 @@ export async function createCoreServices(
     skillService,
     pluginLinkIndex,
     kbDirName,
-    { name: 'hexis', owner: 'Hexis', description: 'Skills and plugins from this knowledge base' },
+    {
+      name: 'hexis',
+      owner: 'Hexis',
+      description: 'Skills and plugins from this knowledge base',
+      // The knowledge base as a tool, shipped in the skills plugin so an
+      // agent installing from the marketplace can read what its skills refer
+      // to. The same address `/api/config` and the OAuth metadata publish,
+      // userinfo stripped; the client's OAuth flow supplies the identity.
+      knowledgeBaseMcp: { name: 'hexis', url: mcpEndpointUrl(config.publicBackendUrl) },
+    },
     pluginSource,
   );
   // Sibling of the workspaces root, like the spill store: one bare repo, one

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -50,6 +50,10 @@ import {
   PluginLinkIndex,
   PluginLinksService,
   MarketplaceCompilerService,
+  NativePluginSource,
+  BundlePluginSource,
+  DEFAULT_REGISTRY_PATH,
+  type PluginSource,
 } from '../modules/plugins/index.js';
 import { MarketplaceRepoService } from '../modules/marketplace/index.js';
 import {
@@ -348,14 +352,25 @@ export async function createCoreServices(
   // Tool manuals: user-authored `*.tool` files under `Plugins/` in the default
   // branch — access-controlled like Skills, served to external agents via
   // `GET /api/agent/all-tools` and registered on the MCP proxy's UTCP client.
-  const toolManualService = new ToolManualService(workspaceService, accessControl, kbDirName);
+  // Where plugins come from: the native layout, or a customer dialect chosen
+  // on the setup screen (see modules/plugins/discovery). One switch, one arm
+  // per dialect — deleting a dialect is deleting its arm.
+  const pluginSource: PluginSource = (() => {
+    switch (settings.resolve('pluginDialect') || 'native') {
+      case 'bundle':
+        return new BundlePluginSource(settings.resolve('mcpRegistryPath') || DEFAULT_REGISTRY_PATH);
+      default:
+        return new NativePluginSource();
+    }
+  })();
+  const toolManualService = new ToolManualService(workspaceService, accessControl, kbDirName, Date.now, pluginSource);
   // Plugins: the folders under `Plugins/` that carry a
   // team's skills AND the tools they need. Enumerated for EVERY authenticated
   // caller — a plugin they cannot read still exists for them, as a locked one —
   // with the counts read off the two catalogs above rather than a second scan.
   // The link index resolves manifests against the released catalog, and the
   // plugin index counts through it (inline + linked), so it comes first.
-  const pluginLinkIndex = new PluginLinkIndex(workspaceService, skillService, accessControl, kbDirName);
+  const pluginLinkIndex = new PluginLinkIndex(workspaceService, skillService, accessControl, kbDirName, Date.now, pluginSource);
   const pluginIndexService = new PluginIndexService(
     workspaceService,
     accessControl,
@@ -364,6 +379,7 @@ export async function createCoreServices(
     kbDirName,
     Date.now,
     pluginLinkIndex,
+    pluginSource,
   );
   // Auth service — resolves identities for login, PR author attribution, and
   // access lookups. (Change requests now store the author email directly, so
@@ -500,6 +516,7 @@ export async function createCoreServices(
     pluginLinkIndex,
     kbDirName,
     { name: 'hexis', owner: 'Hexis', description: 'Skills and plugins from this knowledge base' },
+    pluginSource,
   );
   // Sibling of the workspaces root, like the spill store: one bare repo, one
   // git namespace per caller (see marketplace-repo.service.ts).

--- a/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
+++ b/packages/core-backend/src/modules/access-model/__tests__/access-grammar.test.ts
@@ -5,6 +5,7 @@ import {
   registerAccessFrontmatterExtensions,
   accessFrontmatterExtensionList,
   parseOwnAccessEntries,
+  parseRolesYaml,
 } from '../access-grammar.js';
 import { parseGroupsFile } from '../group-files.js';
 
@@ -19,6 +20,23 @@ describe('parseYamlSubset — inline empty collections', () => {
     const res = parseYamlSubset('groups: {}');
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.value).toEqual({ groups: {} });
+  });
+});
+
+describe("the reserved 'plugin/' prefix — no role or group may pose as a plugin principal", () => {
+  it('parseGroupsFile skips such a group with a warning and keeps the rest', () => {
+    const res = parseGroupsFile('groups:\n  plugin/GTM/read:\n    - mallory@x.io\n  Sales:\n    - sam@x.io\n', 'groups.yaml');
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect([...res.groups.keys()]).toEqual(['sales']);
+    expect(res.warnings.some((w) => w.includes("reserved 'plugin/'"))).toBe(true);
+  });
+
+  it('parseRolesYaml refuses such a role outright', () => {
+    const res = parseRolesYaml('roles:\n  Admin:\n    - admin@x.io\n  plugin/GTM/read:\n    - mallory@x.io\n');
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.errors.some((e) => e.includes("reserved 'plugin/'"))).toBe(true);
   });
 });
 

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -12,6 +12,7 @@
  */
 
 import { parse as parseFullYaml } from 'yaml';
+import { pluginManifestName } from '@bevel-software/platform-shared';
 import type { GroupsIndex } from './group-files.js';
 
 // ---------------------------------------------------------------------------
@@ -85,6 +86,45 @@ export const GROUP_REF_PREFIX = 'group:';
  * registered in the principal index under its `role/<canonical>` alias.
  */
 export const ROLE_TOKEN_PREFIX = 'role/';
+
+/**
+ * PLUGIN-principal token prefix in access.md entries: `plugin/<Name>/<verb>`
+ * names everyone who holds `<verb>` on the plugin folder `Plugins/<Name>` —
+ * `plugin/GTM/read` is the GTM plugin's members, `plugin/GTM/write` its
+ * managers. Membership is DERIVED at model-load time from the plugin's own
+ * `access.md` (see `plugin-principals.ts`), so a grant naming one follows the
+ * plugin's roster with no copying. This is how a shared skill under `Skills/`
+ * is made visible to a plugin: `read: plugin/GTM/read` on the skill folder.
+ *
+ * The name half is canonicalised with the plugin's MANIFEST slug, so
+ * `plugin/Sales Team/read` and `plugin/sales-team/read` are one principal —
+ * the same identity a conformant client keys the plugin on. Reserved in the
+ * group name-safety rules like `role/`.
+ */
+export const PLUGIN_TOKEN_PREFIX = 'plugin/';
+
+/** The verbs a plugin token may name — each is a distinct principal. */
+export const PLUGIN_TOKEN_VERBS = ['read', 'write', 'owner'] as const;
+export type PluginTokenVerb = (typeof PLUGIN_TOKEN_VERBS)[number];
+
+/** The canonical key of a plugin principal, from the plugin's manifest slug. */
+export function pluginPrincipalKey(slug: string, verb: PluginTokenVerb): string {
+  return `${PLUGIN_TOKEN_PREFIX}${slug}/${verb}`;
+}
+
+/** The parts of a canonical plugin key, or null when the token is not one. */
+export function parsePluginPrincipalKey(
+  canonical: string,
+): { slug: string; verb: PluginTokenVerb } | null {
+  if (!canonical.startsWith(PLUGIN_TOKEN_PREFIX)) return null;
+  const rest = canonical.slice(PLUGIN_TOKEN_PREFIX.length);
+  const cut = rest.lastIndexOf('/');
+  if (cut <= 0) return null;
+  const slug = rest.slice(0, cut);
+  const verb = rest.slice(cut + 1);
+  if (!(PLUGIN_TOKEN_VERBS as readonly string[]).includes(verb)) return null;
+  return { slug, verb: verb as PluginTokenVerb };
+}
 
 export const USER_REF_REGEX = /^(.+?)\s+<\s*([^<>\s]+@[^<>\s]+)\s*>\s*$/;
 export const EMAIL_REGEX = /^[^<>\s@]+@[^<>\s@]+\.[^<>\s@]+$/;
@@ -224,9 +264,22 @@ export function hasAccessFrontmatterExtension(p: string): boolean {
 export interface RolesIndex {
   byCanonical: Map<
     string,
-    { displayName: string; emails: Set<string>; groupRefs?: Set<string>; kind?: 'role' | 'group' }
+    {
+      displayName: string;
+      emails: Set<string>;
+      groupRefs?: Set<string>;
+      kind?: 'role' | 'group' | 'plugin';
+      /** For `kind: 'plugin'`: the plugin FOLDER name the principal derives from. */
+      pluginFolder?: string;
+    }
   >;
   byEmail: Map<string, Set<string>>;
+  /**
+   * Principal keys EVERY caller holds, known or not — a plugin whose own
+   * rules grant `everyone` yields a plugin principal no email list can
+   * enumerate. The resolver unions these into every caller's key set.
+   */
+  publicKeys?: Set<string>;
 }
 // ---------------------------------------------------------------------------
 // Tiny YAML subset parser — handles only block mappings + block sequences
@@ -482,6 +535,24 @@ export function parseAccessEntry(
     const suffix = canonicalRoleName(role.slice(ROLE_TOKEN_PREFIX.length));
     if (!suffix) return { ok: false, error: `entry '${body}' names no role after '${ROLE_TOKEN_PREFIX}'` };
     role = `${ROLE_TOKEN_PREFIX}${suffix}`;
+  } else if (role.startsWith(PLUGIN_TOKEN_PREFIX)) {
+    // `plugin/<Name>/<verb>`: the name is canonicalised to the plugin's
+    // manifest slug, the verb must be one of the three. Anything else is a
+    // parse error naming the valid shapes — a token that silently resolved to
+    // nothing would be a grant nobody gets and nobody is told about.
+    const rest = body.slice(body.toLowerCase().indexOf(PLUGIN_TOKEN_PREFIX) + PLUGIN_TOKEN_PREFIX.length).trim();
+    const cut = rest.lastIndexOf('/');
+    const name = cut > 0 ? rest.slice(0, cut).trim() : '';
+    const verb = cut > 0 ? rest.slice(cut + 1).trim().toLowerCase() : '';
+    if (!name || !(PLUGIN_TOKEN_VERBS as readonly string[]).includes(verb)) {
+      return {
+        ok: false,
+        error:
+          `entry '${body}' is not a plugin principal — write it as ` +
+          `${PLUGIN_TOKEN_PREFIX}<plugin>/read, ${PLUGIN_TOKEN_PREFIX}<plugin>/write or ${PLUGIN_TOKEN_PREFIX}<plugin>/owner`,
+      };
+    }
+    role = pluginPrincipalKey(pluginManifestName(name), verb as PluginTokenVerb);
   }
   return { ok: true, entry: { kind: 'role', role, displayRole: body, deny } };
 }

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -546,7 +546,9 @@ export function parseAccessEntry(
     const cut = rest.lastIndexOf('/');
     const name = cut > 0 ? rest.slice(0, cut).trim() : '';
     const verb = cut > 0 ? rest.slice(cut + 1).trim().toLowerCase() : '';
-    if (!name || !(PLUGIN_TOKEN_VERBS as readonly string[]).includes(verb)) {
+    // Exactly one separator: `plugin/GTM/foo/read` is a typo, not a grant to
+    // some plugin whose slug happens to fold `GTM/foo` into `gtm-foo`.
+    if (!name || name.includes('/') || !(PLUGIN_TOKEN_VERBS as readonly string[]).includes(verb)) {
       return {
         ok: false,
         error:

--- a/packages/core-backend/src/modules/access-model/access-grammar.ts
+++ b/packages/core-backend/src/modules/access-model/access-grammar.ts
@@ -271,6 +271,8 @@ export interface RolesIndex {
       kind?: 'role' | 'group' | 'plugin';
       /** For `kind: 'plugin'`: the plugin FOLDER name the principal derives from. */
       pluginFolder?: string;
+      /** For `kind: 'plugin'`: the repo-relative plugin directory, e.g. `Plugins/GTM`. */
+      pluginDir?: string;
     }
   >;
   byEmail: Map<string, Set<string>>;
@@ -597,6 +599,16 @@ export function parseRolesYaml(
     if (canonical.startsWith(ROLE_TOKEN_PREFIX)) {
       errors.push(
         `roles.yaml: role '${displayName}' starts with the reserved '${ROLE_TOKEN_PREFIX}' prefix — that spelling is the explicit role token in access entries`,
+      );
+      continue;
+    }
+    // A role spelled `plugin/…` would be overwritten by the synthesised plugin
+    // principal of the same key while its members kept the token — plugin
+    // access for people who are not plugin members. Refused at parse time,
+    // like the group name-safety rule.
+    if (canonical.startsWith(PLUGIN_TOKEN_PREFIX)) {
+      errors.push(
+        `roles.yaml: role '${displayName}' starts with the reserved '${PLUGIN_TOKEN_PREFIX}' prefix — that spelling is the plugin-principal token in access entries`,
       );
       continue;
     }

--- a/packages/core-backend/src/modules/access-model/group-files.ts
+++ b/packages/core-backend/src/modules/access-model/group-files.ts
@@ -2,6 +2,7 @@ import {
   EMAIL_REGEX,
   GROUP_REF_PREFIX,
   RESERVED_ROLE_NAMES,
+  PLUGIN_TOKEN_PREFIX,
   ROLE_TOKEN_PREFIX,
   canonicalEmail,
   canonicalRoleName,
@@ -67,6 +68,9 @@ export function unsafeNameReason(displayName: string): string | null {
   if (trimmed.startsWith('-')) return "starts with '-'";
   if (canonicalRoleName(trimmed).startsWith(ROLE_TOKEN_PREFIX)) {
     return `starts with the reserved '${ROLE_TOKEN_PREFIX}' prefix (the explicit role token in access entries)`;
+  }
+  if (canonicalRoleName(trimmed).startsWith(PLUGIN_TOKEN_PREFIX)) {
+    return `starts with the reserved '${PLUGIN_TOKEN_PREFIX}' prefix (the plugin-principal token in access entries)`;
   }
   return null;
 }

--- a/packages/core-backend/src/modules/access-model/plugin-principals.ts
+++ b/packages/core-backend/src/modules/access-model/plugin-principals.ts
@@ -1,0 +1,128 @@
+import { PLUGINS_DIR, pluginManifestName } from '@bevel-software/platform-shared';
+import {
+  EVERYONE_CANONICAL,
+  PLUGIN_TOKEN_PREFIX,
+  PLUGIN_TOKEN_VERBS,
+  pluginPrincipalKey,
+  type AccessFile,
+  type PluginTokenVerb,
+  type RolesIndex,
+  type Verb,
+} from './access-grammar.js';
+
+/**
+ * Plugin principals — `plugin/<Name>/<verb>` — synthesised into the principal
+ * index from each plugin folder's own `access.md`, so a grant naming one
+ * resolves exactly like a group grant: the resolver sees a named principal
+ * with member emails and needs no plugin awareness at all.
+ *
+ * WHAT A PLUGIN'S ROSTER IS: the folder-governing rules of
+ * `Plugins/<Name>/access.md` — the file provisioning seeds and the join flow
+ * edits. Three principals per plugin, following the resolver's own superset
+ * convention (write implies read, owner implies both):
+ *
+ *   plugin/<slug>/read    everyone under read, write or owner
+ *   plugin/<slug>/write   everyone under write or owner
+ *   plugin/<slug>/owner   everyone under owner
+ *
+ * The `<slug>` is the manifest slug of the folder (`pluginManifestName`), the
+ * identity `parseAccessEntry` canonicalises a hand-written token to.
+ *
+ * Deliberately NOT membership:
+ *   - the file's frontmatter (`read: everyone` there is DISCOVERABILITY of
+ *     the access.md itself, not membership) — `AccessFile.entries` already
+ *     holds only the folder block;
+ *   - rules inherited from above the plugin folder (the repo root's
+ *     `write: Admin`) — admins reach the skill through those same rules
+ *     anyway, and the roster should be what the plugin's page shows;
+ *   - `deny` entries — a denial subtracts nothing here; a plugin that wants
+ *     someone out removes the grant;
+ *   - other plugin tokens inside a plugin's rules — skipped, so synthesis is
+ *     one pass with no recursion and no cycle to detect.
+ *
+ * `everyone` in a plugin's own rules makes the corresponding principal
+ * PUBLIC: no email list can enumerate it, so its key is recorded in
+ * `index.publicKeys` and the resolver unions those into every caller's set.
+ *
+ * Runs AFTER groups are merged (so role and group entries expand through the
+ * finished index) and BEFORE unknown-role validation (so plugin tokens in
+ * access files count as known).
+ */
+export function synthesizePluginPrincipals(
+  index: RolesIndex,
+  accessFiles: ReadonlyMap<string, AccessFile>,
+  pluginsDir: string = PLUGINS_DIR,
+): void {
+  for (const file of accessFiles.values()) {
+    const folder = pluginFolderOf(file.dir, pluginsDir);
+    if (folder === null) continue;
+    const slug = pluginManifestName(folder);
+    for (const verb of PLUGIN_TOKEN_VERBS) {
+      const { emails, everyone } = holdersOf(index, file, verb);
+      const key = pluginPrincipalKey(slug, verb);
+      index.byCanonical.set(key, {
+        displayName: `${PLUGIN_TOKEN_PREFIX}${folder}/${verb}`,
+        emails,
+        kind: 'plugin',
+        pluginFolder: folder,
+      });
+      for (const email of emails) {
+        let set = index.byEmail.get(email);
+        if (!set) {
+          set = new Set();
+          index.byEmail.set(email, set);
+        }
+        set.add(key);
+      }
+      if (everyone) {
+        index.publicKeys ??= new Set();
+        index.publicKeys.add(key);
+      }
+    }
+  }
+}
+
+/** `Plugins/<Name>` → `<Name>`; anything else (deeper, elsewhere, the root) → null. */
+function pluginFolderOf(dir: string, pluginsDir: string): string | null {
+  const segments = dir.split('/').filter(Boolean);
+  return segments.length === 2 && segments[0] === pluginsDir ? segments[1] : null;
+}
+
+/** The verbs whose grants confer `verb` on the plugin (the superset fold). */
+function sourceVerbsFor(verb: PluginTokenVerb): Verb[] {
+  switch (verb) {
+    case 'read':
+      return ['read', 'write', 'owner'];
+    case 'write':
+      return ['write', 'owner'];
+    case 'owner':
+      return ['owner'];
+  }
+}
+
+function holdersOf(
+  index: RolesIndex,
+  file: AccessFile,
+  verb: PluginTokenVerb,
+): { emails: Set<string>; everyone: boolean } {
+  const emails = new Set<string>();
+  let everyone = false;
+  for (const source of sourceVerbsFor(verb)) {
+    for (const entry of file.entries[source]) {
+      if (entry.deny) continue;
+      if (entry.kind === 'user') {
+        emails.add(entry.email);
+        continue;
+      }
+      if (entry.role === EVERYONE_CANONICAL) {
+        everyone = true;
+        continue;
+      }
+      if (entry.role.startsWith(PLUGIN_TOKEN_PREFIX)) continue; // no recursion
+      const record = index.byCanonical.get(entry.role);
+      if (!record) continue; // an unknown role contributes nothing (loadModel warns separately)
+      for (const email of record.emails) emails.add(email);
+    }
+  }
+  return { emails, everyone };
+}

--- a/packages/core-backend/src/modules/access-model/plugin-principals.ts
+++ b/packages/core-backend/src/modules/access-model/plugin-principals.ts
@@ -75,6 +75,7 @@ export function synthesizePluginPrincipals(
         emails,
         kind: 'plugin',
         pluginFolder: folder,
+        pluginDir: dir,
       });
       for (const email of emails) {
         let set = index.byEmail.get(email);

--- a/packages/core-backend/src/modules/access-model/plugin-principals.ts
+++ b/packages/core-backend/src/modules/access-model/plugin-principals.ts
@@ -1,4 +1,4 @@
-import { PLUGINS_DIR, pluginManifestName } from '@bevel-software/platform-shared';
+import { pluginManifestName } from '@bevel-software/platform-shared';
 import {
   EVERYONE_CANONICAL,
   PLUGIN_TOKEN_PREFIX,
@@ -51,12 +51,22 @@ import {
 export function synthesizePluginPrincipals(
   index: RolesIndex,
   accessFiles: ReadonlyMap<string, AccessFile>,
-  pluginsDir: string = PLUGINS_DIR,
+  /**
+   * The repo-relative folders that ARE plugins — the ones carrying a
+   * `plugin.json` — as the model loader saw them. A plugin is a folder with
+   * a manifest, at any depth; its access.md is its roster. Nothing else's is.
+   */
+  pluginDirs: ReadonlySet<string>,
 ): void {
-  for (const file of accessFiles.values()) {
-    const folder = pluginFolderOf(file.dir, pluginsDir);
-    if (folder === null) continue;
+  const claimed = new Set<string>();
+  for (const dir of [...pluginDirs].sort()) {
+    const file = accessFiles.get(dir);
+    if (!file) continue; // a plugin without rules has no roster
+    const folder = dir.split('/').pop() ?? dir;
     const slug = pluginManifestName(folder);
+    // Two plugins with one name: discovery keeps the first by path, so do we.
+    if (claimed.has(slug)) continue;
+    claimed.add(slug);
     for (const verb of PLUGIN_TOKEN_VERBS) {
       const { emails, everyone } = holdersOf(index, file, verb);
       const key = pluginPrincipalKey(slug, verb);
@@ -80,12 +90,6 @@ export function synthesizePluginPrincipals(
       }
     }
   }
-}
-
-/** `Plugins/<Name>` → `<Name>`; anything else (deeper, elsewhere, the root) → null. */
-function pluginFolderOf(dir: string, pluginsDir: string): string | null {
-  const segments = dir.split('/').filter(Boolean);
-  return segments.length === 2 && segments[0] === pluginsDir ? segments[1] : null;
 }
 
 /** The verbs whose grants confer `verb` on the plugin (the superset fold). */

--- a/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
@@ -68,10 +68,12 @@ describe('plugin principals', () => {
     return new AccessControlService(stubWorkspaceService(workspaceId, workspaceDir), KB_DIR);
   }
 
+  // A plugin IS a folder with a manifest; its access.md is its roster.
   const BASE = {
     'roles.yaml': ROLES_YAML,
     'groups.yaml': GROUPS_YAML,
     'access.md': '---\nwrite:\n  - Admin\n---\n',
+    'Plugins/GTM/plugin.json': '{"name":"gtm"}',
     'Plugins/GTM/access.md': pluginAccessMd(
       'read:\n  - Sales Team\n  - Ali <ali@x.io>\nwrite:\n  - Engineer\nowner:\n  - Owen <owen@x.io>\n',
     ),
@@ -155,6 +157,7 @@ describe('plugin principals', () => {
     it('a plugin readable by everyone yields a public principal', async () => {
       const svc = await makeService({
         ...BASE,
+        'Plugins/Open/plugin.json': '{"name":"open"}',
         'Plugins/Open/access.md': pluginAccessMd('read:\n  - everyone\nwrite:\n  - Admin\n'),
         'Skills/Common/tips/access.md': '---\n---\nread:\n  - plugin/Open/read\n',
       });
@@ -168,6 +171,7 @@ describe('plugin principals', () => {
         ...BASE,
         // Frontmatter `read: everyone` is discoverability of the FILE. The body
         // denies Sue, and points at another plugin's token.
+        'Plugins/Narrow/plugin.json': '{"name":"narrow"}',
         'Plugins/Narrow/access.md': pluginAccessMd(
           'read:\n  - Sales Team\n  - deny Sue <sue@x.io>\n  - plugin/GTM/read\nwrite:\n  - Admin\n',
         ),
@@ -204,10 +208,25 @@ describe('plugin principals', () => {
       expect(readers.principals).toContainEqual({ name: 'plugin/GTM/read', kind: 'plugin' });
     });
 
+    it('a plugin nested deeper than the root gets its principals too — a plugin is a folder with a manifest', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Plugins/teams/Deep/plugin.json': '{"name":"deep"}',
+        'Plugins/teams/Deep/access.md': pluginAccessMd('read:\n  - Ali <ali@x.io>\n'),
+        // A scope folder's own access.md is NOT a roster: no manifest beside it.
+        'Plugins/teams/access.md': '---\n---\nread:\n  - everyone\n',
+        'Skills/S/x/access.md': '---\n---\nread:\n  - plugin/Deep/read\n  - plugin/teams/read\n',
+      });
+      expect(await svc.canRead(workspaceId, 'ali@x.io', 'Skills/S/x/SKILL.md')).toBe(true);
+      expect(await svc.canRead(workspaceId, 'mallory@x.io', 'Skills/S/x/SKILL.md')).toBe(false);
+    });
+
     it('kbPrincipals lists plugin folders once each, personal folders excluded', async () => {
       const svc = await makeService({
         ...BASE,
+        'Plugins/Ops/plugin.json': '{"name":"ops"}',
         'Plugins/Ops/access.md': pluginAccessMd('read:\n  - Admin\n'),
+        'Plugins/personal-abc123/plugin.json': '{"name":"personal-abc123"}',
         'Plugins/personal-abc123/access.md': '---\n---\nread:\n  - Ali <ali@x.io>\n',
       });
       const { plugins } = await svc.kbPrincipals(workspaceId);

--- a/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../access-control.service.js';
+import { parseAccessEntry } from '../../access-model/access-grammar.js';
+
+/**
+ * `plugin/<Name>/<verb>` as a grantable principal: derived from the plugin
+ * folder's own access.md, resolved like any group, and usable on ANY path —
+ * a shared skill under `Skills/`, a Knowledge folder, anything. These tests
+ * drive the public resolver (`canRead`/`canWrite`, `eligibleReaders`,
+ * `kbPrincipals`) over a real on-disk tree; the synthesis is not tested
+ * through its own helper.
+ */
+
+const KB_DIR = 'knowledge-base';
+
+function stubWorkspaceService(workspaceId: string, workspaceDir: string): WorkspaceService {
+  return {
+    getWorkspacePath: async (id: string) => {
+      if (id !== workspaceId) throw new Error(`unexpected workspace ${id}`);
+      return workspaceDir;
+    },
+    ensureRemotesFetched: async () => undefined,
+  } as unknown as WorkspaceService;
+}
+
+const ROLES_YAML = `roles:
+  Admin:
+    - admin@x.io
+  Engineer:
+    - eng@x.io
+`;
+
+const GROUPS_YAML = `groups:
+  Sales Team:
+    - sam@x.io
+    - sue@x.io
+`;
+
+/** A plugin folder's access.md in the body-governed format. */
+function pluginAccessMd(body: string): string {
+  return `---\nread:\n  - everyone\n---\n${body}`;
+}
+
+describe('plugin principals', () => {
+  let root: string;
+  const workspaceId = 'ws-plugins-1';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-plugin-principals-'));
+  });
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function makeService(files: Record<string, string>) {
+    const workspaceDir = path.join(root, workspaceId);
+    const repo = path.join(workspaceDir, KB_DIR);
+    for (const [rel, contents] of Object.entries(files)) {
+      const abs = path.join(repo, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, contents);
+    }
+    return new AccessControlService(stubWorkspaceService(workspaceId, workspaceDir), KB_DIR);
+  }
+
+  const BASE = {
+    'roles.yaml': ROLES_YAML,
+    'groups.yaml': GROUPS_YAML,
+    'access.md': '---\nwrite:\n  - Admin\n---\n',
+    'Plugins/GTM/access.md': pluginAccessMd(
+      'read:\n  - Sales Team\n  - Ali <ali@x.io>\nwrite:\n  - Engineer\nowner:\n  - Owen <owen@x.io>\n',
+    ),
+  };
+
+  describe('grammar', () => {
+    it('canonicalises the name half to the manifest slug and keeps the verb', () => {
+      const parsed = parseAccessEntry('plugin/Sales Team/read');
+      expect(parsed.ok && parsed.entry.kind === 'role' && parsed.entry.role).toBe('plugin/sales-team/read');
+      const upper = parseAccessEntry('Plugin/GTM/Write');
+      expect(upper.ok && upper.entry.kind === 'role' && upper.entry.role).toBe('plugin/gtm/write');
+      const denied = parseAccessEntry('deny plugin/GTM/owner');
+      expect(denied.ok && denied.entry.kind === 'role' && denied.entry.deny).toBe(true);
+    });
+
+    it('rejects a token with a missing or unknown verb, naming the valid shapes', () => {
+      for (const bad of ['plugin/GTM', 'plugin/GTM/', 'plugin/GTM/admin', 'plugin//read']) {
+        const parsed = parseAccessEntry(bad);
+        expect(parsed.ok, bad).toBe(false);
+        expect(!parsed.ok && parsed.error).toMatch(/plugin\/<plugin>\/read/);
+      }
+    });
+  });
+
+  describe('resolution', () => {
+    it('grants a shared skill to the plugin\'s readers, writers and owners — and to nobody else', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Skills/Eng/deploy/access.md': '---\n---\nread:\n  - plugin/GTM/read\n',
+      });
+      const skill = 'Skills/Eng/deploy/SKILL.md';
+      // Group member, direct reader, writer (write implies read), owner.
+      for (const email of ['sam@x.io', 'ali@x.io', 'eng@x.io', 'owen@x.io']) {
+        expect(await svc.canRead(workspaceId, email, skill), email).toBe(true);
+      }
+      expect(await svc.canRead(workspaceId, 'mallory@x.io', skill)).toBe(false);
+      // Read on the plugin is read on the skill, nothing more.
+      expect(await svc.canWrite(workspaceId, 'sam@x.io', skill)).toBe(false);
+    });
+
+    it('the write token names the plugin\'s writers and owners only', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Skills/Eng/deploy/access.md': '---\n---\nread:\n  - plugin/GTM/read\nwrite:\n  - plugin/GTM/write\n',
+      });
+      const skill = 'Skills/Eng/deploy/SKILL.md';
+      expect(await svc.canWrite(workspaceId, 'eng@x.io', skill)).toBe(true);
+      expect(await svc.canWrite(workspaceId, 'owen@x.io', skill)).toBe(true);
+      expect(await svc.canWrite(workspaceId, 'sam@x.io', skill)).toBe(false);
+      expect(await svc.canWrite(workspaceId, 'ali@x.io', skill)).toBe(false);
+    });
+
+    it('the owner token names owners alone', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'KnowledgeBase/Ops/access.md': '---\n---\nread:\n  - plugin/GTM/owner\n',
+      });
+      expect(await svc.canRead(workspaceId, 'owen@x.io', 'KnowledgeBase/Ops/x.md')).toBe(true);
+      expect(await svc.canRead(workspaceId, 'eng@x.io', 'KnowledgeBase/Ops/x.md')).toBe(false);
+    });
+
+    it('follows the plugin\'s roster live: a member removed from the plugin loses the skill', async () => {
+      const files = {
+        ...BASE,
+        'Skills/Eng/deploy/access.md': '---\n---\nread:\n  - plugin/GTM/read\n',
+      };
+      const svc = await makeService(files);
+      const skill = 'Skills/Eng/deploy/SKILL.md';
+      expect(await svc.canRead(workspaceId, 'ali@x.io', skill)).toBe(true);
+
+      // Drop Ali from the plugin's own access.md — nothing on the skill changes.
+      await fs.writeFile(
+        path.join(root, workspaceId, KB_DIR, 'Plugins/GTM/access.md'),
+        pluginAccessMd('read:\n  - Sales Team\nwrite:\n  - Engineer\n'),
+      );
+      svc.invalidate(workspaceId);
+      expect(await svc.canRead(workspaceId, 'ali@x.io', skill)).toBe(false);
+      expect(await svc.canRead(workspaceId, 'sam@x.io', skill)).toBe(true);
+    });
+
+    it('a plugin readable by everyone yields a public principal', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Plugins/Open/access.md': pluginAccessMd('read:\n  - everyone\nwrite:\n  - Admin\n'),
+        'Skills/Common/tips/access.md': '---\n---\nread:\n  - plugin/Open/read\n',
+      });
+      expect(await svc.canRead(workspaceId, 'nobody@elsewhere.io', 'Skills/Common/tips/SKILL.md')).toBe(true);
+      // The write token of that plugin is still its writers only.
+      expect(await svc.canWrite(workspaceId, 'nobody@elsewhere.io', 'Skills/Common/tips/SKILL.md')).toBe(false);
+    });
+
+    it('membership never counts the access.md frontmatter, a deny, or another plugin token', async () => {
+      const svc = await makeService({
+        ...BASE,
+        // Frontmatter `read: everyone` is discoverability of the FILE. The body
+        // denies Sue, and points at another plugin's token.
+        'Plugins/Narrow/access.md': pluginAccessMd(
+          'read:\n  - Sales Team\n  - deny Sue <sue@x.io>\n  - plugin/GTM/read\nwrite:\n  - Admin\n',
+        ),
+        'Skills/S/x/access.md': '---\n---\nread:\n  - plugin/Narrow/read\n',
+      });
+      const skill = 'Skills/S/x/SKILL.md';
+      expect(await svc.canRead(workspaceId, 'sam@x.io', skill)).toBe(true);
+      // Deny entries are skipped, not subtracted: Sue is still in Sales Team.
+      expect(await svc.canRead(workspaceId, 'sue@x.io', skill)).toBe(true);
+      // GTM's reader Ali is NOT a member of Narrow through the nested token.
+      expect(await svc.canRead(workspaceId, 'ali@x.io', skill)).toBe(false);
+      // And nobody at random: the frontmatter `everyone` did not leak in.
+      expect(await svc.canRead(workspaceId, 'mallory@x.io', skill)).toBe(false);
+    });
+
+    it('a token naming a plugin that does not exist is ignored like an unknown role', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Skills/S/x/access.md': '---\n---\nread:\n  - plugin/Ghost/read\n  - Ali <ali@x.io>\n',
+      });
+      expect(await svc.canRead(workspaceId, 'ali@x.io', 'Skills/S/x/SKILL.md')).toBe(true);
+      expect(await svc.canRead(workspaceId, 'sam@x.io', 'Skills/S/x/SKILL.md')).toBe(false);
+    });
+  });
+
+  describe('display', () => {
+    it('eligibleReaders reports the token as a plugin-kind principal with the folder\'s casing', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Skills/Eng/deploy/access.md': '---\n---\nread:\n  - plugin/gtm/read\n',
+      });
+      const readers = await svc.eligibleReaders(workspaceId, 'Skills/Eng/deploy');
+      expect(readers.restricted).toBe(true);
+      expect(readers.principals).toContainEqual({ name: 'plugin/GTM/read', kind: 'plugin' });
+    });
+
+    it('kbPrincipals lists plugin folders once each, personal folders excluded', async () => {
+      const svc = await makeService({
+        ...BASE,
+        'Plugins/Ops/access.md': pluginAccessMd('read:\n  - Admin\n'),
+        'Plugins/personal-abc123/access.md': '---\n---\nread:\n  - Ali <ali@x.io>\n',
+      });
+      const { plugins } = await svc.kbPrincipals(workspaceId);
+      expect(plugins).toEqual(['GTM', 'Ops']);
+    });
+  });
+});

--- a/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-plugin-principals.test.ts
@@ -230,7 +230,10 @@ describe('plugin principals', () => {
         'Plugins/personal-abc123/access.md': '---\n---\nread:\n  - Ali <ali@x.io>\n',
       });
       const { plugins } = await svc.kbPrincipals(workspaceId);
-      expect(plugins).toEqual(['GTM', 'Ops']);
+      expect(plugins).toEqual([
+        { name: 'GTM', folder: 'Plugins/GTM' },
+        { name: 'Ops', folder: 'Plugins/Ops' },
+      ]);
     });
   });
 });

--- a/packages/core-backend/src/modules/access/__tests__/groups-admin.service.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/groups-admin.service.test.ts
@@ -184,6 +184,14 @@ describe('GroupsAdminService', () => {
     expect(await groupsYaml()).not.toContain('role/');
   });
 
+  it("createGroup refuses the reserved 'plugin/' prefix — a group could otherwise pose as a plugin's members", async () => {
+    await expect(service.createGroup(ADMIN, 'plugin/GTM/read')).rejects.toMatchObject({
+      status: 422,
+      message: expect.stringContaining('plugin/'),
+    });
+    expect(await groupsYaml()).not.toContain('plugin/');
+  });
+
   it('create → add → remove → delete lifecycle lands on disk', async () => {
     await service.createGroup(ADMIN, 'Contractors');
     await service.addMember(ADMIN, 'contractors', 'temp@x.io');

--- a/packages/core-backend/src/modules/access/access-control.interface.ts
+++ b/packages/core-backend/src/modules/access/access-control.interface.ts
@@ -326,8 +326,12 @@ export interface IAccessControl {
   kbPrincipals(workspaceId: string): Promise<{
     roles: string[];
     groups: string[];
-    /** Plugin FOLDER names whose `plugin/<Name>/<verb>` principals exist (personal folders excluded). */
-    plugins: string[];
+    /**
+     * Plugins whose `plugin/<Name>/<verb>` principals exist (personal folders
+     * excluded): the display name and the repo-relative folder, so a caller
+     * can apply the discoverability verdict (`canRead` on `<folder>/access.md`).
+     */
+    plugins: { name: string; folder: string }[];
     people: { name: string; email: string }[];
   }>;
 

--- a/packages/core-backend/src/modules/access/access-control.interface.ts
+++ b/packages/core-backend/src/modules/access/access-control.interface.ts
@@ -67,7 +67,7 @@ export type GrantPrincipal =
  * returns it, and payload consumers fall back to `roles` (all treated as
  * roles) when absent.
  */
-export type ResolvedPrincipal = { name: string; kind: 'role' | 'group' };
+export type ResolvedPrincipal = { name: string; kind: 'role' | 'group' | 'plugin' };
 
 /**
  * Per-verb sources of a principal's access on a target. Only verbs the principal
@@ -323,9 +323,13 @@ export interface IAccessControl {
    * (named). The login-only `users` table is unioned in by the caller — this
    * method covers the KB-canonical people the users table misses.
    */
-  kbPrincipals(
-    workspaceId: string,
-  ): Promise<{ roles: string[]; groups: string[]; people: { name: string; email: string }[] }>;
+  kbPrincipals(workspaceId: string): Promise<{
+    roles: string[];
+    groups: string[];
+    /** Plugin FOLDER names whose `plugin/<Name>/<verb>` principals exist (personal folders excluded). */
+    plugins: string[];
+    people: { name: string; email: string }[];
+  }>;
 
   /**
    * Reverse-lookup an email by its SHA-256 hash (per `hashEmail` semantics)

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -1124,7 +1124,7 @@ export class AccessControlService implements IAccessControl {
   async kbPrincipals(workspaceId: string): Promise<{
     roles: string[];
     groups: string[];
-    plugins: string[];
+    plugins: { name: string; folder: string }[];
     people: { name: string; email: string }[];
   }> {
     let model: AccessModel;
@@ -1146,12 +1146,17 @@ export class AccessControlService implements IAccessControl {
     // Plugins = the FOLDER names behind the synthesised `plugin/<Name>/<verb>`
     // principals, once each (three keys share a folder). Personal folders are
     // plugins to the resolver but not to a person picking a grantee.
-    const plugins = new Set<string>();
+    const plugins = new Map<string, string>();
     for (const [key, principal] of model.roles.byCanonical) {
       if (key.startsWith(ROLE_TOKEN_PREFIX)) roles.push(principal.displayName);
       else if (principal.kind === 'group') groups.push(principal.displayName);
-      else if (principal.kind === 'plugin' && principal.pluginFolder && !isPersonalPluginFolder(principal.pluginFolder)) {
-        plugins.add(principal.pluginFolder);
+      else if (
+        principal.kind === 'plugin' &&
+        principal.pluginFolder &&
+        principal.pluginDir &&
+        !isPersonalPluginFolder(principal.pluginFolder)
+      ) {
+        plugins.set(principal.pluginFolder, principal.pluginDir);
       }
     }
     // People = roles.yaml member emails (name-less) ∪ access.md `Name <email>`
@@ -1173,7 +1178,14 @@ export class AccessControlService implements IAccessControl {
       name: name || email.split('@')[0],
       email,
     }));
-    return { roles, groups, plugins: [...plugins].sort((a, b) => a.localeCompare(b)), people };
+    return {
+      roles,
+      groups,
+      plugins: [...plugins.entries()]
+        .map(([name, folder]) => ({ name, folder }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      people,
+    };
   }
 
   async findEmailByHash(

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -13,7 +13,9 @@ import type {
   GrantSources,
   ResolvedPrincipal,
 } from './access-control.interface.js';
+import { PLUGINS_DIR, isPersonalPluginFolder } from '@bevel-software/platform-shared';
 import { AccessConfigError, AccessUnreadableError } from '../access-model/access-errors.js';
+import { synthesizePluginPrincipals } from '../access-model/plugin-principals.js';
 import {
   GROUPS_YAML,
   SYNCED_GROUPS_YAML,
@@ -355,6 +357,19 @@ function resolveAtPath(
   return collapseScopes(resolveScopes(model, verb, relativePath, fileOwn));
 }
 
+/**
+ * Every principal key a caller holds: the tokens their email is a member of,
+ * plus the PUBLIC keys every caller holds regardless (a plugin principal
+ * whose plugin grants `everyone`). Undefined when there is nothing at all,
+ * matching the plain `byEmail.get` the tier-2 check used to read.
+ */
+function principalKeysOf(model: AccessModel, email: string): Set<string> | undefined {
+  const own = model.roles.byEmail.get(email);
+  const pub = model.roles.publicKeys;
+  if (!pub?.size) return own;
+  return new Set([...(own ?? []), ...pub]);
+}
+
 function isAdminEmail(model: AccessModel, email: string): boolean {
   if (model.deploymentOwners.has(email)) return true;
   const roles = model.roles.byEmail.get(email);
@@ -411,7 +426,7 @@ function hasPermissionResolved(
     if (isAccessMdPath(relativePath) && isAdminEmail(model, email)) return true;
   }
 
-  const userRoles = model.roles.byEmail.get(email);
+  const userRoles = principalKeysOf(model, email);
   const scopes = resolveScopes(model, verb, relativePath, fileOwn);
 
   for (const scope of scopes) {
@@ -659,7 +674,7 @@ function eligibleHoldersResolved(
   // principals, and collapsing them to one would hide the role's live
   // `role/<name>` grant from every consumer of the eligible list.
   const byIdentity = new Map<string, ResolvedPrincipal>();
-  const addPrincipal = (name: string, kind: 'role' | 'group') => {
+  const addPrincipal = (name: string, kind: ResolvedPrincipal['kind']) => {
     const key = `${kind}\0${name.toLowerCase()}`;
     if (!byIdentity.has(key)) byIdentity.set(key, { name, kind });
   };
@@ -1106,14 +1121,17 @@ export class AccessControlService implements IAccessControl {
     return out;
   }
 
-  async kbPrincipals(
-    workspaceId: string,
-  ): Promise<{ roles: string[]; groups: string[]; people: { name: string; email: string }[] }> {
+  async kbPrincipals(workspaceId: string): Promise<{
+    roles: string[];
+    groups: string[];
+    plugins: string[];
+    people: { name: string; email: string }[];
+  }> {
     let model: AccessModel;
     try {
       model = await this.loadModel(workspaceId);
     } catch {
-      return { roles: [], groups: [], people: [] };
+      return { roles: [], groups: [], plugins: [], people: [] };
     }
     // Roles = the built-in `everyone` role plus every declared role's display
     // name — ROLE principals only, never groups. Each role is enumerated via
@@ -1125,9 +1143,16 @@ export class AccessControlService implements IAccessControl {
     // direct-access.md edit).
     const roles = [EVERYONE_DISPLAY];
     const groups: string[] = [];
+    // Plugins = the FOLDER names behind the synthesised `plugin/<Name>/<verb>`
+    // principals, once each (three keys share a folder). Personal folders are
+    // plugins to the resolver but not to a person picking a grantee.
+    const plugins = new Set<string>();
     for (const [key, principal] of model.roles.byCanonical) {
       if (key.startsWith(ROLE_TOKEN_PREFIX)) roles.push(principal.displayName);
       else if (principal.kind === 'group') groups.push(principal.displayName);
+      else if (principal.kind === 'plugin' && principal.pluginFolder && !isPersonalPluginFolder(principal.pluginFolder)) {
+        plugins.add(principal.pluginFolder);
+      }
     }
     // People = roles.yaml member emails (name-less) ∪ access.md `Name <email>`
     // grants (named). The login-only users table is unioned in by the caller.
@@ -1148,7 +1173,7 @@ export class AccessControlService implements IAccessControl {
       name: name || email.split('@')[0],
       email,
     }));
-    return { roles, groups, people };
+    return { roles, groups, plugins: [...plugins].sort((a, b) => a.localeCompare(b)), people };
   }
 
   async findEmailByHash(
@@ -1405,6 +1430,12 @@ export class AccessControlService implements IAccessControl {
     // / `roles.yaml` because `hasPermissionResolved` admin-rescues those
     // paths, so the bad config remains fixable from inside the app.
     await this.collectAccessFiles(repoDir, '', accessFiles);
+
+    // Plugin principals (`plugin/<Name>/<verb>`), derived from each plugin
+    // folder's own access.md — after groups merged (so their rosters expand
+    // through the finished index) and before the unknown-role sweep below
+    // (so a grant naming one counts as known).
+    synthesizePluginPrincipals(rolesParsed.index, accessFiles, PLUGINS_DIR);
 
     // Validate role refs against roles.yaml. `everyone` is a built-in role and
     // is valid without a roles.yaml entry. Unknown refs are dropped from the

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -13,7 +13,7 @@ import type {
   GrantSources,
   ResolvedPrincipal,
 } from './access-control.interface.js';
-import { PLUGINS_DIR, isPersonalPluginFolder } from '@bevel-software/platform-shared';
+import { PLUGINS_DIR, PLUGIN_MANIFEST_FILE, isPersonalPluginFolder } from '@bevel-software/platform-shared';
 import { AccessConfigError, AccessUnreadableError } from '../access-model/access-errors.js';
 import { synthesizePluginPrincipals } from '../access-model/plugin-principals.js';
 import {
@@ -1429,13 +1429,15 @@ export class AccessControlService implements IAccessControl {
     // must not 500 the entire editor; admins can still write `access.md`
     // / `roles.yaml` because `hasPermissionResolved` admin-rescues those
     // paths, so the bad config remains fixable from inside the app.
-    await this.collectAccessFiles(repoDir, '', accessFiles);
+    const pluginDirs = new Set<string>();
+    await this.collectAccessFiles(repoDir, '', accessFiles, pluginDirs);
 
     // Plugin principals (`plugin/<Name>/<verb>`), derived from each plugin
-    // folder's own access.md — after groups merged (so their rosters expand
-    // through the finished index) and before the unknown-role sweep below
-    // (so a grant naming one counts as known).
-    synthesizePluginPrincipals(rolesParsed.index, accessFiles, PLUGINS_DIR);
+    // folder's own access.md — a plugin being a folder with a manifest, at
+    // any depth — after groups merged (so their rosters expand through the
+    // finished index) and before the unknown-role sweep below (so a grant
+    // naming one counts as known).
+    synthesizePluginPrincipals(rolesParsed.index, accessFiles, pluginDirs);
 
     // Validate role refs against roles.yaml. `everyone` is a built-in role and
     // is valid without a roles.yaml entry. Unknown refs are dropped from the
@@ -1469,6 +1471,8 @@ export class AccessControlService implements IAccessControl {
     absDir: string,
     relDir: string,
     out: Map<string, AccessFile>,
+    /** Folders under the plugins root carrying a manifest — the plugins, for principal synthesis. */
+    pluginDirs?: Set<string>,
   ): Promise<void> {
     let entries;
     try {
@@ -1485,7 +1489,14 @@ export class AccessControlService implements IAccessControl {
       const abs = path.join(absDir, entry.name);
       const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
       if (entry.isDirectory()) {
-        await this.collectAccessFiles(abs, rel, out);
+        await this.collectAccessFiles(abs, rel, out, pluginDirs);
+      } else if (
+        pluginDirs &&
+        entry.isFile() &&
+        entry.name === PLUGIN_MANIFEST_FILE &&
+        relDir.startsWith(`${PLUGINS_DIR}/`)
+      ) {
+        pluginDirs.add(relDir);
       } else if (entry.isFile() && entry.name === 'access.md') {
         const text = await fs.readFile(abs, 'utf-8');
         const parsed = parseAccessFile(text, rel);
@@ -1645,7 +1656,10 @@ export class AccessControlService implements IAccessControl {
    * `'error'` when git failed: a model built without its access files is
    * not the model, and the caller must not cache it as one.
    */
-  private async listAccessFilesAtRef(repoDir: string, ref: string): Promise<string[] | 'error'> {
+  private async listAccessFilesAtRef(
+    repoDir: string,
+    ref: string,
+  ): Promise<{ accessFiles: string[]; pluginDirs: string[] } | 'error'> {
     try {
       const { stdout } = await execFileAsync(
         'git',
@@ -1653,12 +1667,16 @@ export class AccessControlService implements IAccessControl {
         { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024 },
       );
       const out: string[] = [];
+      const pluginDirs: string[] = [];
       for (const line of stdout.split('\n')) {
         const p = line.trim();
         if (!p) continue;
         if (p === 'access.md' || p.endsWith('/access.md')) out.push(p);
+        else if (p.startsWith(`${PLUGINS_DIR}/`) && p.endsWith(`/${PLUGIN_MANIFEST_FILE}`)) {
+          pluginDirs.push(p.slice(0, -(PLUGIN_MANIFEST_FILE.length + 1)));
+        }
       }
-      return out;
+      return { accessFiles: out, pluginDirs };
     } catch {
       return 'error';
     }
@@ -1812,7 +1830,7 @@ export class AccessControlService implements IAccessControl {
       console.warn(`[access@${tag}] listing access.md files failed; refusing to decide from a partial tree`);
       throw new AccessUnreadableError(label, 'access.md (ls-tree)');
     }
-    for (const p of listed) {
+    for (const p of listed.accessFiles) {
       const text = await read(p);
       if (text === null) continue;
       const parsed = parseAccessFile(text, p);
@@ -1822,6 +1840,11 @@ export class AccessControlService implements IAccessControl {
       // duplicates, but be defensive.
       accessFiles.set(parsed.file.dir, parsed.file);
     }
+
+    // Mirror `loadModel`: plugin principals from the plugins the ref carries,
+    // so a PR-time verdict on a skill granted to `plugin/<Name>/write` counts
+    // the plugin's writers exactly as the working tree would.
+    synthesizePluginPrincipals(rolesParsed.index, accessFiles, new Set(listed.pluginDirs));
 
     // Mirror `loadModel`: drop entries whose role ref is unknown to roles.yaml,
     // while preserving the built-in `everyone` role.

--- a/packages/core-backend/src/modules/access/access.routes.ts
+++ b/packages/core-backend/src/modules/access/access.routes.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import type { AuthUser } from '@bevel-software/platform-shared';
-import { isProtectedBranch, DEFAULT_BRANCH, PLUGINS_DIR, pluginManifestName } from '@bevel-software/platform-shared';
+import { isProtectedBranch, DEFAULT_BRANCH, pluginManifestName } from '@bevel-software/platform-shared';
 import type {
   IAccessControl,
   GrantPrincipal,
@@ -86,7 +86,7 @@ export function createAccessRoutes(
   const defaultBranchPrincipals = async (): Promise<{
     roles: string[];
     groups: string[];
-    plugins: string[];
+    plugins: { name: string; folder: string }[];
   }> => {
     await workspaceService.getOrCreateForBranch(DEFAULT_BRANCH);
     const { roles, groups, plugins } = await accessControl.kbPrincipals(
@@ -94,6 +94,26 @@ export function createAccessRoutes(
     );
     // `plugins` is defensive: an older resolver double may omit it.
     return { roles, groups, plugins: plugins ?? [] };
+  };
+
+  /**
+   * The plugins `email` may DISCOVER — read the folder's access.md, the same
+   * verdict the plugin index lists on. Both the suggest list and the grant
+   * route go through this, so a plugin hidden from the picker cannot be
+   * named in a grant either, and an undiscoverable one answers exactly like
+   * one that does not exist.
+   */
+  const discoverablePlugins = async (
+    email: string,
+    plugins: { name: string; folder: string }[],
+  ): Promise<{ name: string; folder: string }[]> => {
+    if (plugins.length === 0) return [];
+    const verdicts = await accessControl.canReadBatch(
+      workspaceIdForBranch(DEFAULT_BRANCH),
+      email,
+      plugins.map((p) => `${p.folder}/access.md`),
+    );
+    return plugins.filter((p) => verdicts.get(`${p.folder}/access.md`) === true);
   };
 
   /**
@@ -372,16 +392,13 @@ export function createAccessRoutes(
       // same verdict the plugin index lists on), so the picker never names a
       // plugin its enumeration would hide. Their `plugin/<Name>/<verb>`
       // tokens are built client-side; the name is what a person searches for.
-      const candidatePlugins = plugins.filter((p) => !q || p.toLowerCase().includes(q));
-      const discoverable = candidatePlugins.length
-        ? await accessControl.canReadBatch(
-            workspaceIdForBranch(DEFAULT_BRANCH),
-            user.email,
-            candidatePlugins.map((p) => `${PLUGINS_DIR}/${p}/access.md`),
-          )
-        : new Map<string, boolean>();
-      const matchedPlugins = candidatePlugins
-        .filter((p) => discoverable.get(`${PLUGINS_DIR}/${p}/access.md`) === true)
+      const matchedPlugins = (
+        await discoverablePlugins(
+          user.email,
+          plugins.filter((p) => !q || p.name.toLowerCase().includes(q)),
+        )
+      )
+        .map((p) => p.name)
         .slice(0, CAP);
 
       let people: { name: string; email: string }[] = [];
@@ -723,13 +740,15 @@ export function createAccessRoutes(
           );
         }
       } else if (principal.kind === 'plugin') {
-        // A plugin grant must name a plugin that EXISTS on the default branch
-        // (a folder carrying an access.md — the same set the suggest list
-        // offers). Matched on the manifest slug, the identity the token
-        // canonicalises to.
+        // A plugin grant must name a plugin the caller can DISCOVER on the
+        // default branch — the same set the suggest list offers, so a plugin
+        // hidden from the picker is refused here with the same words as one
+        // that does not exist. Matched on the manifest slug, the identity the
+        // token canonicalises to.
         const { plugins } = await defaultBranchPrincipals();
         const slug = pluginManifestName(principal.plugin);
-        if (!plugins.some((p) => pluginManifestName(p) === slug)) {
+        const visible = await discoverablePlugins(user.email, plugins);
+        if (!visible.some((p) => pluginManifestName(p.name) === slug)) {
           throw new AccessMutationError(
             `No plugin named "${principal.plugin}". Pick an existing plugin.`,
             404,

--- a/packages/core-backend/src/modules/access/access.routes.ts
+++ b/packages/core-backend/src/modules/access/access.routes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import type { AuthUser } from '@bevel-software/platform-shared';
-import { isProtectedBranch, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import { isProtectedBranch, DEFAULT_BRANCH, PLUGINS_DIR, pluginManifestName } from '@bevel-software/platform-shared';
 import type {
   IAccessControl,
   GrantPrincipal,
   GrantSources,
+  ResolvedPrincipal,
 } from './access-control.interface.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { branchForWorkspaceId, workspaceIdForBranch } from '../../shared/workspace-id.js';
@@ -22,7 +23,10 @@ import {
 import {
   canonicalRoleName,
   EVERYONE_CANONICAL,
+  PLUGIN_TOKEN_PREFIX,
+  PLUGIN_TOKEN_VERBS,
   ROLE_TOKEN_PREFIX,
+  type PluginTokenVerb,
   type Verb,
 } from '../access-model/access-grammar.js';
 import { listAccessDeclarationsUnder } from './access-declarations.js';
@@ -79,20 +83,31 @@ export function createAccessRoutes(
   // accepts — the same principals the admin screens manage, regardless of
   // which branch the caller is viewing. People stay branch-local (the
   // caller's own workspace).
-  const defaultBranchPrincipals = async (): Promise<{ roles: string[]; groups: string[] }> => {
+  const defaultBranchPrincipals = async (): Promise<{
+    roles: string[];
+    groups: string[];
+    plugins: string[];
+  }> => {
     await workspaceService.getOrCreateForBranch(DEFAULT_BRANCH);
-    const { roles, groups } = await accessControl.kbPrincipals(workspaceIdForBranch(DEFAULT_BRANCH));
-    return { roles, groups };
+    const { roles, groups, plugins } = await accessControl.kbPrincipals(
+      workspaceIdForBranch(DEFAULT_BRANCH),
+    );
+    // `plugins` is defensive: an older resolver double may omit it.
+    return { roles, groups, plugins: plugins ?? [] };
   };
 
   /**
-   * What the mutation routes accept as a principal. `group` exists only at
-   * this boundary: in the access.md entry grammar a group grant is a
-   * bare-name token (bare names resolve GROUP-FIRST, then fall back to the
-   * role), so it is spliced as a role-shaped principal — the separate kind
-   * buys validation against the right namespace and honest 404s.
+   * What the mutation routes accept as a principal. `group` and `plugin`
+   * exist only at this boundary: in the access.md entry grammar a group grant
+   * is a bare-name token (bare names resolve GROUP-FIRST, then fall back to
+   * the role) and a plugin grant is the `plugin/<Name>/<verb>` token, so both
+   * are spliced as role-shaped principals — the separate kinds buy validation
+   * against the right namespace and honest 404s.
    */
-  type RoutePrincipal = Principal | { kind: 'group'; group: string };
+  type RoutePrincipal =
+    | Principal
+    | { kind: 'group'; group: string }
+    | { kind: 'plugin'; plugin: string; verb: PluginTokenVerb };
 
   /**
    * The role-shaped principal the splice layer actually writes/matches.
@@ -104,6 +119,9 @@ export function createAccessRoutes(
    */
   const asSplicePrincipal = (p: RoutePrincipal): Principal => {
     if (p.kind === 'group') return { kind: 'role', role: p.group };
+    // Written with the folder's own casing; `parseAccessEntry` canonicalises
+    // the name half to the manifest slug on the way back in.
+    if (p.kind === 'plugin') return { kind: 'role', role: `${PLUGIN_TOKEN_PREFIX}${p.plugin.trim()}/${p.verb}` };
     if (p.kind === 'role') {
       const canonical = canonicalRoleName(p.role);
       const bare = canonical.startsWith(ROLE_TOKEN_PREFIX)
@@ -336,7 +354,7 @@ export function createAccessRoutes(
       // Independent lookups batched in ONE Promise.all: the default-branch
       // principals (cached model), the branch-local KB people (cached model),
       // and the users table (only consulted once the query is long enough).
-      const [{ roles, groups }, { people: kbPeople }, userRows] = await Promise.all([
+      const [{ roles, groups, plugins }, { people: kbPeople }, userRows] = await Promise.all([
         defaultBranchPrincipals(),
         accessControl.kbPrincipals(req.params.id),
         q.length >= 2 ? db.select().from(users) : Promise.resolve([]),
@@ -348,6 +366,22 @@ export function createAccessRoutes(
 
       const matchedGroups = groups
         .filter((g) => !q || g.toLowerCase().includes(q))
+        .slice(0, CAP);
+
+      // Plugins the caller can DISCOVER (read the folder's access.md — the
+      // same verdict the plugin index lists on), so the picker never names a
+      // plugin its enumeration would hide. Their `plugin/<Name>/<verb>`
+      // tokens are built client-side; the name is what a person searches for.
+      const candidatePlugins = plugins.filter((p) => !q || p.toLowerCase().includes(q));
+      const discoverable = candidatePlugins.length
+        ? await accessControl.canReadBatch(
+            workspaceIdForBranch(DEFAULT_BRANCH),
+            user.email,
+            candidatePlugins.map((p) => `${PLUGINS_DIR}/${p}/access.md`),
+          )
+        : new Map<string, boolean>();
+      const matchedPlugins = candidatePlugins
+        .filter((p) => discoverable.get(`${PLUGINS_DIR}/${p}/access.md`) === true)
         .slice(0, CAP);
 
       let people: { name: string; email: string }[] = [];
@@ -373,6 +407,10 @@ export function createAccessRoutes(
       res.json({
         roles: matchedRoles,
         groups: matchedGroups,
+        // Plugin FOLDER names; each stands for three grantable principals
+        // (`plugin/<Name>/read|write|owner`). Not `plugins` — that key is the
+        // deprecated alias of `roles` below.
+        pluginPrincipals: matchedPlugins,
         people,
         peopleWithheld: q.length < 2,
         // DEPRECATED alias of `roles` — the shipped share dialog still reads
@@ -428,8 +466,19 @@ export function createAccessRoutes(
         throw new AccessMutationError('group principal needs a group name');
       }
       principal = { kind: 'group', group: principalRaw.group };
+    } else if (principalRaw.kind === 'plugin') {
+      if (typeof principalRaw.plugin !== 'string' || !principalRaw.plugin.trim()) {
+        throw new AccessMutationError('plugin principal needs a plugin name');
+      }
+      const verb = principalRaw.verb;
+      if (typeof verb !== 'string' || !(PLUGIN_TOKEN_VERBS as readonly string[]).includes(verb)) {
+        throw new AccessMutationError(
+          `plugin principal needs a verb: one of ${PLUGIN_TOKEN_VERBS.join(', ')}`,
+        );
+      }
+      principal = { kind: 'plugin', plugin: principalRaw.plugin, verb: verb as PluginTokenVerb };
     } else {
-      throw new AccessMutationError("principal.kind must be 'user', 'group', or 'role'");
+      throw new AccessMutationError("principal.kind must be 'user', 'group', 'plugin', or 'role'");
     }
     const targetKind = kind as TargetKind;
     const repoRelTarget = toRepoRelative(rawPath);
@@ -517,12 +566,12 @@ export function createAccessRoutes(
     // non-actionable. Built over the union of every principal in the four
     // eligible lists (kinded `principals`, with the name-only `roles` list as
     // the all-roles fallback).
-    const collectives = new Map<string, { name: string; kind: 'role' | 'group' }>();
+    const collectives = new Map<string, ResolvedPrincipal>();
     for (const list of [eligible, readers, owners, downloaders]) {
       const kinded =
         list.principals ?? list.roles.map((name) => ({ name, kind: 'role' as const }));
       for (const p of kinded) {
-        const key = `${p.kind === 'group' ? 'g' : 'r'}:${p.name.toLowerCase()}`;
+        const key = `${p.kind === 'group' ? 'g' : p.kind === 'plugin' ? 'p' : 'r'}:${p.name.toLowerCase()}`;
         if (!collectives.has(key)) collectives.set(key, p);
       }
     }
@@ -671,6 +720,20 @@ export function createAccessRoutes(
             `No group named "${principal.group}". Pick an existing group.`,
             404,
             { kind: 'unknown-group', group: principal.group },
+          );
+        }
+      } else if (principal.kind === 'plugin') {
+        // A plugin grant must name a plugin that EXISTS on the default branch
+        // (a folder carrying an access.md — the same set the suggest list
+        // offers). Matched on the manifest slug, the identity the token
+        // canonicalises to.
+        const { plugins } = await defaultBranchPrincipals();
+        const slug = pluginManifestName(principal.plugin);
+        if (!plugins.some((p) => pluginManifestName(p) === slug)) {
+          throw new AccessMutationError(
+            `No plugin named "${principal.plugin}". Pick an existing plugin.`,
+            404,
+            { kind: 'unknown-plugin', plugin: principal.plugin },
           );
         }
       }

--- a/packages/core-backend/src/modules/marketplace/__tests__/marketplace-git.test.ts
+++ b/packages/core-backend/src/modules/marketplace/__tests__/marketplace-git.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import express from 'express';
+import type { AuthUser } from '@bevel-software/platform-shared';
+
+import { MarketplaceRepoService, type MarketplaceCompiler } from '../marketplace-repo.service.js';
+import { createMarketplaceGitRoutes } from '../git-http.routes.js';
+import type { VirtualTree } from '../../plugins/compile/compile-marketplace.js';
+
+const execFileAsync = promisify(execFile);
+// No credential helper and no prompt: a 401 must FAIL the command, not open
+// the OS credential manager (which would hang the test on Windows). No
+// autocrlf either, so the bytes the server sent are the bytes we read back.
+const git = (args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) =>
+  execFileAsync('git', ['-c', 'credential.helper=', '-c', 'core.autocrlf=false', ...args], {
+    cwd: opts.cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: 'echo', ...opts.env },
+  });
+
+/**
+ * The marketplace as a git remote, driven the way a client drives it: real
+ * `git clone` and `git pull` over HTTP against the express router, with a
+ * stub compiler standing in for the knowledge base. What is under test is
+ * the namespace isolation, the fast-forward contract, the auth, and the
+ * read-only guarantee — not the compiler.
+ */
+
+const users: Record<string, AuthUser> = {
+  'bevel_alice': { id: 'user-alice', email: 'alice@x.io', name: 'Alice' } as AuthUser,
+  'bevel_bob': { id: 'user-bob', email: 'bob@x.io', name: 'Bob' } as AuthUser,
+};
+
+function tree(files: Record<string, string>, sourceCommit: string): VirtualTree & { sourceCommit: string } {
+  return {
+    files: new Map(Object.entries(files).map(([k, v]) => [k, Buffer.from(v)])),
+    warnings: [],
+    plugins: [],
+    sourceCommit,
+  };
+}
+
+describe('marketplace git endpoint', () => {
+  let root: string;
+  let repo: MarketplaceRepoService;
+  let server: http.Server;
+  let base: string;
+  /** What the "knowledge base" currently is, per user. */
+  let source = 'aaa111';
+  let trees: Record<string, Record<string, string>>;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-mp-'));
+    source = 'aaa111';
+    trees = {
+      'alice@x.io': { 'README.md': 'alice v1\n', 'plugins/gtm/skills/deploy/SKILL.md': '---\n---\nship\n' },
+      'bob@x.io': { 'README.md': 'bob v1\n' },
+    };
+    const compiler: MarketplaceCompiler = {
+      sourceCommit: async () => source,
+      compileFor: async ({ userEmail }) => tree(trees[userEmail] ?? {}, source),
+    };
+    repo = new MarketplaceRepoService(path.join(root, 'data', 'marketplace.git'), compiler);
+    const app = express();
+    app.use(
+      '/git',
+      createMarketplaceGitRoutes({
+        repo,
+        keys: {
+          looksLikeExternalApiKey: (t) => t.startsWith('bevel_'),
+          verifyAndLoadToken: async (t) => (users[t] ? { tokenId: `tok-${t}`, user: users[t] } : null),
+        },
+        mountPath: '/git',
+      }),
+    );
+    server = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    const { port } = server.address() as { port: number };
+    base = `http://127.0.0.1:${port}/git/marketplace.git`;
+  });
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const withKey = (key: string) => base.replace('http://', `http://key:${key}@`);
+  const clone = async (key: string, dir: string) => git(['clone', '--quiet', withKey(key), dir]);
+  const read = (dir: string, rel: string) => fs.readFile(path.join(dir, rel), 'utf-8');
+
+  it('clones each caller their own tree, and nothing of anyone else\'s', async () => {
+    const a = path.join(root, 'alice');
+    const b = path.join(root, 'bob');
+    await clone('bevel_alice', a);
+    await clone('bevel_bob', b);
+    expect(await read(a, 'README.md')).toBe('alice v1\n');
+    expect(await read(a, 'plugins/gtm/skills/deploy/SKILL.md')).toContain('ship');
+    expect(await read(b, 'README.md')).toBe('bob v1\n');
+    await expect(read(b, 'plugins/gtm/skills/deploy/SKILL.md')).rejects.toThrow();
+    // One object store underneath: both namespaces live in the same bare repo.
+    const { stdout } = await git(['-C', repo.repoDir, 'for-each-ref', '--format=%(refname)', 'refs/namespaces/']);
+    // Each namespace carries a HEAD symref beside its branch; the branches are the point.
+    expect(stdout.split('\n').filter((r) => r.endsWith('/refs/heads/main')).sort()).toEqual([
+      'refs/namespaces/u-user-alice/refs/heads/main',
+      'refs/namespaces/u-user-bob/refs/heads/main',
+    ]);
+  });
+
+  it('pulls fast-forward after the knowledge base moves, and does not recompile when it has not', async () => {
+    const a = path.join(root, 'alice');
+    await clone('bevel_alice', a);
+    const first = (await git(['-C', a, 'rev-parse', 'HEAD'])).stdout.trim();
+
+    // Same source: a pull is a no-op with the same head.
+    expect((await repo.ensureCompiled({ id: 'user-alice', email: 'alice@x.io' })).compiled).toBe(false);
+    await git(['-C', a, 'pull', '--quiet', '--ff-only']);
+    expect((await git(['-C', a, 'rev-parse', 'HEAD'])).stdout.trim()).toBe(first);
+
+    // The KB moves and access is withdrawn from the skill: one new commit,
+    // the file is gone, and the pull is still a fast-forward.
+    source = 'bbb222';
+    trees['alice@x.io'] = { 'README.md': 'alice v2\n' };
+    await git(['-C', a, 'pull', '--quiet', '--ff-only']);
+    expect(await read(a, 'README.md')).toBe('alice v2\n');
+    await expect(read(a, 'plugins/gtm/skills/deploy/SKILL.md')).rejects.toThrow();
+    const log = (await git(['-C', a, 'log', '--format=%s'])).stdout.trim().split('\n');
+    expect(log).toEqual(['Compile marketplace from bbb222', 'Compile marketplace from aaa111']);
+  });
+
+  it('a moved source with an identical tree writes no new commit', async () => {
+    const a = path.join(root, 'alice');
+    await clone('bevel_alice', a);
+    source = 'ccc333';
+    const r = await repo.ensureCompiled({ id: 'user-alice', email: 'alice@x.io' });
+    expect(r.compiled).toBe(false);
+    await git(['-C', a, 'pull', '--quiet', '--ff-only']);
+    expect((await git(['-C', a, 'log', '--format=%s'])).stdout.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('refuses a missing or unknown key with a Basic challenge, and refuses pushes', { timeout: 60_000 }, async () => {
+    await expect(git(['clone', '--quiet', base, path.join(root, 'anon')])).rejects.toThrow();
+    await expect(git(['clone', '--quiet', withKey('bevel_nobody'), path.join(root, 'bad')])).rejects.toThrow();
+    const res = await fetch(`${base}/info/refs?service=git-upload-pack`);
+    expect(res.status).toBe(401);
+    expect(res.headers.get('www-authenticate')).toContain('Basic');
+
+    const a = path.join(root, 'alice');
+    await clone('bevel_alice', a);
+    await fs.writeFile(path.join(a, 'evil.md'), 'no');
+    await git(['-C', a, 'add', 'evil.md']);
+    await git(['-C', a, 'commit', '--quiet', '-m', 'push attempt'], {
+      env: { GIT_AUTHOR_NAME: 'x', GIT_AUTHOR_EMAIL: 'x@x', GIT_COMMITTER_NAME: 'x', GIT_COMMITTER_EMAIL: 'x@x' },
+    });
+    await expect(git(['-C', a, 'push', '--quiet', 'origin', 'HEAD:main'])).rejects.toThrow();
+    const push = await fetch(`${base}/info/refs?service=git-receive-pack`, {
+      headers: { authorization: `Basic ${Buffer.from('key:bevel_alice').toString('base64')}` },
+    });
+    expect(push.status).toBe(403);
+  });
+});

--- a/packages/core-backend/src/modules/marketplace/git-http.routes.ts
+++ b/packages/core-backend/src/modules/marketplace/git-http.routes.ts
@@ -1,0 +1,185 @@
+import express from 'express';
+import { spawn } from 'node:child_process';
+import type { AuthUser } from '@bevel-software/platform-shared';
+import type { MarketplaceRepoService } from './marketplace-repo.service.js';
+import '../tool-auth/external-api-key.interface.js'; // Express Request augmentation (req.externalApiKeyId)
+
+/** How a bearer string resolves to a user — the connection-key service's shape. */
+export interface MarketplaceKeyResolver {
+  looksLikeExternalApiKey(token: string): boolean;
+  verifyAndLoadToken(plaintext: string): Promise<{ tokenId: string; user: AuthUser } | null>;
+}
+
+/**
+ * The per-user marketplace as a git remote:
+ *
+ *   git clone https://key:<connection-key>@<host>/git/marketplace.git
+ *
+ * Anything that speaks git's smart HTTP protocol — Claude Code, Codex, `npx
+ * skills`, plain git — clones a repository whose `main` is the caller's
+ * compiled tree. The route authenticates, brings the caller's namespace up to
+ * date (`MarketplaceRepoService.ensureCompiled`), and hands the request to
+ * `git http-backend` with `GIT_NAMESPACE` set, so git itself serves the
+ * protocol and only that namespace's refs exist as far as the client can tell.
+ *
+ * AUTH: HTTP Basic with the connection key as the password (the username is
+ * anything — git sends whatever the URL carried), or the key as a Bearer
+ * token. The same keys the MCP endpoint takes, the same service resolving
+ * them, and the same metering stamp (`req.externalApiKeyId`), so a key's
+ * `lastUsedAt` moves when an agent refreshes its plugins. A 401 challenges
+ * with Basic so a client without credentials prompts for them.
+ *
+ * READ-ONLY: the receive-pack service is refused here by name, and the bare
+ * repository pins `http.receivepack=false` for good measure — a push would
+ * otherwise be enabled by http-backend the moment REMOTE_USER is set.
+ */
+export function createMarketplaceGitRoutes(deps: {
+  repo: MarketplaceRepoService;
+  keys: MarketplaceKeyResolver;
+  /** The URL path the router is mounted at, e.g. `/git`. Used for PATH_INFO. */
+  mountPath: string;
+}): express.Router {
+  const { repo, keys, mountPath } = deps;
+  const router = express.Router();
+  const repoRoute = `/${repo.repoName}`;
+
+  const challenge = (res: express.Response, message: string) => {
+    res.setHeader('WWW-Authenticate', 'Basic realm="hexis-marketplace"');
+    res.status(401).type('text/plain').send(message);
+  };
+
+  /** The connection key out of Basic (`user:key`, `key:` or `:key`) or Bearer. */
+  const keyOf = (header: string | undefined): string | null => {
+    if (!header) return null;
+    const space = header.indexOf(' ');
+    if (space < 0) return null;
+    const scheme = header.slice(0, space).toLowerCase();
+    const value = header.slice(space + 1).trim();
+    if (scheme === 'bearer') return value || null;
+    if (scheme !== 'basic') return null;
+    let decoded: string;
+    try {
+      decoded = Buffer.from(value, 'base64').toString('utf-8');
+    } catch {
+      return null;
+    }
+    const colon = decoded.indexOf(':');
+    const user = colon < 0 ? decoded : decoded.slice(0, colon);
+    const pass = colon < 0 ? '' : decoded.slice(colon + 1);
+    // Either half may carry the key: `https://key:<k>@` puts it in the
+    // password, `https://<k>@` in the username.
+    if (pass && keys.looksLikeExternalApiKey(pass)) return pass;
+    if (user && keys.looksLikeExternalApiKey(user)) return user;
+    return pass || user || null;
+  };
+
+  router.all(`${repoRoute}{/*rest}`, async (req, res) => {
+    const service = String(req.query.service ?? '');
+    const rest = `/${([] as string[]).concat((req.params as { rest?: string | string[] }).rest ?? []).join('/')}`;
+    // Refuse writes before touching anything — by service name on info/refs,
+    // and by endpoint on the POST.
+    if (service === 'git-receive-pack' || rest === '/git-receive-pack') {
+      res.status(403).type('text/plain').send('This repository is read-only.');
+      return;
+    }
+
+    const key = keyOf(req.headers.authorization);
+    if (!key || !keys.looksLikeExternalApiKey(key)) {
+      challenge(res, 'A connection key is required: https://key:<connection-key>@<host>/git/marketplace.git');
+      return;
+    }
+    let resolved: { tokenId: string; user: AuthUser } | null;
+    try {
+      resolved = await keys.verifyAndLoadToken(key);
+    } catch (err) {
+      console.error('[marketplace] connection-key verification failed:', err);
+      res.status(500).type('text/plain').send('Authentication backend unavailable');
+      return;
+    }
+    if (!resolved) {
+      challenge(res, 'Invalid or revoked connection key');
+      return;
+    }
+    req.userId = resolved.user.id;
+    req.userEmail = resolved.user.email;
+    req.externalApiKeyId = resolved.tokenId;
+
+    let ensured: { namespace: string };
+    try {
+      ensured = await repo.ensureCompiled({ id: resolved.user.id, email: resolved.user.email });
+    } catch (err) {
+      console.error('[marketplace] compile failed:', err);
+      res.status(500).type('text/plain').send('Could not prepare your marketplace');
+      return;
+    }
+
+    // CGI, as git documents it. PATH_INFO is the path below GIT_PROJECT_ROOT
+    // — `/marketplace.git/info/refs` — regardless of where we are mounted.
+    const query = req.url.includes('?') ? req.url.slice(req.url.indexOf('?') + 1) : '';
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_PROJECT_ROOT: repo.projectRoot,
+      GIT_HTTP_EXPORT_ALL: '1',
+      GIT_NAMESPACE: ensured.namespace,
+      PATH_INFO: `${repoRoute}${rest}`,
+      REQUEST_METHOD: req.method,
+      QUERY_STRING: query,
+      CONTENT_TYPE: req.headers['content-type'] ?? '',
+      REMOTE_USER: resolved.user.email,
+      REMOTE_ADDR: req.ip ?? '',
+      SERVER_PROTOCOL: 'HTTP/1.1',
+      HTTP_HOST: req.headers.host ?? '',
+      SCRIPT_NAME: mountPath,
+    };
+    if (req.headers['content-length']) env.CONTENT_LENGTH = String(req.headers['content-length']);
+    if (req.headers['content-encoding']) env.HTTP_CONTENT_ENCODING = String(req.headers['content-encoding']);
+    if (req.headers['git-protocol']) env.HTTP_GIT_PROTOCOL = String(req.headers['git-protocol']);
+
+    const child = spawn('git', ['http-backend'], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+    child.stderr.on('data', (chunk: Buffer) => console.warn(`[marketplace] http-backend: ${chunk.toString('utf-8').trim()}`));
+    child.on('error', (err) => {
+      console.error('[marketplace] could not run git http-backend:', err);
+      if (!res.headersSent) res.status(500).type('text/plain').send('git is unavailable');
+    });
+    req.pipe(child.stdin);
+    req.on('aborted', () => child.kill());
+
+    // Parse the CGI header block (`Status:`, `Content-Type:`, …) off stdout,
+    // then stream the body straight through.
+    let headerBuf = Buffer.alloc(0);
+    let headersDone = false;
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (headersDone) {
+        res.write(chunk);
+        return;
+      }
+      headerBuf = Buffer.concat([headerBuf, chunk]);
+      const cut = headerBuf.indexOf('\r\n\r\n') >= 0 ? headerBuf.indexOf('\r\n\r\n') : headerBuf.indexOf('\n\n');
+      if (cut < 0) return;
+      const sepLen = headerBuf.indexOf('\r\n\r\n') >= 0 ? 4 : 2;
+      const head = headerBuf.subarray(0, cut).toString('utf-8');
+      let status = 200;
+      for (const line of head.split(/\r?\n/)) {
+        const colon = line.indexOf(':');
+        if (colon < 0) continue;
+        const name = line.slice(0, colon).trim();
+        const value = line.slice(colon + 1).trim();
+        if (name.toLowerCase() === 'status') status = Number.parseInt(value, 10) || 200;
+        else res.setHeader(name, value);
+      }
+      res.status(status);
+      headersDone = true;
+      const body = headerBuf.subarray(cut + sepLen);
+      if (body.length > 0) res.write(body);
+    });
+    child.stdout.on('end', () => {
+      if (!headersDone) {
+        if (!res.headersSent) res.status(502).type('text/plain').send('git http-backend produced no response');
+        return;
+      }
+      res.end();
+    });
+  });
+
+  return router;
+}

--- a/packages/core-backend/src/modules/marketplace/git-http.routes.ts
+++ b/packages/core-backend/src/modules/marketplace/git-http.routes.ts
@@ -148,13 +148,17 @@ export function createMarketplaceGitRoutes(deps: {
     // then stream the body straight through.
     let headerBuf = Buffer.alloc(0);
     let headersDone = false;
+    // Backpressure: a slow client must not make Node buffer a whole pack. One
+    // path for every body write, the remainder of the header chunk included.
+    const writeBody = (bytes: Buffer) => {
+      if (!res.write(bytes)) {
+        child.stdout.pause();
+        res.once('drain', () => child.stdout.resume());
+      }
+    };
     child.stdout.on('data', (chunk: Buffer) => {
       if (headersDone) {
-        // Backpressure: a slow client must not make Node buffer a whole pack.
-        if (!res.write(chunk)) {
-          child.stdout.pause();
-          res.once('drain', () => child.stdout.resume());
-        }
+        writeBody(chunk);
         return;
       }
       headerBuf = Buffer.concat([headerBuf, chunk]);
@@ -174,7 +178,7 @@ export function createMarketplaceGitRoutes(deps: {
       res.status(status);
       headersDone = true;
       const body = headerBuf.subarray(cut + sepLen);
-      if (body.length > 0) res.write(body);
+      if (body.length > 0) writeBody(body);
     });
     child.stdout.on('end', () => {
       if (!headersDone) {

--- a/packages/core-backend/src/modules/marketplace/git-http.routes.ts
+++ b/packages/core-backend/src/modules/marketplace/git-http.routes.ts
@@ -150,7 +150,11 @@ export function createMarketplaceGitRoutes(deps: {
     let headersDone = false;
     child.stdout.on('data', (chunk: Buffer) => {
       if (headersDone) {
-        res.write(chunk);
+        // Backpressure: a slow client must not make Node buffer a whole pack.
+        if (!res.write(chunk)) {
+          child.stdout.pause();
+          res.once('drain', () => child.stdout.resume());
+        }
         return;
       }
       headerBuf = Buffer.concat([headerBuf, chunk]);

--- a/packages/core-backend/src/modules/marketplace/index.ts
+++ b/packages/core-backend/src/modules/marketplace/index.ts
@@ -1,0 +1,2 @@
+export { MarketplaceRepoService, type MarketplaceCompiler, type EnsureResult } from './marketplace-repo.service.js';
+export { createMarketplaceGitRoutes, type MarketplaceKeyResolver } from './git-http.routes.js';

--- a/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
+++ b/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
@@ -107,15 +107,26 @@ export class MarketplaceRepoService {
     await this.ensureRepo();
     const namespace = MarketplaceRepoService.namespaceFor(user.id);
     return this.locks.run(`ns:${namespace}`, async () => {
-      const current = await this.compiler.sourceCommit();
       const last = await this.readSidecar(namespace);
       const head = await this.headOf(namespace);
+      let current = await this.compiler.sourceCommit();
       if (last === current && head !== null) return { namespace, compiled: false, sourceCommit: current };
 
       // The commit just read is the one the tree is stamped with: a second
       // read that failed would otherwise record a placeholder as the compiled
-      // source and make every later fetch recompile.
-      const tree = await this.compiler.compileFor({ userEmail: user.email }, current);
+      // source and make every later fetch recompile. And the checkout can
+      // move WHILE we compile from it (a merge landing mid-read), so the
+      // commit is re-read afterwards: a tree stamped with a commit it was
+      // not compiled from would freeze that caller on a stale tree until the
+      // next change. Bounded — a checkout that moves on every attempt is
+      // served the latest attempt rather than never.
+      let tree = await this.compiler.compileFor({ userEmail: user.email }, current);
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const after = await this.compiler.sourceCommit();
+        if (after === current) break;
+        current = after;
+        tree = await this.compiler.compileFor({ userEmail: user.email }, current);
+      }
       const sha = await this.commitTree(namespace, tree, head);
       await this.writeSidecar(namespace, tree.sourceCommit);
       return { namespace, compiled: sha !== head, sourceCommit: tree.sourceCommit };

--- a/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
+++ b/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
@@ -138,7 +138,13 @@ export class MarketplaceRepoService {
     const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hexis-marketplace-'));
     try {
       for (const [rel, bytes] of tree.files) {
-        const abs = path.join(scratch, rel);
+        // The compiler sanitises every segment it invents, but the tree is
+        // built from repository content, so the sink checks containment
+        // itself: nothing is written outside the scratch directory.
+        const abs = path.resolve(scratch, rel);
+        if (!abs.startsWith(scratch + path.sep)) {
+          throw new Error(`refusing to materialise "${rel}": escapes the scratch tree`);
+        }
         await fs.mkdir(path.dirname(abs), { recursive: true });
         await fs.writeFile(abs, bytes);
       }

--- a/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
+++ b/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
@@ -11,7 +11,11 @@ const execFileAsync = promisify(execFile);
 /** What the repo service asks the compiler for — the one seam it has. */
 export interface MarketplaceCompiler {
   sourceCommit(): Promise<string>;
-  compileFor(audience: { userEmail: string }): Promise<VirtualTree & { sourceCommit: string }>;
+  compileFor(
+    audience: { userEmail: string },
+    /** The commit the tree is compiled from, when the caller already read it. */
+    sourceCommit?: string,
+  ): Promise<VirtualTree & { sourceCommit: string }>;
 }
 
 export interface EnsureResult {
@@ -84,7 +88,13 @@ export class MarketplaceRepoService {
       await this.git(['-C', this.repoDir, 'config', 'http.receivepack', 'false']);
       await this.git(['-C', this.repoDir, 'config', 'http.uploadpack', 'true']);
       await fs.mkdir(this.sidecarDir(), { recursive: true });
-    })();
+    })().catch((err: unknown) => {
+      // A failed initialisation is retried by the next request, not
+      // remembered until restart: a volume that was briefly unavailable must
+      // not turn every later fetch into a 500.
+      this.initialised = null;
+      throw err;
+    });
     await this.initialised;
   }
 
@@ -102,7 +112,10 @@ export class MarketplaceRepoService {
       const head = await this.headOf(namespace);
       if (last === current && head !== null) return { namespace, compiled: false, sourceCommit: current };
 
-      const tree = await this.compiler.compileFor({ userEmail: user.email });
+      // The commit just read is the one the tree is stamped with: a second
+      // read that failed would otherwise record a placeholder as the compiled
+      // source and make every later fetch recompile.
+      const tree = await this.compiler.compileFor({ userEmail: user.email }, current);
       const sha = await this.commitTree(namespace, tree, head);
       await this.writeSidecar(namespace, tree.sourceCommit);
       return { namespace, compiled: sha !== head, sourceCommit: tree.sourceCommit };
@@ -136,6 +149,10 @@ export class MarketplaceRepoService {
     parent: string | null,
   ): Promise<string> {
     const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hexis-marketplace-'));
+    // The throwaway index lives BESIDE the scratch worktree, never inside it:
+    // `git add -A` would otherwise stage the index (and its lock) into every
+    // compiled tree.
+    const indexDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hexis-marketplace-index-'));
     try {
       for (const [rel, bytes] of tree.files) {
         // The compiler sanitises every segment it invents, but the tree is
@@ -148,7 +165,7 @@ export class MarketplaceRepoService {
         await fs.mkdir(path.dirname(abs), { recursive: true });
         await fs.writeFile(abs, bytes);
       }
-      const index = path.join(scratch, '.hexis-index');
+      const index = path.join(indexDir, 'index');
       const env = { ...process.env, GIT_INDEX_FILE: index, GIT_DIR: this.repoDir, GIT_WORK_TREE: scratch };
       await this.git(['add', '-A', '--', '.'], { cwd: scratch, env });
       const treeSha = (await this.git(['write-tree'], { env })).stdout.trim();
@@ -171,6 +188,7 @@ export class MarketplaceRepoService {
       return sha;
     } finally {
       await fs.rm(scratch, { recursive: true, force: true });
+      await fs.rm(indexDir, { recursive: true, force: true });
     }
   }
 

--- a/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
+++ b/packages/core-backend/src/modules/marketplace/marketplace-repo.service.ts
@@ -1,0 +1,190 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { WorkspaceMutex } from '../kb-fs/mutex.js';
+import type { VirtualTree } from '../plugins/compile/compile-marketplace.js';
+
+const execFileAsync = promisify(execFile);
+
+/** What the repo service asks the compiler for — the one seam it has. */
+export interface MarketplaceCompiler {
+  sourceCommit(): Promise<string>;
+  compileFor(audience: { userEmail: string }): Promise<VirtualTree & { sourceCommit: string }>;
+}
+
+export interface EnsureResult {
+  /** The git namespace the caller's tree lives in. */
+  namespace: string;
+  /** True when a new commit was written this call. */
+  compiled: boolean;
+  sourceCommit: string;
+}
+
+/**
+ * ONE bare repository, ONE git namespace per caller.
+ *
+ * Every person's compiled marketplace is a branch in its own namespace
+ * (`refs/namespaces/<ns>/refs/heads/main`), which is exactly what git
+ * namespaces exist for (gitnamespaces(7)): `git http-backend` run with
+ * `GIT_NAMESPACE=<ns>` advertises only that namespace's refs, so a clone sees
+ * a repository whose `main` is their tree and nothing else — while every
+ * identical skill across callers is one blob in one object store.
+ *
+ * Freshness is LAZY and keyed on the knowledge base's default-branch commit:
+ * every input to a compile (skills, manifests, access rules, roles, groups)
+ * lives in that repository, so "same source commit" means "same answer".
+ * The last compiled source per namespace sits in a sidecar file rather than
+ * a commit trailer, so an unchanged tree costs no commit and no re-check.
+ *
+ * Each recompile appends a commit whose parent is the namespace's current
+ * head, so a client's `git pull` is always a fast-forward — including when
+ * access was withdrawn and files vanish. Writes go through git plumbing
+ * against a temporary index: no working tree of the bare repo, no checkout.
+ *
+ * Read-only by construction: `http.receivepack` is pinned off (http-backend
+ * would otherwise enable pushes for an authenticated REMOTE_USER), and the
+ * route refuses the receive-pack service before git ever sees it.
+ */
+export class MarketplaceRepoService {
+  private readonly locks = new WorkspaceMutex();
+  private initialised: Promise<void> | null = null;
+
+  constructor(
+    /** Absolute path of the bare repository (created on first use). */
+    readonly repoDir: string,
+    private readonly compiler: MarketplaceCompiler,
+    private readonly committer: { name: string; email: string } = {
+      name: 'Hexis',
+      email: 'hexis@localhost',
+    },
+  ) {}
+
+  /** The directory `GIT_PROJECT_ROOT` points at, and the repo's name under it. */
+  get projectRoot(): string {
+    return path.dirname(this.repoDir);
+  }
+  get repoName(): string {
+    return path.basename(this.repoDir);
+  }
+
+  /** The namespace for a user id — one path segment, stable, opaque. */
+  static namespaceFor(userId: string): string {
+    return `u-${userId.replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 120)}`;
+  }
+
+  async ensureRepo(): Promise<void> {
+    this.initialised ??= (async () => {
+      await fs.mkdir(this.projectRoot, { recursive: true });
+      const isRepo = await fs
+        .access(path.join(this.repoDir, 'HEAD'))
+        .then(() => true, () => false);
+      if (!isRepo) await this.git(['init', '--bare', '--quiet', this.repoDir]);
+      await this.git(['-C', this.repoDir, 'config', 'http.receivepack', 'false']);
+      await this.git(['-C', this.repoDir, 'config', 'http.uploadpack', 'true']);
+      await fs.mkdir(this.sidecarDir(), { recursive: true });
+    })();
+    await this.initialised;
+  }
+
+  /**
+   * Bring the caller's namespace up to the knowledge base's current commit,
+   * compiling only when it moved. Serialised per namespace: two fetches
+   * arriving together compile once.
+   */
+  async ensureCompiled(user: { id: string; email: string }): Promise<EnsureResult> {
+    await this.ensureRepo();
+    const namespace = MarketplaceRepoService.namespaceFor(user.id);
+    return this.locks.run(`ns:${namespace}`, async () => {
+      const current = await this.compiler.sourceCommit();
+      const last = await this.readSidecar(namespace);
+      const head = await this.headOf(namespace);
+      if (last === current && head !== null) return { namespace, compiled: false, sourceCommit: current };
+
+      const tree = await this.compiler.compileFor({ userEmail: user.email });
+      const sha = await this.commitTree(namespace, tree, head);
+      await this.writeSidecar(namespace, tree.sourceCommit);
+      return { namespace, compiled: sha !== head, sourceCommit: tree.sourceCommit };
+    });
+  }
+
+  // --- internal --------------------------------------------------------------
+
+  private refOf(namespace: string): string {
+    return `refs/namespaces/${namespace}/refs/heads/main`;
+  }
+
+  private async headOf(namespace: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.git(['-C', this.repoDir, 'rev-parse', '--verify', '--quiet', this.refOf(namespace)]);
+      return stdout.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Write `tree` as a commit on the namespace's branch. Materialises the
+   * virtual tree into a scratch directory, stages it into a throwaway index
+   * against the bare object store, and commits — no working tree involved.
+   * When the tree hash equals the head's, nothing is committed.
+   */
+  private async commitTree(
+    namespace: string,
+    tree: VirtualTree & { sourceCommit: string },
+    parent: string | null,
+  ): Promise<string> {
+    const scratch = await fs.mkdtemp(path.join(os.tmpdir(), 'hexis-marketplace-'));
+    try {
+      for (const [rel, bytes] of tree.files) {
+        const abs = path.join(scratch, rel);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, bytes);
+      }
+      const index = path.join(scratch, '.hexis-index');
+      const env = { ...process.env, GIT_INDEX_FILE: index, GIT_DIR: this.repoDir, GIT_WORK_TREE: scratch };
+      await this.git(['add', '-A', '--', '.'], { cwd: scratch, env });
+      const treeSha = (await this.git(['write-tree'], { env })).stdout.trim();
+      if (parent) {
+        const parentTree = (await this.git(['-C', this.repoDir, 'rev-parse', `${parent}^{tree}`])).stdout.trim();
+        if (parentTree === treeSha) return parent;
+      }
+      const message = `Compile marketplace from ${tree.sourceCommit}\n\nHexis-Source-Commit: ${tree.sourceCommit}\n`;
+      const commitEnv = {
+        ...process.env,
+        GIT_AUTHOR_NAME: this.committer.name,
+        GIT_AUTHOR_EMAIL: this.committer.email,
+        GIT_COMMITTER_NAME: this.committer.name,
+        GIT_COMMITTER_EMAIL: this.committer.email,
+      };
+      const args = ['-C', this.repoDir, 'commit-tree', treeSha, '-m', message, ...(parent ? ['-p', parent] : [])];
+      const sha = (await this.git(args, { env: commitEnv })).stdout.trim();
+      await this.git(['-C', this.repoDir, 'update-ref', this.refOf(namespace), sha, ...(parent ? [parent] : [])]);
+      await this.git(['-C', this.repoDir, 'symbolic-ref', `refs/namespaces/${namespace}/HEAD`, this.refOf(namespace)]);
+      return sha;
+    } finally {
+      await fs.rm(scratch, { recursive: true, force: true });
+    }
+  }
+
+  private sidecarDir(): string {
+    return path.join(this.repoDir, 'hexis-namespaces');
+  }
+
+  private async readSidecar(namespace: string): Promise<string | null> {
+    try {
+      return (await fs.readFile(path.join(this.sidecarDir(), `${namespace}.json`), 'utf-8')).trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeSidecar(namespace: string, sourceCommit: string): Promise<void> {
+    await fs.writeFile(path.join(this.sidecarDir(), `${namespace}.json`), sourceCommit);
+  }
+
+  private git(args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
+    return execFileAsync('git', args, { cwd: opts.cwd, env: opts.env ?? process.env, maxBuffer: 64 * 1024 * 1024 });
+  }
+}

--- a/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DEFAULT_BRANCH, DEFAULT_KB_LAYOUT, configureKbLayout } from '@bevel-software/platform-shared';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../../access/access-control.service.js';
+import { SkillService } from '../../skills/skills.service.js';
+import { ToolManualService } from '../../tool-manuals/tool-manuals.service.js';
+import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
+import { PluginIndexService } from '../plugins.service.js';
+import { PluginLinkIndex } from '../plugin-links.js';
+import { PluginLinksService } from '../plugin-links.service.js';
+import { BundlePluginSource } from '../discovery/bundle-dialect/bundle.source.js';
+import { MarketplaceCompilerService } from '../compile/marketplace-compiler.service.js';
+
+/**
+ * A customer's repository, read as-is: lowercase `skills/` and `plugins/`
+ * roots, bundles at the depths their org uses, a registry with a profile
+ * chain, and a committed `dist/` beside the source. Every consumer — catalog,
+ * plugin index, link index, tool manuals, compiler — must read the SOURCE
+ * trees and agree on what a plugin holds, with nothing written back.
+ */
+
+const KB_DIR = 'knowledge-base';
+const wsId = workspaceIdForBranch(DEFAULT_BRANCH);
+
+describe('bundle dialect, end to end', () => {
+  let root: string;
+  let repo: string;
+  let access: AccessControlService;
+  let skills: SkillService;
+  let tools: ToolManualService;
+  let links: PluginLinkIndex;
+  let index: PluginIndexService;
+  let compiler: MarketplaceCompilerService;
+  let linkService: PluginLinksService;
+
+  const write = async (rel: string, text: string) => {
+    const abs = path.join(repo, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, text);
+  };
+
+  beforeEach(async () => {
+    configureKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-dialect-'));
+    repo = path.join(root, wsId, KB_DIR);
+    const workspaceService = {
+      getOrCreateForBranch: async () => ({ id: wsId }),
+      getWorkspacePath: async (id: string) => path.join(root, id),
+      readFile: async (id: string, rel: string) => fs.readFile(path.join(root, id, rel), 'utf-8'),
+      ensureRemotesFetched: async () => undefined,
+    } as unknown as WorkspaceService;
+
+    await write('roles.yaml', 'roles:\n  Admin:\n    - admin@x.io\n');
+    // Their scopes decide readability; everything here is open to signed-in people.
+    await write('access.md', '---\nwrite:\n  - Admin\n---\nread:\n  - everyone\n');
+    await write(
+      'configs/mcp/registry.json',
+      JSON.stringify({
+        servers: [
+          { id: 'jira', config: { command: 'npx', args: ['-y', 'jira-mcp'] } },
+          { id: 'confluence', config: { type: 'http', url: 'https://mcp.confluence.example' } },
+        ],
+        profiles: [{ id: 'base', servers: ['jira'] }, { id: 'global', servers: ['confluence'], extends: 'base' }],
+      }),
+    );
+    // Skills at their four depths; a build output that must be ignored.
+    await write('skills/functional/cluster-a/one-skill/SKILL.md', '---\nname: one-skill\ndescription: One.\nmetadata:\n  version: "1.4.0"\n  author: "acme"\n---\n');
+    await write('skills/departments/business/finance/close-books/SKILL.md', '---\ndescription: Close.\n---\n');
+    await write('skills/departments/engineering/shared/cluster-a/deploy/SKILL.md', '---\ndescription: Deploy.\n---\n');
+    await write('skills/departments/engineering/shared/cluster-a/rollback/SKILL.md', '---\ndescription: Undo.\n---\n');
+    await write('skills/departments/engineering/team-x/team-only/SKILL.md', '---\ndescription: Ours.\n---\n');
+    await write('dist/docs/plugins/functional/example/skills/deploy/SKILL.md', '---\ndescription: compiled copy\n---\n');
+    // Plugins: one links a cluster + a single skill; one links a department.
+    await write(
+      'plugins/functional/cluster-a/example-plugin/plugin.bundle.json',
+      JSON.stringify({
+        name: 'example-plugin',
+        version: '1.3.1',
+        description: 'Example',
+        mcpProfile: 'global',
+        interface: { displayName: 'Example Plugin' },
+        sourceSkillRoots: ['skills/departments/engineering/shared/cluster-a', 'skills/functional/cluster-a/one-skill'],
+      }),
+    );
+    await write(
+      'plugins/departments/business/finance/finance-kit/plugin.bundle.json',
+      JSON.stringify({ name: 'finance-kit', sourceSkillRoots: ['skills/departments/business/finance'] }),
+    );
+
+    const source = new BundlePluginSource();
+    access = new AccessControlService(workspaceService, KB_DIR);
+    skills = new SkillService(workspaceService, access, KB_DIR);
+    tools = new ToolManualService(workspaceService, access, KB_DIR, Date.now, source);
+    links = new PluginLinkIndex(workspaceService, skills, access, KB_DIR, Date.now, source);
+    index = new PluginIndexService(workspaceService, access, skills, tools, KB_DIR, Date.now, links, source);
+    compiler = new MarketplaceCompilerService(workspaceService, access, skills, links, KB_DIR, { name: 'acme', owner: 'Acme' }, source);
+    linkService = new PluginLinksService(workspaceService, { runPendingCommit: async () => undefined }, access, skills, links, KB_DIR);
+  });
+  afterEach(async () => {
+    configureKbLayout({ ...DEFAULT_KB_LAYOUT });
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('reads the source trees: skills at any depth, plugins as skill lists, servers from the registry', async () => {
+    const catalog = await skills.listSkills();
+    expect(catalog.map((s) => s.name).sort()).toEqual(['close-books', 'deploy', 'one-skill', 'rollback', 'team-only']);
+    expect(catalog.find((s) => s.name === 'one-skill')?.version).toBe('1.4.0');
+    expect(catalog.some((s) => s.path.startsWith('dist/'))).toBe(false);
+
+    const membership = await links.membership();
+    expect(membership.byPlugin.get('example-plugin')?.linkedSkills.sort()).toEqual([
+      'skills/departments/engineering/shared/cluster-a/deploy',
+      'skills/departments/engineering/shared/cluster-a/rollback',
+      'skills/functional/cluster-a/one-skill',
+    ]);
+    expect(membership.byPlugin.get('example-plugin')?.linksAreManaged).toBe(false);
+    expect(membership.bySkill.get('skills/departments/business/finance/close-books')).toEqual([
+      { name: 'finance-kit', linked: true, granted: true },
+    ]);
+    // A standalone skill is in no plugin, and that is a normal state.
+    expect(membership.bySkill.get('skills/departments/engineering/team-x/team-only')).toBeUndefined();
+
+    const plugins = await index.catalog();
+    expect(plugins.map((p) => [p.name, p.skillCount, p.toolCount])).toEqual([
+      ['example-plugin', 3, 2],
+      ['finance-kit', 1, 0],
+    ]);
+    expect(plugins[0].folders).toEqual(['plugins/functional/cluster-a/example-plugin']);
+
+    const manuals = await tools.listAllSummaries();
+    expect(manuals.map((m) => m.name).sort()).toEqual(['confluence', 'jira']);
+  });
+
+  it('compiles a marketplace from the source trees, per caller', async () => {
+    const tree = await compiler.compileFor({ userEmail: 'someone@x.io' });
+    const paths = [...tree.files.keys()];
+    expect(paths).toContain('plugins/example-plugin/skills/deploy/SKILL.md');
+    expect(paths).toContain('plugins/example-plugin/skills/one-skill/SKILL.md');
+    expect(paths).toContain('plugins/finance-kit/skills/close-books/SKILL.md');
+    expect(paths).toContain('plugins/skills-departments/skills/team-only/SKILL.md');
+    const manifest = JSON.parse(tree.files.get('plugins/example-plugin/plugin.json')!.toString());
+    expect(manifest).toMatchObject({ name: 'example-plugin', version: '1.3.1', description: 'Example' });
+    const mcp = JSON.parse(tree.files.get('plugins/example-plugin/.mcp.json')!.toString());
+    expect(Object.keys(mcp.mcpServers).sort()).toEqual(['confluence', 'jira']);
+    expect(paths.some((p) => p.includes('dist/'))).toBe(false);
+  });
+
+  it('never writes into the dialect: linking through hexis is refused as read-only', async () => {
+    const user = { id: 'u1', email: 'admin@x.io', name: 'Admin' };
+    await expect(linkService.link(user, 'example-plugin', 'skills/departments/engineering/team-x/team-only')).rejects.toMatchObject({
+      status: 409,
+      payload: { kind: 'read-only-links' },
+    });
+    const before = await fs.readFile(path.join(repo, 'plugins/functional/cluster-a/example-plugin/plugin.bundle.json'), 'utf-8');
+    expect(JSON.parse(before).sourceSkillRoots).toHaveLength(2);
+  });
+});

--- a/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
@@ -12,7 +12,7 @@ import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
 import { PluginIndexService } from '../plugins.service.js';
 import { PluginLinkIndex } from '../plugin-links.js';
 import { PluginLinksService } from '../plugin-links.service.js';
-import { BundlePluginSource } from '../discovery/bundle-dialect/bundle.source.js';
+import { KbPluginSource } from '../discovery/kb-plugin-source.js';
 import { MarketplaceCompilerService } from '../compile/marketplace-compiler.service.js';
 
 /**
@@ -91,7 +91,7 @@ describe('bundle dialect, end to end', () => {
       JSON.stringify({ name: 'finance-kit', sourceSkillRoots: ['skills/departments/business/finance'] }),
     );
 
-    const source = new BundlePluginSource();
+    const source = new KbPluginSource();
     access = new AccessControlService(workspaceService, KB_DIR);
     skills = new SkillService(workspaceService, access, KB_DIR);
     tools = new ToolManualService(workspaceService, access, KB_DIR, Date.now, source);

--- a/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
@@ -142,8 +142,8 @@ describe('bundle dialect, end to end', () => {
     expect(paths).toContain('plugins/example-plugin/skills/one-skill/SKILL.md');
     expect(paths).toContain('plugins/finance-kit/skills/close-books/SKILL.md');
     // The standalone team skill rides in the leftovers plugin; linked ones do not repeat there.
-    expect(paths).toContain('plugins/skills/skills/team-only/SKILL.md');
-    expect(paths).not.toContain('plugins/skills/skills/deploy/SKILL.md');
+    expect(paths).toContain('plugins/skills-and-knowledge/skills/team-only/SKILL.md');
+    expect(paths).not.toContain('plugins/skills-and-knowledge/skills/deploy/SKILL.md');
     const manifest = JSON.parse(tree.files.get('plugins/example-plugin/plugin.json')!.toString());
     expect(manifest).toMatchObject({ name: 'example-plugin', version: '1.3.1', description: 'Example' });
     const mcp = JSON.parse(tree.files.get('plugins/example-plugin/.mcp.json')!.toString());

--- a/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/bundle-dialect.e2e.test.ts
@@ -141,7 +141,9 @@ describe('bundle dialect, end to end', () => {
     expect(paths).toContain('plugins/example-plugin/skills/deploy/SKILL.md');
     expect(paths).toContain('plugins/example-plugin/skills/one-skill/SKILL.md');
     expect(paths).toContain('plugins/finance-kit/skills/close-books/SKILL.md');
-    expect(paths).toContain('plugins/skills-departments/skills/team-only/SKILL.md');
+    // The standalone team skill rides in the leftovers plugin; linked ones do not repeat there.
+    expect(paths).toContain('plugins/skills/skills/team-only/SKILL.md');
+    expect(paths).not.toContain('plugins/skills/skills/deploy/SKILL.md');
     const manifest = JSON.parse(tree.files.get('plugins/example-plugin/plugin.json')!.toString());
     expect(manifest).toMatchObject({ name: 'example-plugin', version: '1.3.1', description: 'Example' });
     const mcp = JSON.parse(tree.files.get('plugins/example-plugin/.mcp.json')!.toString());

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -173,6 +173,23 @@ describe('compileMarketplace', () => {
     expect(tree.plugins).toEqual(['gtm', 'skills-and-knowledge', 'hexis-all']);
   });
 
+  it('a manifest name is repository content: it is folded to a safe slug, and a duplicate slug is skipped', async () => {
+    // A hostile or mistaken manifest name must never become a path segment
+    // that escapes the compiled tree.
+    await write('Plugins/GTM/plugin.json', JSON.stringify({ name: '../../etc/passwd' }));
+    // A second plugin whose name folds to the same slug as the first.
+    await write('Plugins/Twin/plugin.json', JSON.stringify({ name: 'etc-passwd' }));
+    await write('Plugins/Twin/access.md', '---\nread:\n  - everyone\n---\nread:\n  - Sam <sam@x.io>\n');
+    await write('Plugins/Twin/skills/twin-skill/SKILL.md', '---\ndescription: t\n---\n');
+
+    const tree = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    const paths = [...tree.files.keys()];
+    expect(paths.every((p) => !p.includes('..') && !p.startsWith('/'))).toBe(true);
+    expect(paths).toContain('plugins/etc-passwd/skills/outreach/SKILL.md');
+    expect(paths).not.toContain('plugins/etc-passwd/skills/twin-skill/SKILL.md');
+    expect(tree.warnings.some((w) => w.includes('Plugins/Twin') && w.includes('already taken'))).toBe(true);
+  });
+
   it('a name clash inside one plugin keeps the first by path and says so', async () => {
     // A second `deploy` skill, linked from the same plugin via a folder root.
     await write('Skills/Ops/deploy/SKILL.md', '---\ndescription: Ops deploy.\n---\n');

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -84,6 +84,7 @@ describe('compileMarketplace', () => {
     compiler = new MarketplaceCompilerService(workspaceService, access, skills, links, KB_DIR, {
       name: 'acme-hexis',
       owner: 'Acme',
+      knowledgeBaseMcp: { name: 'hexis', url: 'https://kb.acme.com/api/mcp' },
     });
   });
   afterEach(() => fs.rm(root, { recursive: true, force: true }));
@@ -114,21 +115,25 @@ describe('compileMarketplace', () => {
     expect(mcp.mcpServers.notion).toEqual({ type: 'streamable-http', url: 'https://mcp.notion.com', headers: { 'X-Client': 'hexis' } });
     expect(mcp.mcpServers.local).toEqual({ type: 'stdio', command: 'npx', args: ['-y', 'x'] });
 
-    // Scope plugins for the shared roots, and the flat copy for `npx skills`.
-    expect(paths).toContain('plugins/skills-eng/skills/deploy/SKILL.md');
-    expect(paths).toContain('plugins/skills-sales/skills/pitch/SKILL.md');
+    // The leftovers plugin holds what no real plugin ships (pitch), never what
+    // one does (deploy is GTM's); the flat copy carries everything once.
+    expect(paths).toContain('plugins/skills/skills/pitch/SKILL.md');
+    expect(paths).not.toContain('plugins/skills/skills/deploy/SKILL.md');
+    // …and the knowledge base itself as an MCP server, URL only.
+    expect(json(tree, 'plugins/skills/.mcp.json')).toEqual({
+      mcpServers: { hexis: { type: 'streamable-http', url: 'https://kb.acme.com/api/mcp' } },
+    });
     expect(paths).toContain('skills/deploy/SKILL.md');
     expect(paths).toContain('skills/pitch/SKILL.md');
     expect(paths).toContain('skills/outreach/SKILL.md');
 
     // The bundle depends on every other plugin; the catalogues list them all.
-    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills-eng', 'skills-sales']);
+    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills']);
     const claude = json(tree, '.claude-plugin/marketplace.json');
     expect(claude.name).toBe('acme-hexis');
     expect(claude.plugins.map((p: { name: string; source: string }) => [p.name, p.source])).toEqual([
       ['gtm', './plugins/gtm'],
-      ['skills-eng', './plugins/skills-eng'],
-      ['skills-sales', './plugins/skills-sales'],
+      ['skills', './plugins/skills'],
       ['hexis-all', './plugins/hexis-all'],
     ]);
     const codex = json(tree, '.agents/plugins/marketplace.json');
@@ -143,9 +148,9 @@ describe('compileMarketplace', () => {
     const paths = [...tree.files.keys()].sort();
     expect(paths.some((p) => p.startsWith('plugins/gtm/skills/'))).toBe(false);
     expect(paths).toContain('plugins/gtm/.mcp.json'); // portable servers are not access-gated content
-    expect(paths).toContain('plugins/skills-sales/skills/pitch/SKILL.md');
+    expect(paths).toContain('plugins/skills/skills/pitch/SKILL.md');
     expect(paths.some((p) => p.includes('deploy'))).toBe(false);
-    expect(tree.plugins).toEqual(['gtm', 'skills-sales', 'hexis-all']);
+    expect(tree.plugins).toEqual(['gtm', 'skills', 'hexis-all']);
   });
 
   it('the everyone audience carries the public subset only', async () => {
@@ -153,6 +158,19 @@ describe('compileMarketplace', () => {
     const paths = [...tree.files.keys()];
     expect(paths).toContain('skills/pitch/SKILL.md');
     expect(paths.some((p) => p.includes('deploy') || p.includes('outreach') || p.includes('secret'))).toBe(false);
+  });
+
+  it('with the endpoint configured, the skills plugin exists even for a caller with no leftover skill', async () => {
+    // Make the one public skill part of GTM, so nothing is left over.
+    await write(
+      'Plugins/GTM/plugin.json',
+      JSON.stringify({ name: 'gtm', extensions: { 'software.bevel.hexis': { skills: ['Skills/Eng/deploy', 'Skills/Sales'] } } }),
+    );
+    const tree = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    const paths = [...tree.files.keys()];
+    expect(paths.some((p) => p.startsWith('plugins/skills/skills/'))).toBe(false);
+    expect(paths).toContain('plugins/skills/.mcp.json');
+    expect(tree.plugins).toEqual(['gtm', 'skills', 'hexis-all']);
   });
 
   it('a name clash inside one plugin keeps the first by path and says so', async () => {

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -117,10 +117,10 @@ describe('compileMarketplace', () => {
 
     // The leftovers plugin holds what no real plugin ships (pitch), never what
     // one does (deploy is GTM's); the flat copy carries everything once.
-    expect(paths).toContain('plugins/skills/skills/pitch/SKILL.md');
-    expect(paths).not.toContain('plugins/skills/skills/deploy/SKILL.md');
+    expect(paths).toContain('plugins/skills-and-knowledge/skills/pitch/SKILL.md');
+    expect(paths).not.toContain('plugins/skills-and-knowledge/skills/deploy/SKILL.md');
     // …and the knowledge base itself as an MCP server, URL only.
-    expect(json(tree, 'plugins/skills/.mcp.json')).toEqual({
+    expect(json(tree, 'plugins/skills-and-knowledge/.mcp.json')).toEqual({
       mcpServers: { hexis: { type: 'streamable-http', url: 'https://kb.acme.com/api/mcp' } },
     });
     expect(paths).toContain('skills/deploy/SKILL.md');
@@ -128,12 +128,12 @@ describe('compileMarketplace', () => {
     expect(paths).toContain('skills/outreach/SKILL.md');
 
     // The bundle depends on every other plugin; the catalogues list them all.
-    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills']);
+    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills-and-knowledge']);
     const claude = json(tree, '.claude-plugin/marketplace.json');
     expect(claude.name).toBe('acme-hexis');
     expect(claude.plugins.map((p: { name: string; source: string }) => [p.name, p.source])).toEqual([
       ['gtm', './plugins/gtm'],
-      ['skills', './plugins/skills'],
+      ['skills-and-knowledge', './plugins/skills-and-knowledge'],
       ['hexis-all', './plugins/hexis-all'],
     ]);
     const codex = json(tree, '.agents/plugins/marketplace.json');
@@ -148,9 +148,9 @@ describe('compileMarketplace', () => {
     const paths = [...tree.files.keys()].sort();
     expect(paths.some((p) => p.startsWith('plugins/gtm/skills/'))).toBe(false);
     expect(paths).toContain('plugins/gtm/.mcp.json'); // portable servers are not access-gated content
-    expect(paths).toContain('plugins/skills/skills/pitch/SKILL.md');
+    expect(paths).toContain('plugins/skills-and-knowledge/skills/pitch/SKILL.md');
     expect(paths.some((p) => p.includes('deploy'))).toBe(false);
-    expect(tree.plugins).toEqual(['gtm', 'skills', 'hexis-all']);
+    expect(tree.plugins).toEqual(['gtm', 'skills-and-knowledge', 'hexis-all']);
   });
 
   it('the everyone audience carries the public subset only', async () => {
@@ -168,9 +168,9 @@ describe('compileMarketplace', () => {
     );
     const tree = await compiler.compileFor({ userEmail: 'sam@x.io' });
     const paths = [...tree.files.keys()];
-    expect(paths.some((p) => p.startsWith('plugins/skills/skills/'))).toBe(false);
-    expect(paths).toContain('plugins/skills/.mcp.json');
-    expect(tree.plugins).toEqual(['gtm', 'skills', 'hexis-all']);
+    expect(paths.some((p) => p.startsWith('plugins/skills-and-knowledge/skills/'))).toBe(false);
+    expect(paths).toContain('plugins/skills-and-knowledge/.mcp.json');
+    expect(tree.plugins).toEqual(['gtm', 'skills-and-knowledge', 'hexis-all']);
   });
 
   it('a name clash inside one plugin keeps the first by path and says so', async () => {

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../../access/access-control.service.js';
+import { SkillService } from '../../skills/skills.service.js';
+import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
+import { PluginLinkIndex } from '../plugin-links.js';
+import { MarketplaceCompilerService } from '../compile/marketplace-compiler.service.js';
+
+/**
+ * Source in, distribution out — for one caller. The real resolver decides
+ * what is readable, the real catalog and link index say what is where; the
+ * assertions are on the produced tree.
+ */
+
+const KB_DIR = 'knowledge-base';
+const wsId = workspaceIdForBranch(DEFAULT_BRANCH);
+
+describe('compileMarketplace', () => {
+  let root: string;
+  let repo: string;
+  let compiler: MarketplaceCompilerService;
+
+  const write = async (rel: string, text: string) => {
+    const abs = path.join(repo, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, text);
+  };
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-compile-'));
+    repo = path.join(root, wsId, KB_DIR);
+    const workspaceService = {
+      getOrCreateForBranch: async () => ({ id: wsId }),
+      getWorkspacePath: async (id: string) => path.join(root, id),
+      readFile: async (id: string, rel: string) => fs.readFile(path.join(root, id, rel), 'utf-8'),
+      ensureRemotesFetched: async () => undefined,
+    } as unknown as WorkspaceService;
+
+    await write('roles.yaml', 'roles:\n  Admin:\n    - admin@x.io\n');
+    await write('access.md', '---\nwrite:\n  - Admin\n---\n');
+    // GTM: Sam is a member. One inline skill, one MCP server with a vault header.
+    await write(
+      'Plugins/GTM/access.md',
+      '---\nread:\n  - everyone\n---\nread:\n  - Sam <sam@x.io>\nwrite:\n  - Mia <mia@x.io>\n',
+    );
+    await write(
+      'Plugins/GTM/plugin.json',
+      JSON.stringify({
+        name: 'gtm',
+        version: '2.1.0',
+        description: 'Go to market',
+        extensions: { 'software.bevel.hexis': { skills: ['Skills/Eng/deploy'] } },
+      }),
+    );
+    await write('Plugins/GTM/skills/outreach/SKILL.md', '---\ndescription: Reach out.\n---\nBody\n');
+    await write('Plugins/GTM/skills/outreach/scripts/run.py', 'print(1)\n');
+    await write('Plugins/GTM/software.bevel.hexis/tools/web.tool', 'not shipped');
+    await write(
+      'Plugins/GTM/mcp.json',
+      JSON.stringify({
+        mcpServers: {
+          notion: { type: 'streamable-http', url: 'https://mcp.notion.com', headers: { Authorization: 'Bearer ${NOTION_TOKEN}', 'X-Client': 'hexis' } },
+          local: { type: 'stdio', command: 'npx', args: ['-y', 'x'] },
+        },
+      }),
+    );
+    // Shared skills: Eng/deploy linked into GTM and readable by its members;
+    // Eng/secret readable by nobody but admins; Sales/pitch public.
+    await write('Skills/Eng/deploy/access.md', '---\n---\nread:\n  - plugin/GTM/read\n');
+    await write('Skills/Eng/deploy/SKILL.md', '---\ndescription: Ship it.\n---\n');
+    await write('Skills/Eng/deploy/references/notes.md', 'notes');
+    await write('Skills/Eng/secret/SKILL.md', '---\ndescription: Hush.\n---\n');
+    await write('Skills/Sales/access.md', '---\n---\nread:\n  - everyone\n');
+    await write('Skills/Sales/pitch/SKILL.md', '---\ndescription: Pitch.\n---\n');
+
+    const access = new AccessControlService(workspaceService, KB_DIR);
+    const skills = new SkillService(workspaceService, access, KB_DIR);
+    const links = new PluginLinkIndex(workspaceService, skills, access, KB_DIR);
+    compiler = new MarketplaceCompilerService(workspaceService, access, skills, links, KB_DIR, {
+      name: 'acme-hexis',
+      owner: 'Acme',
+    });
+  });
+  afterEach(() => fs.rm(root, { recursive: true, force: true }));
+
+  const text = (tree: { files: Map<string, Buffer> }, rel: string) => tree.files.get(rel)?.toString('utf-8');
+  const json = (tree: { files: Map<string, Buffer> }, rel: string) => JSON.parse(text(tree, rel) ?? 'null');
+
+  it('compiles exactly what the caller may read, in the layouts the clients want', async () => {
+    const tree = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    const paths = [...tree.files.keys()].sort();
+
+    // GTM: inline + linked skills copied in, tools and access files left out.
+    expect(paths).toContain('plugins/gtm/skills/outreach/SKILL.md');
+    expect(paths).toContain('plugins/gtm/skills/outreach/scripts/run.py');
+    expect(paths).toContain('plugins/gtm/skills/deploy/SKILL.md');
+    expect(paths).toContain('plugins/gtm/skills/deploy/references/notes.md');
+    expect(paths.some((p) => p.includes('.tool') || p.endsWith('access.md'))).toBe(false);
+    // The unreadable skill is nowhere — not in a plugin, not in the flat copy.
+    expect(paths.some((p) => p.includes('secret'))).toBe(false);
+
+    // Three manifests per plugin, with the source manifest's identity.
+    expect(json(tree, 'plugins/gtm/plugin.json')).toMatchObject({ name: 'gtm', version: '2.1.0', description: 'Go to market' });
+    expect(json(tree, 'plugins/gtm/.claude-plugin/plugin.json')).toMatchObject({ name: 'gtm', version: '2.1.0' });
+    expect(json(tree, 'plugins/gtm/.codex-plugin/plugin.json')).toMatchObject({ name: 'gtm' });
+
+    // The portable half of mcp.json: the vault header is gone, the literal stays.
+    const mcp = json(tree, 'plugins/gtm/.mcp.json');
+    expect(mcp.mcpServers.notion).toEqual({ type: 'streamable-http', url: 'https://mcp.notion.com', headers: { 'X-Client': 'hexis' } });
+    expect(mcp.mcpServers.local).toEqual({ type: 'stdio', command: 'npx', args: ['-y', 'x'] });
+
+    // Scope plugins for the shared roots, and the flat copy for `npx skills`.
+    expect(paths).toContain('plugins/skills-eng/skills/deploy/SKILL.md');
+    expect(paths).toContain('plugins/skills-sales/skills/pitch/SKILL.md');
+    expect(paths).toContain('skills/deploy/SKILL.md');
+    expect(paths).toContain('skills/pitch/SKILL.md');
+    expect(paths).toContain('skills/outreach/SKILL.md');
+
+    // The bundle depends on every other plugin; the catalogues list them all.
+    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills-eng', 'skills-sales']);
+    const claude = json(tree, '.claude-plugin/marketplace.json');
+    expect(claude.name).toBe('acme-hexis');
+    expect(claude.plugins.map((p: { name: string; source: string }) => [p.name, p.source])).toEqual([
+      ['gtm', './plugins/gtm'],
+      ['skills-eng', './plugins/skills-eng'],
+      ['skills-sales', './plugins/skills-sales'],
+      ['hexis-all', './plugins/hexis-all'],
+    ]);
+    const codex = json(tree, '.agents/plugins/marketplace.json');
+    expect(codex.plugins.every((p: { policy: { installation: string } }) => p.policy.installation === 'INSTALLED_BY_DEFAULT')).toBe(true);
+    expect(codex.plugins[0].source).toEqual({ source: 'local', path: './plugins/gtm' });
+    expect(text(tree, 'README.md')).toContain('Compiled from Acme');
+    expect(tree.warnings).toEqual([]);
+  });
+
+  it('for a stranger the plugin keeps only its MCP servers, and the public scope is all that ships', async () => {
+    const tree = await compiler.compileFor({ userEmail: 'nobody@elsewhere.io' });
+    const paths = [...tree.files.keys()].sort();
+    expect(paths.some((p) => p.startsWith('plugins/gtm/skills/'))).toBe(false);
+    expect(paths).toContain('plugins/gtm/.mcp.json'); // portable servers are not access-gated content
+    expect(paths).toContain('plugins/skills-sales/skills/pitch/SKILL.md');
+    expect(paths.some((p) => p.includes('deploy'))).toBe(false);
+    expect(tree.plugins).toEqual(['gtm', 'skills-sales', 'hexis-all']);
+  });
+
+  it('the everyone audience carries the public subset only', async () => {
+    const tree = await compiler.compileFor({ everyone: true });
+    const paths = [...tree.files.keys()];
+    expect(paths).toContain('skills/pitch/SKILL.md');
+    expect(paths.some((p) => p.includes('deploy') || p.includes('outreach') || p.includes('secret'))).toBe(false);
+  });
+
+  it('a name clash inside one plugin keeps the first by path and says so', async () => {
+    // A second `deploy` skill, linked from the same plugin via a folder root.
+    await write('Skills/Ops/deploy/SKILL.md', '---\ndescription: Ops deploy.\n---\n');
+    await write('Skills/Ops/access.md', '---\n---\nread:\n  - plugin/GTM/read\n');
+    await write(
+      'Plugins/GTM/plugin.json',
+      JSON.stringify({ name: 'gtm', extensions: { 'software.bevel.hexis': { skills: ['Skills/Eng/deploy', 'Skills/Ops'] } } }),
+    );
+    // Catalog-level dedup already keeps ONE `deploy` (Skills/Eng wins by path),
+    // so the compiled plugin has one and the tree stays coherent.
+    const tree = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    expect(text(tree, 'plugins/gtm/skills/deploy/SKILL.md')).toContain('Ship it.');
+  });
+});

--- a/packages/core-backend/src/modules/plugins/__tests__/plugin-index.service.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugin-index.service.test.ts
@@ -62,9 +62,14 @@ describe('PluginIndexService', () => {
 
   const kb = () => join(root, wsId, KB_DIR);
 
-  /** A REAL plugin: a folder carrying the access.md that makes it exist. */
+  /**
+   * A REAL plugin: a folder carrying the manifest discovery reads AND the
+   * access.md that makes it exist to the index (a legacy folder without a
+   * manifest gets one from the boot step before the index ever runs).
+   */
   const pluginDir = async (name: string) => {
     await mkdir(join(kb(), 'Plugins', name), { recursive: true });
+    await writeFile(join(kb(), 'Plugins', name, 'plugin.json'), `{"name":"${name.toLowerCase()}"}`);
     await writeFile(join(kb(), 'Plugins', name, 'access.md'), '---\nread:\n  - everyone\n---\n');
   };
 
@@ -90,6 +95,10 @@ describe('PluginIndexService', () => {
     await mkdir(join(kb(), 'Plugins', 'Ghost'), { recursive: true });
     await mkdir(join(kb(), 'Plugins', 'Residue'), { recursive: true });
     await writeFile(join(kb(), 'Plugins', 'Residue', 'notes.md'), 'leftover');
+    // A manifest alone is a plugin to discovery but not to the index: the
+    // access.md is what a deleted plugin's residue lacks.
+    await mkdir(join(kb(), 'Plugins', 'Manifest-only'), { recursive: true });
+    await writeFile(join(kb(), 'Plugins', 'Manifest-only', 'plugin.json'), '{"name":"manifest-only"}');
     await pluginDir('Real');
 
     const catalog = await svc().catalog();

--- a/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
@@ -160,7 +160,9 @@ describe('PluginLinksService', () => {
     expect(JSON.parse(await read('Plugins/GTM/plugin.json')).extensions).toBeUndefined();
     expect(await read('Skills/Eng/deploy/access.md')).not.toContain('plugin/GTM');
     expect(await access.canRead(wsId, member.email, 'Skills/Eng/deploy/SKILL.md')).toBe(false);
-    expect(commits).toEqual([`${KB_DIR}/Plugins/GTM/plugin.json`, `${KB_DIR}/Skills/Eng/deploy/access.md`]);
+    // Revoke lands first, manifest second: a failure between the two leaves
+    // the visible half-state (still listed, no grant), never the silent one.
+    expect(commits).toEqual([`${KB_DIR}/Skills/Eng/deploy/access.md`, `${KB_DIR}/Plugins/GTM/plugin.json`]);
   });
 
   it('unlink leaves the grant in place when the actor may not edit the skill — and says so', async () => {

--- a/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { DEFAULT_BRANCH, type AuthUser } from '@bevel-software/platform-shared';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../../access/access-control.service.js';
+import { SkillService } from '../../skills/skills.service.js';
+import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
+import { PluginLinkIndex } from '../plugin-links.js';
+import { PluginLinksService, PluginLinkError } from '../plugin-links.service.js';
+import type { ProvisionCommitDriver } from '../plugin-provision.service.js';
+
+/**
+ * Linking end to end over a real tree: the real resolver decides who may
+ * link and who may read afterwards, the real catalog resolves roots, and the
+ * commit driver is the only thing stubbed (it records what would land).
+ */
+
+const KB_DIR = 'knowledge-base';
+const wsId = workspaceIdForBranch(DEFAULT_BRANCH);
+
+const manager: AuthUser = { id: 'u-mia', email: 'mia@x.io', name: 'Mia' } as AuthUser;
+const editor: AuthUser = { id: 'u-eve', email: 'eve@x.io', name: 'Eve' } as AuthUser;
+const member: AuthUser = { id: 'u-sam', email: 'sam@x.io', name: 'Sam' } as AuthUser;
+
+const ROLES_YAML = `roles:
+  Admin:
+    - admin@x.io
+`;
+
+describe('PluginLinksService', () => {
+  let root: string;
+  let repo: string;
+  let commits: string[];
+  let access: AccessControlService;
+  let skills: SkillService;
+  let index: PluginLinkIndex;
+  let svc: PluginLinksService;
+
+  const write = async (rel: string, text: string) => {
+    const abs = path.join(repo, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, text);
+  };
+  const read = (rel: string) => fs.readFile(path.join(repo, rel), 'utf-8');
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-links-'));
+    repo = path.join(root, wsId, KB_DIR);
+    commits = [];
+    const workspaceService = {
+      getOrCreateForBranch: async () => ({ id: wsId }),
+      getWorkspacePath: async (id: string) => path.join(root, id),
+      readFile: async (id: string, rel: string) => fs.readFile(path.join(root, id, rel), 'utf-8'),
+      writeFile: async (id: string, rel: string, text: string) => {
+        const abs = path.join(root, id, rel);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, text);
+      },
+      ensureRemotesFetched: async () => undefined,
+    } as unknown as WorkspaceService;
+    const driver: ProvisionCommitDriver = {
+      runPendingCommit: async (_ws, _branch, target) => {
+        commits.push(target);
+      },
+    };
+
+    await write('roles.yaml', ROLES_YAML);
+    await write('access.md', '---\nwrite:\n  - Admin\n---\n');
+    // GTM: Mia manages, Sam is a member.
+    await write(
+      'Plugins/GTM/access.md',
+      '---\nread:\n  - everyone\n---\nread:\n  - Sam <sam@x.io>\nwrite:\n  - Mia <mia@x.io>\nowner:\n  - Mia <mia@x.io>\n',
+    );
+    await write('Plugins/GTM/plugin.json', '{\n  "name": "gtm",\n  "version": "1.0.0"\n}\n');
+    // A shared scope Eve edits, holding two skills.
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Eve <eve@x.io>\n');
+    await write('Skills/Eng/deploy/SKILL.md', '---\ndescription: Ship it.\n---\n');
+    await write('Skills/Eng/rollback/SKILL.md', '---\ndescription: Undo it.\n---\n');
+
+    access = new AccessControlService(workspaceService, KB_DIR);
+    skills = new SkillService(workspaceService, access, KB_DIR);
+    index = new PluginLinkIndex(workspaceService, skills, access, KB_DIR);
+    svc = new PluginLinksService(workspaceService, driver, access, skills, index, KB_DIR);
+  });
+  afterEach(() => fs.rm(root, { recursive: true, force: true }));
+
+  it('links a skill: manifest entry + read/write grants for the plugin principals, both committed', async () => {
+    // Mia manages GTM but cannot edit Skills/Eng — Eve grants her write first.
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Eve <eve@x.io>\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+
+    const result = await svc.link(manager, 'GTM', 'Skills/Eng/deploy');
+    expect(result).toEqual({ root: 'Skills/Eng/deploy', skills: ['Skills/Eng/deploy'] });
+
+    const manifest = JSON.parse(await read('Plugins/GTM/plugin.json'));
+    expect(manifest.version).toBe('1.0.0'); // untouched
+    expect(manifest.extensions['software.bevel.hexis'].skills).toEqual(['Skills/Eng/deploy']);
+    const rules = await read('Skills/Eng/deploy/access.md');
+    expect(rules).toContain('plugin/GTM/read');
+    expect(rules).toContain('plugin/GTM/write');
+    expect(commits).toEqual([
+      `${KB_DIR}/Plugins/GTM/plugin.json`,
+      `${KB_DIR}/Skills/Eng/deploy/access.md`,
+    ]);
+
+    // The point of it all: Sam, a GTM member, can now read the skill; Mia can edit it.
+    expect(await access.canRead(wsId, member.email, 'Skills/Eng/deploy/SKILL.md')).toBe(true);
+    expect(await access.canWrite(wsId, manager.email, 'Skills/Eng/deploy/SKILL.md')).toBe(true);
+    // And the index reports the membership as linked and granted.
+    expect(await index.pluginsOf('Skills/Eng/deploy')).toEqual([{ name: 'GTM', linked: true, granted: true }]);
+    expect(await index.pluginsOf('Skills/Eng/rollback')).toEqual([]);
+  });
+
+  it('refuses with needs-skill-write when the manager cannot edit the skill\'s rules', async () => {
+    await expect(svc.link(manager, 'GTM', 'Skills/Eng/deploy')).rejects.toMatchObject({
+      status: 409,
+      payload: { kind: 'needs-skill-write' },
+    });
+    expect(commits).toEqual([]);
+    expect(await fs.readFile(path.join(repo, 'Plugins/GTM/plugin.json'), 'utf-8')).not.toContain('skills');
+  });
+
+  it('a folder of skills links every skill beneath it with one grant on the folder', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Eve <eve@x.io>\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    const result = await svc.link(manager, 'GTM', 'Skills/Eng');
+    expect(result.skills.sort()).toEqual(['Skills/Eng/deploy', 'Skills/Eng/rollback']);
+    expect(await read('Skills/Eng/access.md')).toContain('plugin/GTM/read');
+    expect(await access.canRead(wsId, member.email, 'Skills/Eng/rollback/SKILL.md')).toBe(true);
+    const m = await index.membership();
+    expect(m.byPlugin.get('GTM')?.linkedSkills.sort()).toEqual(['Skills/Eng/deploy', 'Skills/Eng/rollback']);
+  });
+
+  it('is fail-closed on the plugin side: a non-manager, or an unknown plugin, gets the same 404', async () => {
+    await expect(svc.link(member, 'GTM', 'Skills/Eng/deploy')).rejects.toMatchObject({ status: 404 });
+    await expect(svc.link(manager, 'Ghost', 'Skills/Eng/deploy')).rejects.toMatchObject({ status: 404 });
+    await expect(svc.link(manager, 'personal-abc', 'Skills/Eng/deploy')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rejects a root that holds no released skill, and a path that could escape the repo', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    await expect(svc.link(manager, 'GTM', 'Skills/Nowhere')).rejects.toMatchObject({
+      status: 422,
+      payload: { kind: 'no-skills' },
+    });
+    await expect(svc.link(manager, 'GTM', '../etc')).rejects.toMatchObject({ status: 422, payload: { kind: 'bad-root' } });
+  });
+
+  it('unlink removes the entry and revokes the tokens when the actor may edit the skill', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    await svc.link(manager, 'GTM', 'Skills/Eng/deploy');
+    commits.length = 0;
+
+    expect(await svc.unlink(manager, 'GTM', 'Skills/Eng/deploy')).toEqual({ root: 'Skills/Eng/deploy', revoked: true });
+    expect(JSON.parse(await read('Plugins/GTM/plugin.json')).extensions).toBeUndefined();
+    expect(await read('Skills/Eng/deploy/access.md')).not.toContain('plugin/GTM');
+    expect(await access.canRead(wsId, member.email, 'Skills/Eng/deploy/SKILL.md')).toBe(false);
+    expect(commits).toEqual([`${KB_DIR}/Plugins/GTM/plugin.json`, `${KB_DIR}/Skills/Eng/deploy/access.md`]);
+  });
+
+  it('unlink leaves the grant in place when the actor may not edit the skill — and says so', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    await svc.link(manager, 'GTM', 'Skills/Eng/deploy');
+    // Eve takes Mia's write on the scope away, and hand-edits the skill's own
+    // rules down to the read token — the link's write token, which would still
+    // let GTM's managers edit, is gone.
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Eve <eve@x.io>\n');
+    await write('Skills/Eng/deploy/access.md', '---\n---\nread:\n  - plugin/GTM/read\n');
+    access.invalidate(wsId);
+
+    expect(await svc.unlink(manager, 'GTM', 'Skills/Eng/deploy')).toEqual({ root: 'Skills/Eng/deploy', revoked: false });
+    expect(await read('Skills/Eng/deploy/access.md')).toContain('plugin/GTM/read');
+    await expect(svc.unlink(manager, 'GTM', 'Skills/Eng/deploy')).rejects.toMatchObject({ status: 404, payload: { kind: 'not-linked' } });
+  });
+
+  it('a hand-removed grant shows as not granted, and repair puts it back', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    await svc.link(manager, 'GTM', 'Skills/Eng/deploy');
+
+    await write('Skills/Eng/deploy/access.md', '---\n---\nread:\n  - Sam <sam@x.io>\n');
+    access.invalidate(wsId);
+    index.invalidate();
+    expect(await index.pluginsOf('Skills/Eng/deploy')).toEqual([{ name: 'GTM', linked: true, granted: false }]);
+
+    await svc.repair(manager, 'GTM', 'Skills/Eng/deploy');
+    expect(await index.pluginsOf('Skills/Eng/deploy')).toEqual([{ name: 'GTM', linked: true, granted: true }]);
+    // Repair is a skill-editor's action, not a plugin-manager's: with both the
+    // scope grant and the link's write token gone, Mia may not touch the rules.
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Eve <eve@x.io>\n');
+    await write('Skills/Eng/deploy/access.md', '---\n---\nread:\n  - Sam <sam@x.io>\n');
+    access.invalidate(wsId);
+    await expect(svc.repair(manager, 'GTM', 'Skills/Eng/deploy')).rejects.toBeInstanceOf(PluginLinkError);
+    // Eve, who edits the scope, can.
+    await svc.repair(editor, 'GTM', 'Skills/Eng/deploy');
+    expect(await read('Skills/Eng/deploy/access.md')).toContain('plugin/GTM/read');
+  });
+
+  it('a skill inside a plugin folder is inline membership, never a link', async () => {
+    await write('Plugins/GTM/skills/outreach/SKILL.md', '---\ndescription: Reach out.\n---\n');
+    skills.invalidate();
+    index.invalidate();
+    expect(await index.pluginsOf('Plugins/GTM/skills/outreach')).toEqual([{ name: 'GTM', linked: false, granted: true }]);
+  });
+});

--- a/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
@@ -202,6 +202,20 @@ describe('PluginLinksService', () => {
     expect(await read('Skills/Eng/deploy/access.md')).toContain('plugin/GTM/read');
   });
 
+  it('a plugin nested below the root links like any other — position means nothing', async () => {
+    await write('Plugins/teams/Deep/plugin.json', '{\n  "name": "deep"\n}\n');
+    await write('Plugins/teams/Deep/access.md', '---\n---\nread:\n  - Sam <sam@x.io>\nwrite:\n  - Mia <mia@x.io>\n');
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    access.invalidate(wsId);
+    index.invalidate();
+
+    await svc.link(manager, 'Deep', 'Skills/Eng/rollback');
+    expect(JSON.parse(await read('Plugins/teams/Deep/plugin.json')).extensions['software.bevel.hexis'].skills).toEqual(['Skills/Eng/rollback']);
+    expect(await read('Skills/Eng/rollback/access.md')).toContain('plugin/Deep/read');
+    expect(await access.canRead(wsId, member.email, 'Skills/Eng/rollback/SKILL.md')).toBe(true);
+    expect(await index.pluginsOf('Skills/Eng/rollback')).toEqual([{ name: 'Deep', linked: true, granted: true }]);
+  });
+
   it('a skill inside a plugin folder is inline membership, never a link', async () => {
     await write('Plugins/GTM/skills/outreach/SKILL.md', '---\ndescription: Reach out.\n---\n');
     skills.invalidate();

--- a/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugin-links.service.test.ts
@@ -150,6 +150,23 @@ describe('PluginLinksService', () => {
     await expect(svc.link(manager, 'GTM', '../etc')).rejects.toMatchObject({ status: 422, payload: { kind: 'bad-root' } });
   });
 
+  it('refuses a root that holds a retired skill anywhere beneath it — the grant would reach it', async () => {
+    await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
+    await write('Skills/Eng/old-deploy/SKILL.md', '---\ndescription: Gone.\nmetadata:\n  lifecycle: retired\n---\n');
+    access.invalidate(wsId);
+    skills.invalidate();
+
+    await expect(svc.link(manager, 'GTM', 'Skills/Eng')).rejects.toMatchObject({
+      status: 422,
+      payload: { kind: 'retired-skills', retired: ['Skills/Eng/old-deploy'] },
+    });
+    await expect(svc.link(manager, 'GTM', 'Skills/Eng/old-deploy')).rejects.toMatchObject({ status: 422 });
+    // The active skill on its own is fine.
+    await svc.link(manager, 'GTM', 'Skills/Eng/deploy');
+    expect(await read('Skills/Eng/deploy/access.md')).toContain('plugin/GTM/read');
+    expect(await access.canRead(wsId, member.email, 'Skills/Eng/old-deploy/SKILL.md')).toBe(false);
+  });
+
   it('unlink removes the entry and revokes the tokens when the actor may edit the skill', async () => {
     await write('Skills/Eng/access.md', '---\n---\nwrite:\n  - Mia <mia@x.io>\n');
     access.invalidate(wsId);

--- a/packages/core-backend/src/modules/plugins/__tests__/plugins.routes.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/plugins.routes.test.ts
@@ -75,17 +75,16 @@ async function makeHarness(opts: HarnessOpts = {}) {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-plugins-routes-'));
   tmpDirs.push(workspaceDir);
   const kbRoot = path.join(workspaceDir, KB);
-  // Both carry the access.md that makes a folder a plugin at all.
-  await fs.mkdir(path.join(kbRoot, 'Plugins', 'GTM'), { recursive: true });
-  await fs.writeFile(
-    path.join(kbRoot, 'Plugins', 'GTM', 'access.md'),
-    '---\nread:\n  - everyone\n---\nread: []\n',
-  );
-  await fs.mkdir(path.join(kbRoot, 'Plugins', 'Finance'), { recursive: true });
-  await fs.writeFile(
-    path.join(kbRoot, 'Plugins', 'Finance', 'access.md'),
-    '---\nread:\n  - everyone\n---\nread: []\n',
-  );
+  // Both carry the manifest that makes a folder a plugin to discovery, and
+  // the access.md that makes it exist to the index.
+  for (const name of ['GTM', 'Finance']) {
+    await fs.mkdir(path.join(kbRoot, 'Plugins', name), { recursive: true });
+    await fs.writeFile(path.join(kbRoot, 'Plugins', name, 'plugin.json'), `{"name":"${name.toLowerCase()}"}`);
+    await fs.writeFile(
+      path.join(kbRoot, 'Plugins', name, 'access.md'),
+      '---\nread:\n  - everyone\n---\nread: []\n',
+    );
+  }
 
   const workspaceService = {
     getOrCreateForBranch: async (branch: string) => ({ id: workspaceIdForBranch(branch) }),

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -166,7 +166,11 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     // provisioner applies (`[a-z0-9.-]`, no runs, no leading dots) leaves
     // nothing that can be a separator or a parent reference.
     const slug = pluginManifestName(typeof manifest?.name === 'string' && manifest.name ? manifest.name : name);
-    if (out.some((p) => p.slug === slug) || RESERVED_SLUGS.has(slug)) {
+    if (RESERVED_SLUGS.has(slug)) {
+      warnings.push(`${plugin.folder}: manifest name "${slug}" is reserved by the marketplace and cannot be a plugin — plugin skipped`);
+      continue;
+    }
+    if (out.some((p) => p.slug === slug)) {
       warnings.push(`${plugin.folder}: manifest name "${slug}" is already taken in this marketplace — plugin skipped`);
       continue;
     }
@@ -241,7 +245,13 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
   // 4. The one-install bundle: a Claude manifest with nothing but dependencies.
   const bundle = pluginManifestName(options.bundleName ?? BUNDLE_NAME);
   const slugs = out.map((p) => p.slug);
-  if (slugs.length > 0) {
+  if (slugs.includes(bundle)) {
+    // Only reachable with a non-default bundle name that folds to a real
+    // plugin's slug: the default is reserved above. Skipping the bundle
+    // beats overwriting that plugin's manifests with a dependency list.
+    warnings.push(`the bundle name "${bundle}" collides with a plugin's manifest name — no bundle plugin emitted`);
+  }
+  if (slugs.length > 0 && !slugs.includes(bundle)) {
     const shortSha = options.sourceCommit.slice(0, 12) || '0';
     const description = `Everything in ${options.owner}'s marketplace you may read — one install.`;
     put(
@@ -266,7 +276,8 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
   for (const s of flat) await copySkill(kbRoot, s, `skills/${s.name}`, put);
 
   // 6. The two catalogues + a README naming the source.
-  const entries = [...out.map((p) => ({ slug: p.slug, description: p.description ?? p.displayName })), ...(slugs.length ? [{ slug: bundle, description: 'Everything you may read, one install' }] : [])];
+  const bundleEmitted = slugs.length > 0 && !slugs.includes(bundle);
+  const entries = [...out.map((p) => ({ slug: p.slug, description: p.description ?? p.displayName })), ...(bundleEmitted ? [{ slug: bundle, description: 'Everything you may read, one install' }] : [])];
   put(
     '.claude-plugin/marketplace.json',
     `${JSON.stringify(

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -5,7 +5,6 @@ import {
   PLUGIN_MCP_FILE,
   PLUGIN_MANIFEST_SCHEMA,
   PLUGIN_MCP_SCHEMA,
-  SKILLS_DIR,
   pluginManifestName,
   pluginOfPath,
 } from '@bevel-software/platform-shared';
@@ -35,8 +34,11 @@ import type { DiscoveredPlugin } from '../discovery/plugin-source.js';
  *   plugins/<slug>/…                     one per plugin the caller may read
  *                                        anything of: inline + linked skills,
  *                                        the portable half of mcp.json
- *   plugins/skills-<scope>/…             one per top-level Skills/ folder, so
- *                                        standalone skills are installable
+ *   plugins/skills/…                     every readable skill no plugin above
+ *                                        ships — how a standalone skill, or one
+ *                                        only in plugins the caller cannot see,
+ *                                        is still one install away — plus the
+ *                                        knowledge base's own MCP endpoint
  *   plugins/hexis-all/…                  a bundle whose only content is a
  *                                        dependency on every plugin above —
  *                                        Claude Code installs them all from
@@ -70,6 +72,16 @@ export interface MarketplaceOptions {
   sourceCommit: string;
   /** The name of the one-install bundle plugin. */
   bundleName?: string;
+  /** The name of the leftovers plugin holding skills no other plugin ships. */
+  skillsPluginName?: string;
+  /**
+   * This deployment's hosted MCP endpoint — the knowledge base as a tool.
+   * Shipped in the leftovers plugin's `mcp.json` so an agent that installs
+   * from the marketplace can read the knowledge its skills refer to. URL only,
+   * never a credential: the endpoint challenges with OAuth metadata, and the
+   * client signs the person in on first use.
+   */
+  knowledgeBaseMcp?: { name: string; url: string };
 }
 
 export interface CompileInput {
@@ -96,6 +108,7 @@ export interface VirtualTree {
 }
 
 const BUNDLE_NAME = 'hexis-all';
+const SKILLS_PLUGIN_NAME = 'skills';
 const NEVER_SHIPPED = new Set(['access.md', '.bevelignore']);
 
 export async function compileMarketplace(input: CompileInput): Promise<VirtualTree> {
@@ -120,8 +133,10 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     description?: string;
     version?: string;
     skills: SkillSummary[];
-    /** Source folder for mcp.json (real plugins only). */
+    /** Source folder (real plugins only). */
     folder?: string;
+    /** The portable `mcpServers` map to ship, when the plugin has servers. */
+    mcp?: Record<string, Record<string, unknown>>;
   }
   const out: PluginOut[] = [];
 
@@ -152,38 +167,44 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
       version: typeof manifest?.version === 'string' ? manifest.version : undefined,
       skills: dedup,
       folder: plugin.folder,
+      mcp: mcp ?? undefined,
     });
-    if (mcp !== null) {
-      const text = `${JSON.stringify({ $schema: PLUGIN_MCP_SCHEMA, mcpServers: mcp }, null, 2)}\n`;
-      put(`plugins/${slug}/${PLUGIN_MCP_FILE}`, text);
-      put(`plugins/${slug}/.mcp.json`, `${JSON.stringify({ mcpServers: mcp }, null, 2)}\n`);
-    }
   }
 
-  // 2. Synthetic scope plugins: one per top-level folder under Skills/, holding
-  //    every readable skill beneath it — how a skill in no plugin gets installed.
-  const byScope = new Map<string, SkillSummary[]>();
-  for (const s of readableSkills.values()) {
-    const segments = s.path.split('/');
-    if (segments[0] !== SKILLS_DIR) continue;
-    // `Skills/<skill>` (no scope folder) lands in the root scope.
-    const scope = segments.length > 2 ? segments[1] : '';
-    byScope.set(scope, [...(byScope.get(scope) ?? []), s]);
-  }
-  for (const [scope, list] of [...byScope.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    const slug = scope ? `skills-${pluginManifestName(scope)}` : 'skills';
+  // 2. The leftovers plugin: every readable skill that no plugin above ships.
+  //    Agents install plugins, not loose skills, so a skill in no plugin — or
+  //    only in plugins this caller cannot see anything of — still has to be one
+  //    install away. ONE plugin per caller, not one per scope: there is nothing
+  //    to choose between (the caller may read all of it) and the bundle installs
+  //    it regardless, so scope plugins would only add names and duplicate what
+  //    the real plugins already carry.
+  //    It also carries the knowledge base's own MCP endpoint (URL only — the
+  //    client's OAuth flow signs the person in), so an agent installing from
+  //    the marketplace can read the knowledge its skills point at. With the
+  //    endpoint configured the plugin exists even for a caller with no
+  //    leftover skill: the knowledge is the point.
+  const covered = new Set(out.flatMap((p) => p.skills.map((s) => s.path)));
+  const leftovers = [...readableSkills.values()].filter((s) => !covered.has(s.path));
+  const kbMcp = options.knowledgeBaseMcp
+    ? { [options.knowledgeBaseMcp.name]: { type: 'streamable-http', url: options.knowledgeBaseMcp.url } }
+    : undefined;
+  if (leftovers.length > 0 || kbMcp) {
+    const slug = options.skillsPluginName ?? SKILLS_PLUGIN_NAME;
     if (out.some((p) => p.slug === slug)) {
-      warnings.push(`scope plugin "${slug}" collides with a plugin's manifest name — scope skipped`);
-      continue;
+      warnings.push(`the skills plugin "${slug}" collides with a plugin's manifest name — standalone skills not shipped`);
+    } else {
+      out.push({
+        slug,
+        displayName: 'Skills',
+        description: kbMcp
+          ? 'Every skill you may read that no other plugin here ships, and the knowledge base as an MCP server'
+          : 'Every skill you may read that no other plugin here ships',
+        skills: dedupeByName(leftovers, (s, other) =>
+          warnings.push(`${slug}: "${s.name}" at ${s.path} shares its name with ${other.path} — left out`),
+        ),
+        mcp: kbMcp,
+      });
     }
-    out.push({
-      slug,
-      displayName: scope ? `Skills · ${scope}` : 'Skills',
-      description: scope ? `Every shared skill under ${SKILLS_DIR}/${scope}` : `Shared skills at the ${SKILLS_DIR} root`,
-      skills: dedupeByName(list, (s, other) =>
-        warnings.push(`${slug}: "${s.name}" at ${s.path} shares its name with ${other.path} — left out`),
-      ),
-    });
   }
 
   // 3. Materialise every plugin: the three manifests + copied skill folders.
@@ -198,6 +219,10 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     vendor.description = p.description ?? p.displayName;
     put(`${base}/.claude-plugin/plugin.json`, `${JSON.stringify(vendor, null, 2)}\n`);
     put(`${base}/.codex-plugin/plugin.json`, `${JSON.stringify(vendor, null, 2)}\n`);
+    if (p.mcp) {
+      put(`${base}/${PLUGIN_MCP_FILE}`, `${JSON.stringify({ $schema: PLUGIN_MCP_SCHEMA, mcpServers: p.mcp }, null, 2)}\n`);
+      put(`${base}/.mcp.json`, `${JSON.stringify({ mcpServers: p.mcp }, null, 2)}\n`);
+    }
     for (const s of p.skills) {
       await copySkill(kbRoot, s, `${base}/skills/${s.name}`, put);
     }

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -1,0 +1,355 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  PLUGIN_MCP_FILE,
+  PLUGIN_MANIFEST_SCHEMA,
+  PLUGIN_MCP_SCHEMA,
+  SKILLS_DIR,
+  pluginManifestName,
+  pluginOfPath,
+} from '@bevel-software/platform-shared';
+import { walkFiles } from '../../../shared/fs-walk.js';
+import { containsVariableReference } from '../../../shared/variable-refs.js';
+import type { SkillSummary } from '../../skills/skills.contract.js';
+import type { LinkMembership } from '../plugin-links.js';
+
+/**
+ * The compiler: SOURCE layout in, DISTRIBUTION layout out.
+ *
+ * Source is what lives in the knowledge base — shared skills under
+ * `Skills/`, plugin folders under `Plugins/` whose manifests LINK to them.
+ * Distribution is what an agent installs: a marketplace of self-contained
+ * plugins, each physically holding its skills (Claude Code refuses paths
+ * that escape a plugin's directory, and symlinks are out), in the vendor
+ * layouts the clients read today — `.claude-plugin/plugin.json`,
+ * `.codex-plugin/plugin.json`, `.mcp.json` — beside the Agent Plugins
+ * `plugin.json` and `mcp.json`.
+ *
+ * What comes out, for one caller:
+ *
+ *   .claude-plugin/marketplace.json      Claude Code's catalogue
+ *   .agents/plugins/marketplace.json     Codex's catalogue, every entry
+ *                                        INSTALLED_BY_DEFAULT
+ *   plugins/<slug>/…                     one per plugin the caller may read
+ *                                        anything of: inline + linked skills,
+ *                                        the portable half of mcp.json
+ *   plugins/skills-<scope>/…             one per top-level Skills/ folder, so
+ *                                        standalone skills are installable
+ *   plugins/hexis-all/…                  a bundle whose only content is a
+ *                                        dependency on every plugin above —
+ *                                        Claude Code installs them all from
+ *                                        one `claude plugin install`
+ *   skills/<name>/…                      every readable skill once, flat, for
+ *                                        `npx skills add <url> --all`
+ *   README.md                            names the source commit
+ *
+ * FAIL CLOSED, per file: a skill is copied only when `readable` says yes for
+ * its SKILL.md — the same per-path verdict the catalog filters on — so the
+ * compiled tree for a caller holds exactly what that caller may read, and
+ * nothing about a skill they may not. Plugins with nothing readable are
+ * left out entirely. `access.md` and `.bevelignore` never ship; neither do
+ * the hexis-only `.tool` manuals (no other client can run them), nor an
+ * `mcp.json` header carrying a `${VAR}` vault reference (the extension block
+ * that resolves it is ours, and a header a client would send verbatim must
+ * not name a secret it cannot expand).
+ *
+ * A pure function of its inputs — it reads the KB tree it is pointed at and
+ * returns a virtual tree; writing it somewhere (a git namespace, a folder, a
+ * remote) is the sink's business.
+ */
+
+export interface MarketplaceOptions {
+  /** The marketplace's name — a slug the clients key it on. */
+  name: string;
+  /** Shown as the marketplace owner. */
+  owner: string;
+  description?: string;
+  /** The default-branch commit the tree was compiled from; also the bundle's version. */
+  sourceCommit: string;
+  /** The name of the one-install bundle plugin. */
+  bundleName?: string;
+}
+
+export interface CompileInput {
+  /** Absolute path of the KB checkout (the folder holding `Plugins/`, `Skills/`, …). */
+  kbRoot: string;
+  /** The released catalog, UNFILTERED — `readable` does the filtering. */
+  skills: SkillSummary[];
+  /** Which plugins hold which skills, from the link index. */
+  membership: LinkMembership;
+  /** The caller's read verdict on a repo-relative path (`<skillFolder>/SKILL.md`). */
+  readable: (repoPath: string) => Promise<boolean>;
+  options: MarketplaceOptions;
+}
+
+export interface VirtualTree {
+  /** repo-relative POSIX path → file bytes. */
+  files: Map<string, Buffer>;
+  /** What was left out and why — name clashes, unparsable manifests. */
+  warnings: string[];
+  /** The plugin slugs the tree carries, in marketplace order. */
+  plugins: string[];
+}
+
+const BUNDLE_NAME = 'hexis-all';
+const NEVER_SHIPPED = new Set(['access.md', '.bevelignore']);
+
+export async function compileMarketplace(input: CompileInput): Promise<VirtualTree> {
+  const { kbRoot, skills, membership, readable, options } = input;
+  const files = new Map<string, Buffer>();
+  const warnings: string[] = [];
+  const put = (rel: string, content: string | Buffer) =>
+    files.set(rel, typeof content === 'string' ? Buffer.from(content, 'utf-8') : content);
+
+  // One verdict per skill, resolved once: every plugin below reads from it.
+  const readableSkills = new Map<string, SkillSummary>();
+  for (const s of skills) {
+    if (await readable(`${s.path}/SKILL.md`)) readableSkills.set(s.path, s);
+  }
+
+  interface PluginOut {
+    slug: string;
+    displayName: string;
+    description?: string;
+    version?: string;
+    skills: SkillSummary[];
+    /** Source folder for mcp.json (real plugins only). */
+    folder?: string;
+  }
+  const out: PluginOut[] = [];
+
+  // 1. Real plugins: inline skills (in the folder) + linked skills (from the
+  //    manifest), each only if readable.
+  for (const [folder, links] of [...membership.byPlugin.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const manifest = await readJson(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MANIFEST_FILE));
+    if (manifest === undefined) {
+      warnings.push(`${PLUGINS_DIR}/${folder}/${PLUGIN_MANIFEST_FILE} is not valid JSON — plugin skipped`);
+      continue;
+    }
+    const inline = [...readableSkills.values()].filter((s) => pluginOfPath(s.path) === folder);
+    const linked = links.linkedSkills
+      .map((p) => readableSkills.get(p))
+      .filter((s): s is SkillSummary => s !== undefined);
+    const dedup = dedupeByName([...inline, ...linked], (s, other) =>
+      warnings.push(
+        `${folder}: skill "${s.name}" at ${s.path} shares its name with ${other.path} — the second is left out`,
+      ),
+    );
+    const mcp = await portableMcp(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MCP_FILE));
+    if (dedup.length === 0 && mcp === null) continue; // nothing this caller may see
+    const slug = typeof manifest?.name === 'string' && manifest.name ? manifest.name : pluginManifestName(folder);
+    out.push({
+      slug,
+      displayName: folder,
+      description: typeof manifest?.description === 'string' ? manifest.description : undefined,
+      version: typeof manifest?.version === 'string' ? manifest.version : undefined,
+      skills: dedup,
+      folder,
+    });
+    if (mcp !== null) {
+      const text = `${JSON.stringify({ $schema: PLUGIN_MCP_SCHEMA, mcpServers: mcp }, null, 2)}\n`;
+      put(`plugins/${slug}/${PLUGIN_MCP_FILE}`, text);
+      put(`plugins/${slug}/.mcp.json`, `${JSON.stringify({ mcpServers: mcp }, null, 2)}\n`);
+    }
+  }
+
+  // 2. Synthetic scope plugins: one per top-level folder under Skills/, holding
+  //    every readable skill beneath it — how a skill in no plugin gets installed.
+  const byScope = new Map<string, SkillSummary[]>();
+  for (const s of readableSkills.values()) {
+    const segments = s.path.split('/');
+    if (segments[0] !== SKILLS_DIR) continue;
+    // `Skills/<skill>` (no scope folder) lands in the root scope.
+    const scope = segments.length > 2 ? segments[1] : '';
+    byScope.set(scope, [...(byScope.get(scope) ?? []), s]);
+  }
+  for (const [scope, list] of [...byScope.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const slug = scope ? `skills-${pluginManifestName(scope)}` : 'skills';
+    if (out.some((p) => p.slug === slug)) {
+      warnings.push(`scope plugin "${slug}" collides with a plugin's manifest name — scope skipped`);
+      continue;
+    }
+    out.push({
+      slug,
+      displayName: scope ? `Skills · ${scope}` : 'Skills',
+      description: scope ? `Every shared skill under ${SKILLS_DIR}/${scope}` : `Shared skills at the ${SKILLS_DIR} root`,
+      skills: dedupeByName(list, (s, other) =>
+        warnings.push(`${slug}: "${s.name}" at ${s.path} shares its name with ${other.path} — left out`),
+      ),
+    });
+  }
+
+  // 3. Materialise every plugin: the three manifests + copied skill folders.
+  for (const p of out) {
+    const base = `plugins/${p.slug}`;
+    const spec: Record<string, unknown> = { $schema: PLUGIN_MANIFEST_SCHEMA, name: p.slug };
+    if (p.version) spec.version = p.version;
+    if (p.description) spec.description = p.description;
+    put(`${base}/${PLUGIN_MANIFEST_FILE}`, `${JSON.stringify(spec, null, 2)}\n`);
+    const vendor: Record<string, unknown> = { name: p.slug };
+    if (p.version) vendor.version = p.version;
+    vendor.description = p.description ?? p.displayName;
+    put(`${base}/.claude-plugin/plugin.json`, `${JSON.stringify(vendor, null, 2)}\n`);
+    put(`${base}/.codex-plugin/plugin.json`, `${JSON.stringify(vendor, null, 2)}\n`);
+    for (const s of p.skills) {
+      await copySkill(kbRoot, s, `${base}/skills/${s.name}`, put);
+    }
+  }
+
+  // 4. The one-install bundle: a Claude manifest with nothing but dependencies.
+  const bundle = options.bundleName ?? BUNDLE_NAME;
+  const slugs = out.map((p) => p.slug);
+  if (slugs.length > 0) {
+    const shortSha = options.sourceCommit.slice(0, 12) || '0';
+    const description = `Everything in ${options.owner}'s marketplace you may read — one install.`;
+    put(
+      `plugins/${bundle}/.claude-plugin/plugin.json`,
+      `${JSON.stringify({ name: bundle, version: `0.0.0-${shortSha}`, description, dependencies: slugs }, null, 2)}\n`,
+    );
+    put(
+      `plugins/${bundle}/${PLUGIN_MANIFEST_FILE}`,
+      `${JSON.stringify({ $schema: PLUGIN_MANIFEST_SCHEMA, name: bundle, description }, null, 2)}\n`,
+    );
+    put(
+      `plugins/${bundle}/.codex-plugin/plugin.json`,
+      `${JSON.stringify({ name: bundle, description }, null, 2)}\n`,
+    );
+  }
+
+  // 5. The flat root skills/ folder, every readable skill once.
+  const flat = dedupeByName(
+    [...readableSkills.values()].sort((a, b) => a.path.localeCompare(b.path)),
+    (s, other) => warnings.push(`skills/: "${s.name}" at ${s.path} shares its name with ${other.path} — left out`),
+  );
+  for (const s of flat) await copySkill(kbRoot, s, `skills/${s.name}`, put);
+
+  // 6. The two catalogues + a README naming the source.
+  const entries = [...out.map((p) => ({ slug: p.slug, description: p.description ?? p.displayName })), ...(slugs.length ? [{ slug: bundle, description: 'Everything you may read, one install' }] : [])];
+  put(
+    '.claude-plugin/marketplace.json',
+    `${JSON.stringify(
+      {
+        name: options.name,
+        owner: { name: options.owner },
+        ...(options.description ? { description: options.description } : {}),
+        plugins: entries.map((e) => ({ name: e.slug, source: `./plugins/${e.slug}`, description: e.description })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  put(
+    '.agents/plugins/marketplace.json',
+    `${JSON.stringify(
+      {
+        name: options.name,
+        plugins: entries.map((e) => ({
+          name: e.slug,
+          source: { source: 'local', path: `./plugins/${e.slug}` },
+          policy: { installation: 'INSTALLED_BY_DEFAULT' },
+          description: e.description,
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  put(
+    'README.md',
+    [
+      `# ${options.name}`,
+      '',
+      `Compiled from ${options.owner}'s knowledge base at commit \`${options.sourceCommit}\`.`,
+      'This tree is generated: edit the knowledge base, not these files.',
+      '',
+      `Plugins: ${entries.map((e) => e.slug).join(', ') || 'none'}.`,
+      '',
+    ].join('\n'),
+  );
+
+  return { files, warnings, plugins: entries.map((e) => e.slug) };
+}
+
+// --- helpers ------------------------------------------------------------------
+
+/** Copy a skill folder (minus what never ships) under `dest`. */
+async function copySkill(
+  kbRoot: string,
+  skill: SkillSummary,
+  dest: string,
+  put: (rel: string, content: Buffer) => void,
+): Promise<void> {
+  const abs = path.join(kbRoot, skill.path);
+  for (const rel of await walkFiles(abs, (name) => !NEVER_SHIPPED.has(name))) {
+    put(`${dest}/${rel}`, await fs.readFile(path.join(abs, rel)));
+  }
+}
+
+/** First by (name, path) order wins; the loser is reported to `onClash`. */
+function dedupeByName(
+  list: SkillSummary[],
+  onClash: (loser: SkillSummary, winner: SkillSummary) => void,
+): SkillSummary[] {
+  const sorted = [...list].sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+  const seen = new Map<string, SkillSummary>();
+  const out: SkillSummary[] = [];
+  for (const s of sorted) {
+    const winner = seen.get(s.name);
+    if (winner) {
+      if (winner.path !== s.path) onClash(s, winner);
+      continue;
+    }
+    seen.set(s.name, s);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * The portable half of a plugin's mcp.json: transport, url, command, args,
+ * env, cwd, and only those headers a client may send verbatim (no `${VAR}`
+ * vault references). Null when the file is absent or holds no server.
+ */
+async function portableMcp(abs: string): Promise<Record<string, Record<string, unknown>> | null> {
+  const parsed = await readJson(abs);
+  if (!parsed || typeof parsed.mcpServers !== 'object' || parsed.mcpServers === null) return null;
+  const out: Record<string, Record<string, unknown>> = {};
+  for (const [name, raw] of Object.entries(parsed.mcpServers as Record<string, unknown>)) {
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) continue;
+    const server = raw as Record<string, unknown>;
+    const entry: Record<string, unknown> = {};
+    for (const key of ['type', 'url', 'command', 'args', 'env', 'cwd'] as const) {
+      if (server[key] !== undefined) entry[key] = server[key];
+    }
+    if (typeof server.headers === 'object' && server.headers !== null) {
+      const headers: Record<string, string> = {};
+      for (const [h, v] of Object.entries(server.headers as Record<string, unknown>)) {
+        if (typeof v === 'string' && !containsVariableReference(v)) headers[h] = v;
+      }
+      if (Object.keys(headers).length > 0) entry.headers = headers;
+    }
+    if (typeof entry.url === 'string' && containsVariableReference(entry.url)) continue; // ours to expand, not theirs
+    out[name] = entry;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/** Parsed JSON object; `null` when absent; `undefined` when present but unparsable. */
+async function readJson(abs: string): Promise<Record<string, unknown> | null | undefined> {
+  let text: string;
+  try {
+    text = await fs.readFile(abs, 'utf-8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -108,6 +108,8 @@ export interface VirtualTree {
 
 const BUNDLE_NAME = 'hexis-all';
 const SKILLS_PLUGIN_NAME = 'skills-and-knowledge';
+/** Slugs the compiler emits itself; a real plugin may not take them. */
+const RESERVED_SLUGS = new Set([BUNDLE_NAME, SKILLS_PLUGIN_NAME]);
 const NEVER_SHIPPED = new Set(['access.md', '.bevelignore']);
 
 export async function compileMarketplace(input: CompileInput): Promise<VirtualTree> {
@@ -158,7 +160,16 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     );
     const mcp = portableMcp(plugin.mcpServers);
     if (dedup.length === 0 && mcp === null) continue; // nothing this caller may see
-    const slug = typeof manifest?.name === 'string' && manifest.name ? manifest.name : pluginManifestName(name);
+    // The slug is ALWAYS sanitised, even when the manifest declares a name: it
+    // becomes a path segment in the compiled tree, and a checked-in manifest
+    // is repository content, not trusted input. The same folding the
+    // provisioner applies (`[a-z0-9.-]`, no runs, no leading dots) leaves
+    // nothing that can be a separator or a parent reference.
+    const slug = pluginManifestName(typeof manifest?.name === 'string' && manifest.name ? manifest.name : name);
+    if (out.some((p) => p.slug === slug) || RESERVED_SLUGS.has(slug)) {
+      warnings.push(`${plugin.folder}: manifest name "${slug}" is already taken in this marketplace — plugin skipped`);
+      continue;
+    }
     out.push({
       slug,
       displayName: typeof manifest?.displayName === 'string' ? manifest.displayName : name,
@@ -188,7 +199,7 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     ? { [options.knowledgeBaseMcp.name]: { type: 'streamable-http', url: options.knowledgeBaseMcp.url } }
     : undefined;
   if (leftovers.length > 0 || kbMcp) {
-    const slug = options.skillsPluginName ?? SKILLS_PLUGIN_NAME;
+    const slug = pluginManifestName(options.skillsPluginName ?? SKILLS_PLUGIN_NAME);
     if (out.some((p) => p.slug === slug)) {
       warnings.push(`the skills plugin "${slug}" collides with a plugin's manifest name — standalone skills not shipped`);
     } else {
@@ -228,7 +239,7 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
   }
 
   // 4. The one-install bundle: a Claude manifest with nothing but dependencies.
-  const bundle = options.bundleName ?? BUNDLE_NAME;
+  const bundle = pluginManifestName(options.bundleName ?? BUNDLE_NAME);
   const slugs = out.map((p) => p.slug);
   if (slugs.length > 0) {
     const shortSha = options.sourceCommit.slice(0, 12) || '0';

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -34,7 +34,7 @@ import type { DiscoveredPlugin } from '../discovery/plugin-source.js';
  *   plugins/<slug>/…                     one per plugin the caller may read
  *                                        anything of: inline + linked skills,
  *                                        the portable half of mcp.json
- *   plugins/skills/…                     every readable skill no plugin above
+ *   plugins/skills-and-knowledge/…       every readable skill no plugin above
  *                                        ships — how a standalone skill, or one
  *                                        only in plugins the caller cannot see,
  *                                        is still one install away — plus the
@@ -108,7 +108,7 @@ export interface VirtualTree {
 }
 
 const BUNDLE_NAME = 'hexis-all';
-const SKILLS_PLUGIN_NAME = 'skills';
+const SKILLS_PLUGIN_NAME = 'skills-and-knowledge';
 const NEVER_SHIPPED = new Set(['access.md', '.bevelignore']);
 
 export async function compileMarketplace(input: CompileInput): Promise<VirtualTree> {
@@ -195,7 +195,7 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     } else {
       out.push({
         slug,
-        displayName: 'Skills',
+        displayName: 'Skills and knowledge',
         description: kbMcp
           ? 'Every skill you may read that no other plugin here ships, and the knowledge base as an MCP server'
           : 'Every skill you may read that no other plugin here ships',

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
-  PLUGINS_DIR,
   PLUGIN_MANIFEST_FILE,
   PLUGIN_MCP_FILE,
   PLUGIN_MANIFEST_SCHEMA,
@@ -14,6 +13,7 @@ import { walkFiles } from '../../../shared/fs-walk.js';
 import { containsVariableReference } from '../../../shared/variable-refs.js';
 import type { SkillSummary } from '../../skills/skills.contract.js';
 import type { LinkMembership } from '../plugin-links.js';
+import type { DiscoveredPlugin } from '../discovery/plugin-source.js';
 
 /**
  * The compiler: SOURCE layout in, DISTRIBUTION layout out.
@@ -77,6 +77,8 @@ export interface CompileInput {
   kbRoot: string;
   /** The released catalog, UNFILTERED — `readable` does the filtering. */
   skills: SkillSummary[];
+  /** The plugins as the configured source discovered them (manifests and servers already parsed). */
+  plugins: DiscoveredPlugin[];
   /** Which plugins hold which skills, from the link index. */
   membership: LinkMembership;
   /** The caller's read verdict on a repo-relative path (`<skillFolder>/SKILL.md`). */
@@ -97,15 +99,18 @@ const BUNDLE_NAME = 'hexis-all';
 const NEVER_SHIPPED = new Set(['access.md', '.bevelignore']);
 
 export async function compileMarketplace(input: CompileInput): Promise<VirtualTree> {
-  const { kbRoot, skills, membership, readable, options } = input;
+  const { kbRoot, skills, plugins, membership, readable, options } = input;
   const files = new Map<string, Buffer>();
   const warnings: string[] = [];
   const put = (rel: string, content: string | Buffer) =>
     files.set(rel, typeof content === 'string' ? Buffer.from(content, 'utf-8') : content);
 
-  // One verdict per skill, resolved once: every plugin below reads from it.
+  // One verdict per skill, resolved once: every plugin below reads from it. A
+  // RETIRED skill (its governance lifecycle) stays in the catalog for its
+  // owners but never ships — retiring is how a skill leaves every agent.
   const readableSkills = new Map<string, SkillSummary>();
   for (const s of skills) {
+    if (s.lifecycle === 'retired') continue;
     if (await readable(`${s.path}/SKILL.md`)) readableSkills.set(s.path, s);
   }
 
@@ -121,32 +126,32 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
   const out: PluginOut[] = [];
 
   // 1. Real plugins: inline skills (in the folder) + linked skills (from the
-  //    manifest), each only if readable.
-  for (const [folder, links] of [...membership.byPlugin.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    const manifest = await readJson(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MANIFEST_FILE));
-    if (manifest === undefined) {
-      warnings.push(`${PLUGINS_DIR}/${folder}/${PLUGIN_MANIFEST_FILE} is not valid JSON — plugin skipped`);
-      continue;
-    }
-    const inline = [...readableSkills.values()].filter((s) => pluginOfPath(s.path) === folder);
+  //    manifest), each only if readable. Personal folders are places, not
+  //    plugins; a plugin the index does not count as existing is not shipped.
+  const byName = new Map(plugins.map((p) => [p.name, p]));
+  for (const [name, links] of [...membership.byPlugin.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const plugin = byName.get(name);
+    if (!plugin || plugin.personal || !plugin.exists) continue;
+    const manifest = plugin.manifest;
+    const inline = [...readableSkills.values()].filter((s) => pluginOfPath(s.path) === name);
     const linked = links.linkedSkills
       .map((p) => readableSkills.get(p))
       .filter((s): s is SkillSummary => s !== undefined);
     const dedup = dedupeByName([...inline, ...linked], (s, other) =>
       warnings.push(
-        `${folder}: skill "${s.name}" at ${s.path} shares its name with ${other.path} — the second is left out`,
+        `${name}: skill "${s.name}" at ${s.path} shares its name with ${other.path} — the second is left out`,
       ),
     );
-    const mcp = await portableMcp(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MCP_FILE));
+    const mcp = portableMcp(plugin.mcpServers);
     if (dedup.length === 0 && mcp === null) continue; // nothing this caller may see
-    const slug = typeof manifest?.name === 'string' && manifest.name ? manifest.name : pluginManifestName(folder);
+    const slug = typeof manifest?.name === 'string' && manifest.name ? manifest.name : pluginManifestName(name);
     out.push({
       slug,
-      displayName: folder,
+      displayName: typeof manifest?.displayName === 'string' ? manifest.displayName : name,
       description: typeof manifest?.description === 'string' ? manifest.description : undefined,
       version: typeof manifest?.version === 'string' ? manifest.version : undefined,
       skills: dedup,
-      folder,
+      folder: plugin.folder,
     });
     if (mcp !== null) {
       const text = `${JSON.stringify({ $schema: PLUGIN_MCP_SCHEMA, mcpServers: mcp }, null, 2)}\n`;
@@ -308,15 +313,14 @@ function dedupeByName(
 }
 
 /**
- * The portable half of a plugin's mcp.json: transport, url, command, args,
- * env, cwd, and only those headers a client may send verbatim (no `${VAR}`
- * vault references). Null when the file is absent or holds no server.
+ * The portable half of a plugin's `mcpServers`: transport, url, command,
+ * args, env, cwd, and only those headers a client may send verbatim (no
+ * `${VAR}` vault references). Null when there is no server to ship.
  */
-async function portableMcp(abs: string): Promise<Record<string, Record<string, unknown>> | null> {
-  const parsed = await readJson(abs);
-  if (!parsed || typeof parsed.mcpServers !== 'object' || parsed.mcpServers === null) return null;
+function portableMcp(servers: Record<string, unknown> | null): Record<string, Record<string, unknown>> | null {
+  if (!servers) return null;
   const out: Record<string, Record<string, unknown>> = {};
-  for (const [name, raw] of Object.entries(parsed.mcpServers as Record<string, unknown>)) {
+  for (const [name, raw] of Object.entries(servers)) {
     if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) continue;
     const server = raw as Record<string, unknown>;
     const entry: Record<string, unknown> = {};
@@ -334,22 +338,4 @@ async function portableMcp(abs: string): Promise<Record<string, Record<string, u
     out[name] = entry;
   }
   return Object.keys(out).length > 0 ? out : null;
-}
-
-/** Parsed JSON object; `null` when absent; `undefined` when present but unparsable. */
-async function readJson(abs: string): Promise<Record<string, unknown> | null | undefined> {
-  let text: string;
-  try {
-    text = await fs.readFile(abs, 'utf-8');
-  } catch {
-    return null;
-  }
-  try {
-    const parsed: unknown = JSON.parse(text);
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -6,7 +6,6 @@ import {
   PLUGIN_MANIFEST_SCHEMA,
   PLUGIN_MCP_SCHEMA,
   pluginManifestName,
-  pluginOfPath,
 } from '@bevel-software/platform-shared';
 import { walkFiles } from '../../../shared/fs-walk.js';
 import { containsVariableReference } from '../../../shared/variable-refs.js';
@@ -148,7 +147,7 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     const plugin = byName.get(name);
     if (!plugin || plugin.personal || !plugin.exists) continue;
     const manifest = plugin.manifest;
-    const inline = [...readableSkills.values()].filter((s) => pluginOfPath(s.path) === name);
+    const inline = [...readableSkills.values()].filter((s) => s.path.startsWith(`${plugin.folder}/`));
     const linked = links.linkedSkills
       .map((p) => readableSkills.get(p))
       .filter((s): s is SkillSummary => s !== undefined);

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -45,20 +45,27 @@ export class MarketplaceCompilerService {
     private readonly source: PluginSource = new KbPluginSource(),
   ) {}
 
-  /** The default-branch commit the next compile would read. */
+  /**
+   * The default-branch commit the next compile would read. Throws when git
+   * cannot say: the repo service keys freshness on this value, and a stable
+   * placeholder would make every later compile look unnecessary — source
+   * changes and access revocations would never reach that caller again.
+   */
   async sourceCommit(): Promise<string> {
     const { kbRoot } = await this.checkout();
-    try {
-      const { stdout } = await execFileAsync('git', ['-C', kbRoot, 'rev-parse', 'HEAD']);
-      return stdout.trim();
-    } catch {
-      return 'unknown';
-    }
+    const { stdout } = await execFileAsync('git', ['-C', kbRoot, 'rev-parse', 'HEAD']);
+    const sha = stdout.trim();
+    if (!/^[0-9a-f]{40}$/.test(sha)) throw new Error(`could not read the default branch's commit (${sha || 'empty'})`);
+    return sha;
   }
 
   async compileFor(audience: CompileAudience): Promise<VirtualTree & { sourceCommit: string }> {
     const { wsId, kbRoot } = await this.checkout();
-    const sourceCommit = await this.sourceCommit();
+    // Strictness about the commit belongs to the FRESHNESS check (the repo
+    // service calls `sourceCommit()` itself and refuses to serve without
+    // one). A compile of a checkout git cannot describe still yields a
+    // correct tree; only its README and bundle version lose the sha.
+    const sourceCommit = await this.sourceCommit().catch(() => 'unknown');
     const skills = await this.skillService.listSkills(undefined);
     const membership = await this.links.membership();
     const { plugins } = await this.source.discover(kbRoot);

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -1,0 +1,109 @@
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import type { IAccessControl } from '../../access/access-control.interface.js';
+import type { ISkillService } from '../../skills/skills.contract.js';
+import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
+import type { PluginLinkIndex } from '../plugin-links.js';
+import { compileMarketplace, type VirtualTree } from './compile-marketplace.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Whose view of the knowledge base to compile. */
+export type CompileAudience = { userEmail: string } | { everyone: true };
+
+/**
+ * The compiler wired to the live deployment: the default-branch checkout,
+ * the released catalog, the link index, and the access resolver as the read
+ * verdict. Every sink — the per-user git endpoint, a public mirror, a local
+ * export — asks this for a tree and writes it somewhere.
+ *
+ * Two audiences: a PERSON (their `canRead` per skill, exactly the catalog's
+ * filter) or EVERYONE (only what `read: everyone` reaches cleanly — the
+ * public subset a shared mirror may carry). Nothing in between: an audience
+ * that is "these three people" would need a union of verdicts nobody has
+ * asked for yet.
+ */
+export class MarketplaceCompilerService {
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly accessControl: IAccessControl,
+    private readonly skillService: ISkillService,
+    private readonly links: PluginLinkIndex,
+    private readonly kbDirName: string,
+    private readonly marketplace: { name: string; owner: string; description?: string },
+  ) {}
+
+  /** The default-branch commit the next compile would read. */
+  async sourceCommit(): Promise<string> {
+    const { kbRoot } = await this.checkout();
+    try {
+      const { stdout } = await execFileAsync('git', ['-C', kbRoot, 'rev-parse', 'HEAD']);
+      return stdout.trim();
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  async compileFor(audience: CompileAudience): Promise<VirtualTree & { sourceCommit: string }> {
+    const { wsId, kbRoot } = await this.checkout();
+    const sourceCommit = await this.sourceCommit();
+    const skills = await this.skillService.listSkills(undefined);
+    const membership = await this.links.membership();
+    const readable = await this.readPredicate(wsId, audience, skills.map((s) => `${s.path}/SKILL.md`));
+    const tree = await compileMarketplace({
+      kbRoot,
+      skills,
+      membership,
+      readable,
+      options: { ...this.marketplace, sourceCommit },
+    });
+    return { ...tree, sourceCommit };
+  }
+
+  // --- internal --------------------------------------------------------------
+
+  private async checkout(): Promise<{ wsId: string; kbRoot: string }> {
+    const wsId = (await this.workspaceService.getOrCreateForBranch(DEFAULT_BRANCH)).id;
+    return { wsId, kbRoot: path.join(await this.workspaceService.getWorkspacePath(wsId), this.kbDirName) };
+  }
+
+  /**
+   * One batch verdict per compile, then a lookup. Fail closed both ways: a
+   * path the batch skipped is unreadable, and for the everyone audience a
+   * skill is public only when the resolver says `read: everyone` applies
+   * cleanly (`restricted: false`).
+   */
+  private async readPredicate(
+    wsId: string,
+    audience: CompileAudience,
+    docPaths: string[],
+  ): Promise<(repoPath: string) => Promise<boolean>> {
+    if ('userEmail' in audience) {
+      const verdicts = docPaths.length
+        ? await this.accessControl.canReadBatch(wsId, audience.userEmail, docPaths)
+        : new Map<string, boolean>();
+      return async (p) => verdicts.get(p) === true;
+    }
+    const cache = new Map<string, boolean>();
+    return async (p) => {
+      const hit = cache.get(p);
+      if (hit !== undefined) return hit;
+      let verdict = false;
+      try {
+        verdict = !(await this.accessControl.eligibleReaders(wsId, p)).restricted;
+      } catch {
+        verdict = false;
+      }
+      cache.set(p, verdict);
+      return verdict;
+    };
+  }
+}
+
+/** The default-branch workspace id compiles run against. */
+export function compileWorkspaceId(): string {
+  return workspaceIdForBranch(DEFAULT_BRANCH);
+}

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -55,17 +55,22 @@ export class MarketplaceCompilerService {
     const { kbRoot } = await this.checkout();
     const { stdout } = await execFileAsync('git', ['-C', kbRoot, 'rev-parse', 'HEAD']);
     const sha = stdout.trim();
-    if (!/^[0-9a-f]{40}$/.test(sha)) throw new Error(`could not read the default branch's commit (${sha || 'empty'})`);
+    // SHA-1 or SHA-256 object format: any hex object id is a commit.
+    if (!/^[0-9a-f]{40,64}$/.test(sha)) throw new Error(`could not read the default branch's commit (${sha || 'empty'})`);
     return sha;
   }
 
-  async compileFor(audience: CompileAudience): Promise<VirtualTree & { sourceCommit: string }> {
+  async compileFor(
+    audience: CompileAudience,
+    /** The commit to stamp the tree with, when the caller already read it (the freshness check does). */
+    knownCommit?: string,
+  ): Promise<VirtualTree & { sourceCommit: string }> {
     const { wsId, kbRoot } = await this.checkout();
     // Strictness about the commit belongs to the FRESHNESS check (the repo
     // service calls `sourceCommit()` itself and refuses to serve without
     // one). A compile of a checkout git cannot describe still yields a
     // correct tree; only its README and bundle version lose the sha.
-    const sourceCommit = await this.sourceCommit().catch(() => 'unknown');
+    const sourceCommit = knownCommit ?? (await this.sourceCommit().catch(() => 'unknown'));
     const skills = await this.skillService.listSkills(undefined);
     const membership = await this.links.membership();
     const { plugins } = await this.source.discover(kbRoot);

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -8,7 +8,7 @@ import type { ISkillService } from '../../skills/skills.contract.js';
 import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
 import type { PluginLinkIndex } from '../plugin-links.js';
 import type { PluginSource } from '../discovery/plugin-source.js';
-import { NativePluginSource } from '../discovery/native.source.js';
+import { KbPluginSource } from '../discovery/kb-plugin-source.js';
 import { compileMarketplace, type VirtualTree } from './compile-marketplace.js';
 
 const execFileAsync = promisify(execFile);
@@ -42,7 +42,7 @@ export class MarketplaceCompilerService {
       /** The hosted MCP endpoint to ship in the skills plugin (URL only). */
       knowledgeBaseMcp?: { name: string; url: string };
     },
-    private readonly source: PluginSource = new NativePluginSource(),
+    private readonly source: PluginSource = new KbPluginSource(),
   ) {}
 
   /** The default-branch commit the next compile would read. */

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -35,7 +35,13 @@ export class MarketplaceCompilerService {
     private readonly skillService: ISkillService,
     private readonly links: PluginLinkIndex,
     private readonly kbDirName: string,
-    private readonly marketplace: { name: string; owner: string; description?: string },
+    private readonly marketplace: {
+      name: string;
+      owner: string;
+      description?: string;
+      /** The hosted MCP endpoint to ship in the skills plugin (URL only). */
+      knowledgeBaseMcp?: { name: string; url: string };
+    },
     private readonly source: PluginSource = new NativePluginSource(),
   ) {}
 

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -56,7 +56,9 @@ export class MarketplaceCompilerService {
     const { stdout } = await execFileAsync('git', ['-C', kbRoot, 'rev-parse', 'HEAD']);
     const sha = stdout.trim();
     // SHA-1 or SHA-256 object format: any hex object id is a commit.
-    if (!/^[0-9a-f]{40,64}$/.test(sha)) throw new Error(`could not read the default branch's commit (${sha || 'empty'})`);
+    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(sha)) {
+      throw new Error(`could not read the default branch's commit (${sha || 'empty'})`);
+    }
     return sha;
   }
 

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -7,6 +7,8 @@ import type { IAccessControl } from '../../access/access-control.interface.js';
 import type { ISkillService } from '../../skills/skills.contract.js';
 import { workspaceIdForBranch } from '../../../shared/workspace-id.js';
 import type { PluginLinkIndex } from '../plugin-links.js';
+import type { PluginSource } from '../discovery/plugin-source.js';
+import { NativePluginSource } from '../discovery/native.source.js';
 import { compileMarketplace, type VirtualTree } from './compile-marketplace.js';
 
 const execFileAsync = promisify(execFile);
@@ -34,6 +36,7 @@ export class MarketplaceCompilerService {
     private readonly links: PluginLinkIndex,
     private readonly kbDirName: string,
     private readonly marketplace: { name: string; owner: string; description?: string },
+    private readonly source: PluginSource = new NativePluginSource(),
   ) {}
 
   /** The default-branch commit the next compile would read. */
@@ -52,10 +55,12 @@ export class MarketplaceCompilerService {
     const sourceCommit = await this.sourceCommit();
     const skills = await this.skillService.listSkills(undefined);
     const membership = await this.links.membership();
+    const { plugins } = await this.source.discover(kbRoot);
     const readable = await this.readPredicate(wsId, audience, skills.map((s) => `${s.path}/SKILL.md`));
     const tree = await compileMarketplace({
       kbRoot,
       skills,
+      plugins,
       membership,
       readable,
       options: { ...this.marketplace, sourceCommit },

--- a/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
@@ -100,6 +100,27 @@ describe('KbPluginSource — bundles', () => {
     expect(plugins.find((p) => p.name === 'close')!.mcpServers).toBeNull();
   });
 
+  it('skips a registry server that could not work, and the second of two declarations with one id', async () => {
+    await write(
+      'configs/mcp/registry.json',
+      JSON.stringify({
+        servers: [
+          { id: 'jira', config: { command: 'npx', args: ['-y', 'jira-mcp'] } },
+          { id: 'jira', config: { command: 'something-else' } },
+          { id: 'no-url', config: { type: 'http' } },
+          { id: 'odd', config: { type: 'grpc', url: 'https://x' } },
+        ],
+        profiles: [{ id: 'global', servers: ['jira', 'no-url', 'odd'] }],
+      }),
+    );
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
+    const example = plugins.find((p) => p.name === 'example-plugin')!;
+    expect(example.mcpServers).toEqual({ jira: { type: 'stdio', command: 'npx', args: ['-y', 'jira-mcp'] } });
+    expect(warnings.some((w) => w.includes('"jira" is declared twice'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"no-url" has transport "http" but no url'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"odd" has an unknown transport'))).toBe(true);
+  });
+
   it('cuts an extends cycle instead of hanging, and keeps what it collected', async () => {
     await write('plugins/loop/plugin.bundle.json', JSON.stringify({ name: 'loop', mcpProfile: 'loop-a' }));
     const { plugins, warnings } = await new KbPluginSource().discover(kb);

--- a/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
@@ -139,7 +139,8 @@ describe('KbPluginSource — one walk, both shapes', () => {
     await write('Plugins/GTM/access.md', '---\n---\nread:\n  - everyone\n');
     await write('Plugins/GTM/skills/outreach/SKILL.md', '---\ndescription: x\n---\n');
     await write('Plugins/GTM/skills/outreach/plugin.json', '{"name":"not-a-plugin"}');
-    // A pre-manifest folder (access.md only) directly under the root.
+    // A pre-manifest folder (access.md only) directly under the root: NOT a
+    // plugin to discovery — the boot step gives it a manifest first.
     await write('Plugins/Legacy/access.md', '---\n---\nread:\n  - everyone\n');
     // A bundle three folders down, and a native manifest two folders down.
     await write('Plugins/functional/cluster/example/plugin.bundle.json', JSON.stringify({ name: 'example', sourceSkillRoots: ['Skills/x'] }));
@@ -149,24 +150,19 @@ describe('KbPluginSource — one walk, both shapes', () => {
     await write('Plugins/Both/plugin.bundle.json', JSON.stringify({ name: 'both-bundle', sourceSkillRoots: ['Skills/y'] }));
     // A deeper folder that is only a container: walked through, never a plugin.
     await write('Plugins/teams/empty-container/README.md', 'nothing here');
-    // A level-one folder with only an mcp.json — a plugin whose manifest never
-    // got written, which the tool scanner has always read.
-    await write('Plugins/Servers/mcp.json', JSON.stringify({ mcpServers: { x: { type: 'stdio', command: 'x' } } }));
     // A level-one scope that carries an access.md of its own AND plugins
     // beneath: a container, not a plugin.
     await write('Plugins/functional/access.md', '---\n---\nread:\n  - everyone\n');
 
     const { plugins, warnings } = await new KbPluginSource().discover(kb);
     // Folders are visited in locale order (case-insensitive), depth first.
+    // Position means nothing: only the two files make a plugin.
     expect(plugins.map((p) => [p.name, p.folder, p.linksAreManaged, p.exists])).toEqual([
       ['Both', 'Plugins/Both', true, false],
       ['example', 'Plugins/functional/cluster/example', false, true],
       ['GTM', 'Plugins/GTM', true, true],
-      ['Legacy', 'Plugins/Legacy', true, true],
-      ['Servers', 'Plugins/Servers', true, false],
       ['deep', 'Plugins/teams/deep', true, false],
     ]);
-    expect(plugins.find((p) => p.name === 'Servers')?.mcpServers).toEqual({ x: { type: 'stdio', command: 'x' } });
     expect(plugins.find((p) => p.name === 'GTM')?.linkedRoots).toEqual(['Skills/Eng']);
     expect(plugins.find((p) => p.name === 'Both')?.linkedRoots).toEqual([]);
     expect(warnings).toEqual([]);

--- a/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
@@ -108,16 +108,25 @@ describe('KbPluginSource — bundles', () => {
           { id: 'jira', config: { command: 'npx', args: ['-y', 'jira-mcp'] } },
           { id: 'jira', config: { command: 'something-else' } },
           { id: 'no-url', config: { type: 'http' } },
+          { id: 'blank-url', config: { url: '  ' } },
           { id: 'odd', config: { type: 'grpc', url: 'https://x' } },
+          // A stray blank url beside a real command is still a stdio server.
+          { id: 'launch', config: { type: 'stdio', command: 'run-it', url: '' } },
+          { id: 'untyped-launch', config: { command: 'run-it', url: '' } },
         ],
-        profiles: [{ id: 'global', servers: ['jira', 'no-url', 'odd'] }],
+        profiles: [{ id: 'global', servers: ['jira', 'no-url', 'blank-url', 'odd', 'launch', 'untyped-launch'] }],
       }),
     );
     const { plugins, warnings } = await new KbPluginSource().discover(kb);
     const example = plugins.find((p) => p.name === 'example-plugin')!;
-    expect(example.mcpServers).toEqual({ jira: { type: 'stdio', command: 'npx', args: ['-y', 'jira-mcp'] } });
+    expect(example.mcpServers).toEqual({
+      jira: { type: 'stdio', command: 'npx', args: ['-y', 'jira-mcp'] },
+      launch: { type: 'stdio', command: 'run-it' },
+      'untyped-launch': { type: 'stdio', command: 'run-it' },
+    });
     expect(warnings.some((w) => w.includes('"jira" is declared twice'))).toBe(true);
     expect(warnings.some((w) => w.includes('"no-url" has transport "http" but no url'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"blank-url" has neither a url nor a command'))).toBe(true);
     expect(warnings.some((w) => w.includes('"odd" has an unknown transport'))).toBe(true);
   });
 

--- a/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
@@ -168,12 +168,17 @@ describe('KbPluginSource — one walk, both shapes', () => {
     expect(warnings).toEqual([]);
   });
 
-  it('keeps the first of two plugins that share a name and says which was skipped', async () => {
+  it('keeps the first of two plugins whose names fold to one slug, and says which was skipped', async () => {
     await write('Plugins/a/GTM/plugin.json', '{}');
     await write('Plugins/b/GTM/plugin.json', '{}');
+    // Different spelling, same manifest slug: still one plugin.
+    await write('Plugins/c/gtm/plugin.json', '{}');
     const { plugins, warnings } = await new KbPluginSource().discover(kb);
     expect(plugins.map((p) => p.folder)).toEqual(['Plugins/a/GTM']);
-    expect(warnings).toEqual(['Plugins/b/GTM: plugin name "GTM" is already used by Plugins/a/GTM — plugin skipped']);
+    expect(warnings).toEqual([
+      'Plugins/b/GTM: plugin name "GTM" is already used by Plugins/a/GTM — plugin skipped',
+      'Plugins/c/gtm: plugin name "gtm" is already used by Plugins/a/GTM — plugin skipped',
+    ]);
   });
 
   it('a knowledge base without a plugins root has no plugins and no complaint', async () => {

--- a/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/__tests__/kb-plugin-source.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { DEFAULT_KB_LAYOUT, configureKbLayout } from '@bevel-software/platform-shared';
-import { BundlePluginSource } from '../bundle.source.js';
+import { KbPluginSource } from '../kb-plugin-source.js';
 
 /**
  * The customer's tree, in their own root names (lowercase `plugins/` and
@@ -26,7 +26,7 @@ const REGISTRY = {
   ],
 };
 
-describe('BundlePluginSource', () => {
+describe('KbPluginSource — bundles', () => {
   let kb: string;
   const write = async (rel: string, text: string) => {
     const abs = path.join(kb, rel);
@@ -62,7 +62,7 @@ describe('BundlePluginSource', () => {
   });
 
   it('finds bundles at any depth and reads them as plugins that link skill roots', async () => {
-    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
     const byName = new Map(plugins.map((p) => [p.name, p]));
     expect([...byName.keys()].sort()).toEqual(['close', 'example-plugin', 'unnamed']);
 
@@ -88,7 +88,7 @@ describe('BundlePluginSource', () => {
   });
 
   it('expands mcpProfile through the registry, following extends and reporting unknowns', async () => {
-    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
     const example = plugins.find((p) => p.name === 'example-plugin')!;
     expect(example.mcpServers).toEqual({
       confluence: { type: 'streamable-http', url: 'https://mcp.confluence.example' },
@@ -102,7 +102,7 @@ describe('BundlePluginSource', () => {
 
   it('cuts an extends cycle instead of hanging, and keeps what it collected', async () => {
     await write('plugins/loop/plugin.bundle.json', JSON.stringify({ name: 'loop', mcpProfile: 'loop-a' }));
-    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
     const loop = plugins.find((p) => p.name === 'loop')!;
     expect(loop.mcpServers).toEqual({ 'flat-http': { type: 'streamable-http', url: 'https://flat.example' } });
     expect(warnings.some((w) => w.includes('cycle'))).toBe(true);
@@ -110,8 +110,79 @@ describe('BundlePluginSource', () => {
 
   it('a missing registry leaves the plugins standing, servers-less, with a warning per profile', async () => {
     await fs.rm(path.join(kb, 'configs'), { recursive: true });
-    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
     expect(plugins.find((p) => p.name === 'example-plugin')!.mcpServers).toBeNull();
     expect(warnings.some((w) => w.includes('no registry'))).toBe(true);
+  });
+});
+
+describe('KbPluginSource — one walk, both shapes', () => {
+  let kb: string;
+  const write = async (rel: string, text: string) => {
+    const abs = path.join(kb, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, text);
+  };
+
+  beforeEach(async () => {
+    kb = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-mixed-'));
+  });
+  afterEach(async () => {
+    configureKbLayout({ ...DEFAULT_KB_LAYOUT });
+    await fs.rm(kb, { recursive: true, force: true });
+  });
+
+  it('reads native manifests and bundles side by side, at any depth, and stops at a plugin folder', async () => {
+    // A native plugin directly under the root, with a skill inside — the
+    // skill folder must not be mistaken for a nested plugin.
+    await write('Plugins/GTM/plugin.json', JSON.stringify({ name: 'gtm', extensions: { 'software.bevel.hexis': { skills: ['Skills/Eng'] } } }));
+    await write('Plugins/GTM/access.md', '---\n---\nread:\n  - everyone\n');
+    await write('Plugins/GTM/skills/outreach/SKILL.md', '---\ndescription: x\n---\n');
+    await write('Plugins/GTM/skills/outreach/plugin.json', '{"name":"not-a-plugin"}');
+    // A pre-manifest folder (access.md only) directly under the root.
+    await write('Plugins/Legacy/access.md', '---\n---\nread:\n  - everyone\n');
+    // A bundle three folders down, and a native manifest two folders down.
+    await write('Plugins/functional/cluster/example/plugin.bundle.json', JSON.stringify({ name: 'example', sourceSkillRoots: ['Skills/x'] }));
+    await write('Plugins/teams/deep/plugin.json', JSON.stringify({ name: 'deep' }));
+    // A folder with BOTH files: the manifest wins.
+    await write('Plugins/Both/plugin.json', JSON.stringify({ name: 'both' }));
+    await write('Plugins/Both/plugin.bundle.json', JSON.stringify({ name: 'both-bundle', sourceSkillRoots: ['Skills/y'] }));
+    // A deeper folder that is only a container: walked through, never a plugin.
+    await write('Plugins/teams/empty-container/README.md', 'nothing here');
+    // A level-one folder with only an mcp.json — a plugin whose manifest never
+    // got written, which the tool scanner has always read.
+    await write('Plugins/Servers/mcp.json', JSON.stringify({ mcpServers: { x: { type: 'stdio', command: 'x' } } }));
+    // A level-one scope that carries an access.md of its own AND plugins
+    // beneath: a container, not a plugin.
+    await write('Plugins/functional/access.md', '---\n---\nread:\n  - everyone\n');
+
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
+    // Folders are visited in locale order (case-insensitive), depth first.
+    expect(plugins.map((p) => [p.name, p.folder, p.linksAreManaged, p.exists])).toEqual([
+      ['Both', 'Plugins/Both', true, false],
+      ['example', 'Plugins/functional/cluster/example', false, true],
+      ['GTM', 'Plugins/GTM', true, true],
+      ['Legacy', 'Plugins/Legacy', true, true],
+      ['Servers', 'Plugins/Servers', true, false],
+      ['deep', 'Plugins/teams/deep', true, false],
+    ]);
+    expect(plugins.find((p) => p.name === 'Servers')?.mcpServers).toEqual({ x: { type: 'stdio', command: 'x' } });
+    expect(plugins.find((p) => p.name === 'GTM')?.linkedRoots).toEqual(['Skills/Eng']);
+    expect(plugins.find((p) => p.name === 'Both')?.linkedRoots).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps the first of two plugins that share a name and says which was skipped', async () => {
+    await write('Plugins/a/GTM/plugin.json', '{}');
+    await write('Plugins/b/GTM/plugin.json', '{}');
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
+    expect(plugins.map((p) => p.folder)).toEqual(['Plugins/a/GTM']);
+    expect(warnings).toEqual(['Plugins/b/GTM: plugin name "GTM" is already used by Plugins/a/GTM — plugin skipped']);
+  });
+
+  it('a knowledge base without a plugins root has no plugins and no complaint', async () => {
+    const { plugins, warnings } = await new KbPluginSource().discover(kb);
+    expect(plugins).toEqual([]);
+    expect(warnings).toEqual([]);
   });
 });

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/__tests__/bundle.source.test.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/__tests__/bundle.source.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DEFAULT_KB_LAYOUT, configureKbLayout } from '@bevel-software/platform-shared';
+import { BundlePluginSource } from '../bundle.source.js';
+
+/**
+ * The customer's tree, in their own root names (lowercase `plugins/` and
+ * `skills/`), with the four ownership scopes they use and a registry with an
+ * `extends` chain. The dialect must read it as plugins that link skills.
+ */
+
+const REGISTRY = {
+  servers: [
+    { id: 'jira', name: 'Jira', config: { command: 'npx', args: ['-y', 'jira-mcp'], env: { JIRA_URL: 'https://j' } } },
+    { id: 'confluence', name: 'Confluence', config: { type: 'http', url: 'https://mcp.confluence.example' } },
+    { id: 'flat-http', type: 'http', url: 'https://flat.example' },
+  ],
+  profiles: [
+    { id: 'base', servers: ['jira'] },
+    { id: 'global', servers: ['confluence', 'ghost'], extends: 'base' },
+    { id: 'loop-a', servers: ['flat-http'], extends: 'loop-b' },
+    { id: 'loop-b', servers: [], extends: 'loop-a' },
+    { id: 'empty', servers: [] },
+  ],
+};
+
+describe('BundlePluginSource', () => {
+  let kb: string;
+  const write = async (rel: string, text: string) => {
+    const abs = path.join(kb, rel);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, text);
+  };
+
+  beforeEach(async () => {
+    kb = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-bundle-'));
+    configureKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+    await write('configs/mcp/registry.json', JSON.stringify(REGISTRY));
+    await write(
+      'plugins/functional/cluster-a/example-plugin/plugin.bundle.json',
+      JSON.stringify({
+        name: 'example-plugin',
+        version: '1.3.1',
+        description: 'What this plugin is for',
+        mcpProfile: 'global',
+        interface: { displayName: 'Example Plugin', category: 'Productivity' },
+        sourceSkillRoots: ['skills/departments/engineering/shared/cluster-a', 'skills/functional/cluster-a/one-skill'],
+      }),
+    );
+    await write(
+      'plugins/departments/business/finance/close/plugin.bundle.json',
+      JSON.stringify({ name: 'close', version: '0.1.0', mcpProfile: 'empty', sourceSkillRoots: ['skills/departments/business/finance'] }),
+    );
+    await write('plugins/departments/engineering/shared/unnamed/plugin.bundle.json', JSON.stringify({ sourceSkillRoots: ['../escape', 'skills/x'] }));
+    await write('plugins/broken/plugin.bundle.json', '{ not json');
+  });
+  afterEach(async () => {
+    configureKbLayout({ ...DEFAULT_KB_LAYOUT });
+    await fs.rm(kb, { recursive: true, force: true });
+  });
+
+  it('finds bundles at any depth and reads them as plugins that link skill roots', async () => {
+    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const byName = new Map(plugins.map((p) => [p.name, p]));
+    expect([...byName.keys()].sort()).toEqual(['close', 'example-plugin', 'unnamed']);
+
+    const example = byName.get('example-plugin')!;
+    expect(example.folder).toBe('plugins/functional/cluster-a/example-plugin');
+    expect(example.relFolder).toBe('functional/cluster-a/example-plugin');
+    expect(example.exists).toBe(true);
+    expect(example.linksAreManaged).toBe(false);
+    expect(example.linkedRoots).toEqual([
+      'skills/departments/engineering/shared/cluster-a',
+      'skills/functional/cluster-a/one-skill',
+    ]);
+    expect(example.manifest).toEqual({
+      name: 'example-plugin',
+      version: '1.3.1',
+      description: 'What this plugin is for',
+      displayName: 'Example Plugin',
+    });
+    // An unnamed bundle takes its folder's name; a bad root is dropped with a warning.
+    expect(byName.get('unnamed')!.linkedRoots).toEqual(['skills/x']);
+    expect(warnings.some((w) => w.includes('../escape'))).toBe(true);
+    expect(warnings.some((w) => w.includes('plugins/broken'))).toBe(true);
+  });
+
+  it('expands mcpProfile through the registry, following extends and reporting unknowns', async () => {
+    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const example = plugins.find((p) => p.name === 'example-plugin')!;
+    expect(example.mcpServers).toEqual({
+      confluence: { type: 'streamable-http', url: 'https://mcp.confluence.example' },
+      jira: { type: 'stdio', command: 'npx', args: ['-y', 'jira-mcp'], env: { JIRA_URL: 'https://j' } },
+    });
+    expect(JSON.parse(example.mcpJsonText!)).toEqual({ mcpServers: example.mcpServers });
+    expect(warnings.some((w) => w.includes('unknown server "ghost"'))).toBe(true);
+    // An empty profile is valid and selects nothing.
+    expect(plugins.find((p) => p.name === 'close')!.mcpServers).toBeNull();
+  });
+
+  it('cuts an extends cycle instead of hanging, and keeps what it collected', async () => {
+    await write('plugins/loop/plugin.bundle.json', JSON.stringify({ name: 'loop', mcpProfile: 'loop-a' }));
+    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    const loop = plugins.find((p) => p.name === 'loop')!;
+    expect(loop.mcpServers).toEqual({ 'flat-http': { type: 'streamable-http', url: 'https://flat.example' } });
+    expect(warnings.some((w) => w.includes('cycle'))).toBe(true);
+  });
+
+  it('a missing registry leaves the plugins standing, servers-less, with a warning per profile', async () => {
+    await fs.rm(path.join(kb, 'configs'), { recursive: true });
+    const { plugins, warnings } = await new BundlePluginSource().discover(kb);
+    expect(plugins.find((p) => p.name === 'example-plugin')!.mcpServers).toBeNull();
+    expect(warnings.some((w) => w.includes('no registry'))).toBe(true);
+  });
+});

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { normalizeSkillRoot, pluginManifestName } from '@bevel-software/platform-shared';
+import { isPersonalPluginFolder, normalizeSkillRoot, pluginManifestName } from '@bevel-software/platform-shared';
 import type { DiscoveredPlugin } from '../plugin-source.js';
 import { expandProfile, parseRegistry, type McpRegistry } from './registry.js';
 
@@ -41,8 +41,14 @@ export async function loadRegistry(kbRoot: string, warnings: string[]): Promise<
   let text: string;
   try {
     text = await fs.readFile(path.join(kbRoot, DEFAULT_REGISTRY_PATH), 'utf-8');
-  } catch {
-    return null; // no registry: bundles without a profile are still plugins
+  } catch (err) {
+    const code = (err as { code?: unknown } | null)?.code;
+    // No registry is a valid state: bundles without a profile are still
+    // plugins. A registry that exists but cannot be read is not.
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      warnings.push(`${DEFAULT_REGISTRY_PATH} could not be read (${String(code ?? err)}) — every mcpProfile is unresolved`);
+    }
+    return null;
   }
   const registry = parseRegistry(text);
   warnings.push(...registry.warnings);
@@ -102,7 +108,9 @@ export async function readBundlePlugin(
     name,
     folder,
     relFolder,
-    personal: false,
+    // The same rule as the native reader: a reserved personal folder directly
+    // under the root is a place, not a plugin, whatever file it carries.
+    personal: !relFolder.includes('/') && isPersonalPluginFolder(leaf),
     exists: true,
     manifest,
     manifestText: null,

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
@@ -1,12 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { PLUGINS_DIR, normalizeSkillRoot, pluginManifestName } from '@bevel-software/platform-shared';
-import { walkFiles } from '../../../../shared/fs-walk.js';
-import type { DiscoveredPlugin, Discovery, PluginSource } from '../plugin-source.js';
+import { normalizeSkillRoot, pluginManifestName } from '@bevel-software/platform-shared';
+import type { DiscoveredPlugin } from '../plugin-source.js';
 import { expandProfile, parseRegistry, type McpRegistry } from './registry.js';
 
 /**
- * THE DETACHABLE PART — a customer's plugin source format, read as-is:
+ * THE DETACHABLE PART — a customer's plugin file format, read as-is:
  *
  *   <pluginsRoot>/<scope…>/<plugin>/plugin.bundle.json
  *     {
@@ -16,109 +15,100 @@ import { expandProfile, parseRegistry, type McpRegistry } from './registry.js';
  *       "sourceSkillRoots": [ "skills/departments/engineering/shared/<cluster>" ]
  *     }
  *
- * A bundle is a LIST OF SKILL PATHS plus a pointer into an MCP registry, at
- * any depth under the plugins root — which is exactly the native model's
- * "a plugin links skills" with different field names. So the dialect maps:
+ * A bundle is a LIST OF SKILL PATHS plus a pointer into an MCP registry —
+ * which is exactly the native model's "a plugin links skills" with different
+ * field names. So the reader maps:
  *
  *   sourceSkillRoots   → linkedRoots          (a root is a skill or a folder of skills)
  *   mcpProfile         → mcpServers           (expanded through the registry)
  *   name/version/desc  → a synthesised manifest
  *   interface.displayName → the plugin's display name
  *
- * READ-ONLY by construction: nothing in this directory writes. A plugin
- * created in hexis inside such a KB gets a native manifest from the native
- * writers; this source will not see it, the native one would. Their links
- * are plain references (`linksAreManaged: false`): no principal grant is
- * written or checked, the skills' own scopes decide readability.
+ * The walker (`kb-plugin-source.ts`) calls this for every folder holding a
+ * bundle file; this reads the file and decides nothing else. READ-ONLY by
+ * construction: nothing in this directory writes. A bundle's links are plain
+ * references (`linksAreManaged: false`): no principal grant is written or
+ * checked, the skills' own scopes decide readability.
  *
- * Deleting the dialect later = this directory, its setting, and the one
- * switch arm in the composition root.
+ * Deleting the dialect later = this directory, the one `else if` in the
+ * walker that calls it, and the walker's registry load.
  */
 export const BUNDLE_FILE = 'plugin.bundle.json';
 export const DEFAULT_REGISTRY_PATH = 'configs/mcp/registry.json';
 
-export class BundlePluginSource implements PluginSource {
-  readonly dialect = 'bundle';
+/** The registry, when the repository has one; a missing file is null, a broken one warns. */
+export async function loadRegistry(kbRoot: string, warnings: string[]): Promise<McpRegistry | null> {
+  let text: string;
+  try {
+    text = await fs.readFile(path.join(kbRoot, DEFAULT_REGISTRY_PATH), 'utf-8');
+  } catch {
+    return null; // no registry: bundles without a profile are still plugins
+  }
+  const registry = parseRegistry(text);
+  warnings.push(...registry.warnings);
+  return registry;
+}
 
-  constructor(private readonly registryPath: string = DEFAULT_REGISTRY_PATH) {}
+export async function readBundlePlugin(
+  dir: string,
+  folder: string,
+  relFolder: string,
+  registry: McpRegistry | null,
+  warnings: string[],
+): Promise<DiscoveredPlugin | null> {
+  let bundle: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(await fs.readFile(path.join(dir, BUNDLE_FILE), 'utf-8'));
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('not an object');
+    bundle = parsed as Record<string, unknown>;
+  } catch {
+    warnings.push(`${folder}/${BUNDLE_FILE} is not a JSON object — plugin skipped`);
+    return null;
+  }
+  const leaf = path.posix.basename(relFolder);
+  const name = typeof bundle.name === 'string' && bundle.name.trim() ? bundle.name.trim() : leaf;
 
-  async discover(kbRoot: string): Promise<Discovery> {
-    const warnings: string[] = [];
-    const registry = await this.loadRegistry(kbRoot, warnings);
-    const root = path.join(kbRoot, PLUGINS_DIR);
-    const plugins: DiscoveredPlugin[] = [];
-    const seen = new Map<string, string>();
-    for (const rel of await walkFiles(root, (name) => name === BUNDLE_FILE)) {
-      const relFolder = path.posix.dirname(rel.replace(/\\/g, '/'));
-      const folder = relFolder === '.' ? PLUGINS_DIR : `${PLUGINS_DIR}/${relFolder}`;
-      let bundle: Record<string, unknown>;
-      try {
-        const parsed: unknown = JSON.parse(await fs.readFile(path.join(root, rel), 'utf-8'));
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('not an object');
-        bundle = parsed as Record<string, unknown>;
-      } catch {
-        warnings.push(`${folder}/${BUNDLE_FILE} is not a JSON object — plugin skipped`);
-        continue;
-      }
-      const leaf = path.posix.basename(relFolder);
-      const name = typeof bundle.name === 'string' && bundle.name.trim() ? bundle.name.trim() : leaf;
-      const twin = seen.get(name);
-      if (twin) {
-        warnings.push(`${folder}: bundle name "${name}" is already used by ${twin} — plugin skipped`);
-        continue;
-      }
-      seen.set(name, folder);
-
-      const linkedRoots: string[] = [];
-      for (const raw of Array.isArray(bundle.sourceSkillRoots) ? bundle.sourceSkillRoots : []) {
-        const normalised = normalizeSkillRoot(typeof raw === 'string' ? raw : '');
-        if (normalised === null) warnings.push(`${folder}: sourceSkillRoots entry ${JSON.stringify(raw)} is not a folder path — ignored`);
-        else if (!linkedRoots.includes(normalised)) linkedRoots.push(normalised);
-      }
-
-      let mcpServers: Record<string, unknown> | null = null;
-      if (typeof bundle.mcpProfile === 'string' && bundle.mcpProfile.trim()) {
-        if (!registry) {
-          warnings.push(`${folder}: mcpProfile "${bundle.mcpProfile}" named but no registry could be read`);
-        } else {
-          const expanded = expandProfile(registry, bundle.mcpProfile.trim());
-          warnings.push(...expanded.warnings.map((w) => `${folder}: ${w}`));
-          if (Object.keys(expanded.mcpServers).length > 0) mcpServers = expanded.mcpServers;
-        }
-      }
-
-      const ui = typeof bundle.interface === 'object' && bundle.interface !== null ? (bundle.interface as Record<string, unknown>) : {};
-      const manifest: Record<string, unknown> = { name: pluginManifestName(name) };
-      if (typeof bundle.version === 'string') manifest.version = bundle.version;
-      if (typeof bundle.description === 'string') manifest.description = bundle.description;
-      if (typeof ui.displayName === 'string') manifest.displayName = ui.displayName;
-
-      plugins.push({
-        name,
-        folder,
-        relFolder: relFolder === '.' ? '' : relFolder,
-        personal: false,
-        exists: true,
-        manifest,
-        manifestText: null,
-        linkedRoots,
-        mcpServers,
-        mcpJsonText: mcpServers ? JSON.stringify({ mcpServers }) : null,
-        linksAreManaged: false,
-      });
+  const linkedRoots: string[] = [];
+  for (const raw of Array.isArray(bundle.sourceSkillRoots) ? bundle.sourceSkillRoots : []) {
+    const normalised = normalizeSkillRoot(typeof raw === 'string' ? raw : '');
+    if (normalised === null) {
+      warnings.push(`${folder}: sourceSkillRoots entry ${JSON.stringify(raw)} is not a folder path — ignored`);
+    } else if (!linkedRoots.includes(normalised)) {
+      linkedRoots.push(normalised);
     }
-    return { plugins, warnings };
   }
 
-  private async loadRegistry(kbRoot: string, warnings: string[]): Promise<McpRegistry | null> {
-    let text: string;
-    try {
-      text = await fs.readFile(path.join(kbRoot, this.registryPath), 'utf-8');
-    } catch {
-      return null; // no registry: bundles without a profile are still plugins
+  let mcpServers: Record<string, unknown> | null = null;
+  if (typeof bundle.mcpProfile === 'string' && bundle.mcpProfile.trim()) {
+    if (!registry) {
+      warnings.push(`${folder}: mcpProfile "${bundle.mcpProfile}" named but no registry could be read`);
+    } else {
+      const expanded = expandProfile(registry, bundle.mcpProfile.trim());
+      warnings.push(...expanded.warnings.map((w) => `${folder}: ${w}`));
+      if (Object.keys(expanded.mcpServers).length > 0) mcpServers = expanded.mcpServers;
     }
-    const registry = parseRegistry(text);
-    warnings.push(...registry.warnings);
-    return registry;
   }
+
+  const ui =
+    typeof bundle.interface === 'object' && bundle.interface !== null
+      ? (bundle.interface as Record<string, unknown>)
+      : {};
+  const manifest: Record<string, unknown> = { name: pluginManifestName(name) };
+  if (typeof bundle.version === 'string') manifest.version = bundle.version;
+  if (typeof bundle.description === 'string') manifest.description = bundle.description;
+  if (typeof ui.displayName === 'string') manifest.displayName = ui.displayName;
+
+  return {
+    name,
+    folder,
+    relFolder,
+    personal: false,
+    exists: true,
+    manifest,
+    manifestText: null,
+    linkedRoots,
+    mcpServers,
+    mcpJsonText: mcpServers ? JSON.stringify({ mcpServers }) : null,
+    linksAreManaged: false,
+  };
 }

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/bundle.source.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { PLUGINS_DIR, normalizeSkillRoot, pluginManifestName } from '@bevel-software/platform-shared';
+import { walkFiles } from '../../../../shared/fs-walk.js';
+import type { DiscoveredPlugin, Discovery, PluginSource } from '../plugin-source.js';
+import { expandProfile, parseRegistry, type McpRegistry } from './registry.js';
+
+/**
+ * THE DETACHABLE PART — a customer's plugin source format, read as-is:
+ *
+ *   <pluginsRoot>/<scope…>/<plugin>/plugin.bundle.json
+ *     {
+ *       "name": "example-plugin", "version": "1.3.1", "description": "…",
+ *       "mcpProfile": "global",
+ *       "interface": { "displayName": "Example Plugin", "category": "…" },
+ *       "sourceSkillRoots": [ "skills/departments/engineering/shared/<cluster>" ]
+ *     }
+ *
+ * A bundle is a LIST OF SKILL PATHS plus a pointer into an MCP registry, at
+ * any depth under the plugins root — which is exactly the native model's
+ * "a plugin links skills" with different field names. So the dialect maps:
+ *
+ *   sourceSkillRoots   → linkedRoots          (a root is a skill or a folder of skills)
+ *   mcpProfile         → mcpServers           (expanded through the registry)
+ *   name/version/desc  → a synthesised manifest
+ *   interface.displayName → the plugin's display name
+ *
+ * READ-ONLY by construction: nothing in this directory writes. A plugin
+ * created in hexis inside such a KB gets a native manifest from the native
+ * writers; this source will not see it, the native one would. Their links
+ * are plain references (`linksAreManaged: false`): no principal grant is
+ * written or checked, the skills' own scopes decide readability.
+ *
+ * Deleting the dialect later = this directory, its setting, and the one
+ * switch arm in the composition root.
+ */
+export const BUNDLE_FILE = 'plugin.bundle.json';
+export const DEFAULT_REGISTRY_PATH = 'configs/mcp/registry.json';
+
+export class BundlePluginSource implements PluginSource {
+  readonly dialect = 'bundle';
+
+  constructor(private readonly registryPath: string = DEFAULT_REGISTRY_PATH) {}
+
+  async discover(kbRoot: string): Promise<Discovery> {
+    const warnings: string[] = [];
+    const registry = await this.loadRegistry(kbRoot, warnings);
+    const root = path.join(kbRoot, PLUGINS_DIR);
+    const plugins: DiscoveredPlugin[] = [];
+    const seen = new Map<string, string>();
+    for (const rel of await walkFiles(root, (name) => name === BUNDLE_FILE)) {
+      const relFolder = path.posix.dirname(rel.replace(/\\/g, '/'));
+      const folder = relFolder === '.' ? PLUGINS_DIR : `${PLUGINS_DIR}/${relFolder}`;
+      let bundle: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(await fs.readFile(path.join(root, rel), 'utf-8'));
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) throw new Error('not an object');
+        bundle = parsed as Record<string, unknown>;
+      } catch {
+        warnings.push(`${folder}/${BUNDLE_FILE} is not a JSON object — plugin skipped`);
+        continue;
+      }
+      const leaf = path.posix.basename(relFolder);
+      const name = typeof bundle.name === 'string' && bundle.name.trim() ? bundle.name.trim() : leaf;
+      const twin = seen.get(name);
+      if (twin) {
+        warnings.push(`${folder}: bundle name "${name}" is already used by ${twin} — plugin skipped`);
+        continue;
+      }
+      seen.set(name, folder);
+
+      const linkedRoots: string[] = [];
+      for (const raw of Array.isArray(bundle.sourceSkillRoots) ? bundle.sourceSkillRoots : []) {
+        const normalised = normalizeSkillRoot(typeof raw === 'string' ? raw : '');
+        if (normalised === null) warnings.push(`${folder}: sourceSkillRoots entry ${JSON.stringify(raw)} is not a folder path — ignored`);
+        else if (!linkedRoots.includes(normalised)) linkedRoots.push(normalised);
+      }
+
+      let mcpServers: Record<string, unknown> | null = null;
+      if (typeof bundle.mcpProfile === 'string' && bundle.mcpProfile.trim()) {
+        if (!registry) {
+          warnings.push(`${folder}: mcpProfile "${bundle.mcpProfile}" named but no registry could be read`);
+        } else {
+          const expanded = expandProfile(registry, bundle.mcpProfile.trim());
+          warnings.push(...expanded.warnings.map((w) => `${folder}: ${w}`));
+          if (Object.keys(expanded.mcpServers).length > 0) mcpServers = expanded.mcpServers;
+        }
+      }
+
+      const ui = typeof bundle.interface === 'object' && bundle.interface !== null ? (bundle.interface as Record<string, unknown>) : {};
+      const manifest: Record<string, unknown> = { name: pluginManifestName(name) };
+      if (typeof bundle.version === 'string') manifest.version = bundle.version;
+      if (typeof bundle.description === 'string') manifest.description = bundle.description;
+      if (typeof ui.displayName === 'string') manifest.displayName = ui.displayName;
+
+      plugins.push({
+        name,
+        folder,
+        relFolder: relFolder === '.' ? '' : relFolder,
+        personal: false,
+        exists: true,
+        manifest,
+        manifestText: null,
+        linkedRoots,
+        mcpServers,
+        mcpJsonText: mcpServers ? JSON.stringify({ mcpServers }) : null,
+        linksAreManaged: false,
+      });
+    }
+    return { plugins, warnings };
+  }
+
+  private async loadRegistry(kbRoot: string, warnings: string[]): Promise<McpRegistry | null> {
+    let text: string;
+    try {
+      text = await fs.readFile(path.join(kbRoot, this.registryPath), 'utf-8');
+    } catch {
+      return null; // no registry: bundles without a profile are still plugins
+    }
+    const registry = parseRegistry(text);
+    warnings.push(...registry.warnings);
+    return registry;
+  }
+}

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
@@ -151,6 +151,9 @@ function unusableConfigReason(config: Record<string, unknown>): string | null {
   const type = typeof config.type === 'string' ? config.type.toLowerCase() : undefined;
   const url = typeof config.url === 'string' ? config.url.trim() : '';
   const command = typeof config.command === 'string' ? config.command.trim() : '';
+  // A `url` key that is present but blank would still be preferred by the
+  // converter over a command; refuse it rather than emit an http entry to nowhere.
+  if (typeof config.url === 'string' && !url) return 'has an empty url';
   if (type === 'http' || type === 'streamable-http' || type === 'sse') {
     return url ? null : `has transport "${type}" but no url`;
   }

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
@@ -1,0 +1,149 @@
+/**
+ * The customer's MCP registry — `configs/mcp/registry.json` — and how a
+ * bundle's `mcpProfile` expands through it into an `mcpServers` map of the
+ * shape `mcp.json` carries.
+ *
+ * The file holds two lists:
+ *
+ *   servers   each with an `id`, a `name`, and the real config — either a
+ *             stdio launch (`command`, `args`, `env`) or `type: http` + `url`;
+ *             the config may sit under a `config` key or flat on the entry.
+ *   profiles  each with an `id`, the server ids it selects, and an optional
+ *             `extends` naming another profile (a chain, never a cycle).
+ *
+ * Pure: parse once, expand many. Unknown ids and cycles are warnings, never
+ * throws — a registry typo must not take every plugin down.
+ */
+
+export interface RegistryServer {
+  id: string;
+  name?: string;
+  config: Record<string, unknown>;
+}
+
+export interface RegistryProfile {
+  id: string;
+  servers: string[];
+  extends?: string;
+}
+
+export interface McpRegistry {
+  servers: Map<string, RegistryServer>;
+  profiles: Map<string, RegistryProfile>;
+  warnings: string[];
+}
+
+export function parseRegistry(text: string): McpRegistry {
+  const warnings: string[] = [];
+  const servers = new Map<string, RegistryServer>();
+  const profiles = new Map<string, RegistryProfile>();
+  let root: unknown;
+  try {
+    root = JSON.parse(text);
+  } catch {
+    return { servers, profiles, warnings: ['registry.json is not valid JSON'] };
+  }
+  if (!isRecord(root)) return { servers, profiles, warnings: ['registry.json must be a JSON object'] };
+
+  for (const raw of asArray(root.servers)) {
+    if (!isRecord(raw) || typeof raw.id !== 'string' || !raw.id) {
+      warnings.push('registry.json: a server without an id was skipped');
+      continue;
+    }
+    const config = isRecord(raw.config) ? raw.config : configFromFlat(raw);
+    if (!config) {
+      warnings.push(`registry.json: server "${raw.id}" has no usable config — skipped`);
+      continue;
+    }
+    servers.set(raw.id, { id: raw.id, name: typeof raw.name === 'string' ? raw.name : undefined, config });
+  }
+  for (const raw of asArray(root.profiles)) {
+    if (!isRecord(raw) || typeof raw.id !== 'string' || !raw.id) {
+      warnings.push('registry.json: a profile without an id was skipped');
+      continue;
+    }
+    profiles.set(raw.id, {
+      id: raw.id,
+      servers: asArray(raw.servers).filter((s): s is string => typeof s === 'string'),
+      extends: typeof raw.extends === 'string' ? raw.extends : undefined,
+    });
+  }
+  return { servers, profiles, warnings };
+}
+
+/**
+ * The `mcpServers` map a profile resolves to, in `mcp.json` terms: a stdio
+ * server keeps `command`/`args`/`env`/`cwd`; an http server becomes
+ * `type: streamable-http` + `url` (+ literal `headers`). Keyed by server id —
+ * the namespace vault secrets bind to, so the same registry server in three
+ * plugins shares one credential, which is what a registry means.
+ */
+export function expandProfile(
+  registry: McpRegistry,
+  profileId: string,
+): { mcpServers: Record<string, unknown>; warnings: string[] } {
+  const warnings: string[] = [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  let current: string | undefined = profileId;
+  while (current !== undefined) {
+    if (seen.has(current)) {
+      warnings.push(`registry.json: profile "${current}" extends itself through a cycle — chain cut`);
+      break;
+    }
+    seen.add(current);
+    const profile = registry.profiles.get(current);
+    if (!profile) {
+      warnings.push(`registry.json: profile "${current}" does not exist`);
+      break;
+    }
+    // Nearest profile first, so a base profile's servers come after the
+    // extending one's; the map below keeps the first occurrence of an id.
+    for (const id of profile.servers) if (!ids.includes(id)) ids.push(id);
+    current = profile.extends;
+  }
+  const mcpServers: Record<string, unknown> = {};
+  for (const id of ids) {
+    const server = registry.servers.get(id);
+    if (!server) {
+      warnings.push(`registry.json: profile "${profileId}" selects unknown server "${id}"`);
+      continue;
+    }
+    mcpServers[id] = toMcpEntry(server.config);
+  }
+  return { mcpServers, warnings };
+}
+
+/** A registry config → one `mcp.json` server entry. */
+function toMcpEntry(config: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const type = typeof config.type === 'string' ? config.type.toLowerCase() : undefined;
+  if (typeof config.url === 'string' && (type === 'http' || type === 'streamable-http' || type === 'sse' || type === undefined)) {
+    out.type = type === 'sse' ? 'sse' : 'streamable-http';
+    out.url = config.url;
+    if (isRecord(config.headers)) out.headers = config.headers;
+    return out;
+  }
+  out.type = 'stdio';
+  if (typeof config.command === 'string') out.command = config.command;
+  if (Array.isArray(config.args)) out.args = config.args.map(String);
+  if (isRecord(config.env)) out.env = config.env;
+  if (typeof config.cwd === 'string') out.cwd = config.cwd;
+  return out;
+}
+
+function configFromFlat(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const picked: Record<string, unknown> = {};
+  for (const key of ['type', 'url', 'headers', 'command', 'args', 'env', 'cwd']) {
+    if (raw[key] !== undefined) picked[key] = raw[key];
+  }
+  return typeof picked.url === 'string' || typeof picked.command === 'string' ? picked : null;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
@@ -50,9 +50,14 @@ export function parseRegistry(text: string): McpRegistry {
       warnings.push('registry.json: a server without an id was skipped');
       continue;
     }
+    if (servers.has(raw.id)) {
+      warnings.push(`registry.json: server "${raw.id}" is declared twice — the second declaration is ignored`);
+      continue;
+    }
     const config = isRecord(raw.config) ? raw.config : configFromFlat(raw);
-    if (!config) {
-      warnings.push(`registry.json: server "${raw.id}" has no usable config — skipped`);
+    const problem = config ? unusableConfigReason(config) : 'no usable config';
+    if (!config || problem) {
+      warnings.push(`registry.json: server "${raw.id}" ${problem} — skipped`);
       continue;
     }
     servers.set(raw.id, { id: raw.id, name: typeof raw.name === 'string' ? raw.name : undefined, config });
@@ -60,6 +65,10 @@ export function parseRegistry(text: string): McpRegistry {
   for (const raw of asArray(root.profiles)) {
     if (!isRecord(raw) || typeof raw.id !== 'string' || !raw.id) {
       warnings.push('registry.json: a profile without an id was skipped');
+      continue;
+    }
+    if (profiles.has(raw.id)) {
+      warnings.push(`registry.json: profile "${raw.id}" is declared twice — the second declaration is ignored`);
       continue;
     }
     profiles.set(raw.id, {
@@ -130,6 +139,24 @@ function toMcpEntry(config: Record<string, unknown>): Record<string, unknown> {
   if (isRecord(config.env)) out.env = config.env;
   if (typeof config.cwd === 'string') out.cwd = config.cwd;
   return out;
+}
+
+/**
+ * Why a config cannot become a working `mcp.json` entry, or null when it can:
+ * an http-style transport needs a non-empty `url`, anything else needs a
+ * non-empty `command`. Compiled as-is, such an entry would fail in every
+ * client that installs it.
+ */
+function unusableConfigReason(config: Record<string, unknown>): string | null {
+  const type = typeof config.type === 'string' ? config.type.toLowerCase() : undefined;
+  const url = typeof config.url === 'string' ? config.url.trim() : '';
+  const command = typeof config.command === 'string' ? config.command.trim() : '';
+  if (type === 'http' || type === 'streamable-http' || type === 'sse') {
+    return url ? null : `has transport "${type}" but no url`;
+  }
+  if (type === 'stdio') return command ? null : 'has transport "stdio" but no command';
+  if (type !== undefined) return `has an unknown transport "${type}"`;
+  return url || command ? null : 'has neither a url nor a command';
 }
 
 function configFromFlat(raw: Record<string, unknown>): Record<string, unknown> | null {

--- a/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/bundle-dialect/registry.ts
@@ -18,7 +18,8 @@
 export interface RegistryServer {
   id: string;
   name?: string;
-  config: Record<string, unknown>;
+  /** The server as one `mcp.json` entry — converted, and therefore usable, at parse time. */
+  entry: Record<string, unknown>;
 }
 
 export interface RegistryProfile {
@@ -54,13 +55,14 @@ export function parseRegistry(text: string): McpRegistry {
       warnings.push(`registry.json: server "${raw.id}" is declared twice — the second declaration is ignored`);
       continue;
     }
-    const config = isRecord(raw.config) ? raw.config : configFromFlat(raw);
-    const problem = config ? unusableConfigReason(config) : 'no usable config';
-    if (!config || problem) {
-      warnings.push(`registry.json: server "${raw.id}" ${problem} — skipped`);
+    // Converting IS the validation: a server the registry keeps is one whose
+    // entry a client can run, and nothing decides the transport twice.
+    const converted = mcpEntryOf(isRecord(raw.config) ? raw.config : raw);
+    if ('reason' in converted) {
+      warnings.push(`registry.json: server "${raw.id}" ${converted.reason} — skipped`);
       continue;
     }
-    servers.set(raw.id, { id: raw.id, name: typeof raw.name === 'string' ? raw.name : undefined, config });
+    servers.set(raw.id, { id: raw.id, name: typeof raw.name === 'string' ? raw.name : undefined, entry: converted.entry });
   }
   for (const raw of asArray(root.profiles)) {
     if (!isRecord(raw) || typeof raw.id !== 'string' || !raw.id) {
@@ -81,11 +83,10 @@ export function parseRegistry(text: string): McpRegistry {
 }
 
 /**
- * The `mcpServers` map a profile resolves to, in `mcp.json` terms: a stdio
- * server keeps `command`/`args`/`env`/`cwd`; an http server becomes
- * `type: streamable-http` + `url` (+ literal `headers`). Keyed by server id —
- * the namespace vault secrets bind to, so the same registry server in three
- * plugins shares one credential, which is what a registry means.
+ * The `mcpServers` map a profile resolves to, in `mcp.json` terms. Keyed by
+ * server id — the namespace vault secrets bind to, so the same registry
+ * server in three plugins shares one credential, which is what a registry
+ * means.
  */
 export function expandProfile(
   registry: McpRegistry,
@@ -118,56 +119,54 @@ export function expandProfile(
       warnings.push(`registry.json: profile "${profileId}" selects unknown server "${id}"`);
       continue;
     }
-    mcpServers[id] = toMcpEntry(server.config);
+    mcpServers[id] = server.entry;
   }
   return { mcpServers, warnings };
 }
 
-/** A registry config → one `mcp.json` server entry. */
-function toMcpEntry(config: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const type = typeof config.type === 'string' ? config.type.toLowerCase() : undefined;
-  if (typeof config.url === 'string' && (type === 'http' || type === 'streamable-http' || type === 'sse' || type === undefined)) {
-    out.type = type === 'sse' ? 'sse' : 'streamable-http';
-    out.url = config.url;
-    if (isRecord(config.headers)) out.headers = config.headers;
-    return out;
-  }
-  out.type = 'stdio';
-  if (typeof config.command === 'string') out.command = config.command;
-  if (Array.isArray(config.args)) out.args = config.args.map(String);
-  if (isRecord(config.env)) out.env = config.env;
-  if (typeof config.cwd === 'string') out.cwd = config.cwd;
-  return out;
-}
-
 /**
- * Why a config cannot become a working `mcp.json` entry, or null when it can:
- * an http-style transport needs a non-empty `url`, anything else needs a
- * non-empty `command`. Compiled as-is, such an entry would fail in every
- * client that installs it.
+ * A registry config → one `mcp.json` server entry, or why there is none.
+ *
+ * The transport is decided ONCE, here: a declared `type` names it, and an
+ * undeclared one is read off the fields — a `url` means http, else a
+ * `command` means stdio. Blank strings are absent, whatever the transport.
+ * An http-style server (`http`, `streamable-http`, `sse`) keeps `url` (+
+ * literal `headers`); a stdio server keeps `command`/`args`/`env`/`cwd`.
  */
-function unusableConfigReason(config: Record<string, unknown>): string | null {
-  const type = typeof config.type === 'string' ? config.type.toLowerCase() : undefined;
-  const url = typeof config.url === 'string' ? config.url.trim() : '';
-  const command = typeof config.command === 'string' ? config.command.trim() : '';
-  // A `url` key that is present but blank would still be preferred by the
-  // converter over a command; refuse it rather than emit an http entry to nowhere.
-  if (typeof config.url === 'string' && !url) return 'has an empty url';
-  if (type === 'http' || type === 'streamable-http' || type === 'sse') {
-    return url ? null : `has transport "${type}" but no url`;
+function mcpEntryOf(config: Record<string, unknown>): { entry: Record<string, unknown> } | { reason: string } {
+  const declared = typeof config.type === 'string' ? config.type.trim().toLowerCase() : undefined;
+  const url = nonBlank(config.url);
+  const command = nonBlank(config.command);
+
+  let transport: 'streamable-http' | 'sse' | 'stdio';
+  if (declared === undefined) {
+    if (url) transport = 'streamable-http';
+    else if (command) transport = 'stdio';
+    else return { reason: 'has neither a url nor a command' };
+  } else if (declared === 'http' || declared === 'streamable-http') {
+    transport = 'streamable-http';
+  } else if (declared === 'sse' || declared === 'stdio') {
+    transport = declared;
+  } else {
+    return { reason: `has an unknown transport "${declared}"` };
   }
-  if (type === 'stdio') return command ? null : 'has transport "stdio" but no command';
-  if (type !== undefined) return `has an unknown transport "${type}"`;
-  return url || command ? null : 'has neither a url nor a command';
+
+  if (transport === 'stdio') {
+    if (!command) return { reason: 'has transport "stdio" but no command' };
+    const entry: Record<string, unknown> = { type: 'stdio', command };
+    if (Array.isArray(config.args)) entry.args = config.args.map(String);
+    if (isRecord(config.env)) entry.env = config.env;
+    if (typeof config.cwd === 'string') entry.cwd = config.cwd;
+    return { entry };
+  }
+  if (!url) return { reason: `has transport "${declared}" but no url` };
+  const entry: Record<string, unknown> = { type: transport, url };
+  if (isRecord(config.headers)) entry.headers = config.headers;
+  return { entry };
 }
 
-function configFromFlat(raw: Record<string, unknown>): Record<string, unknown> | null {
-  const picked: Record<string, unknown> = {};
-  for (const key of ['type', 'url', 'headers', 'command', 'args', 'env', 'cwd']) {
-    if (raw[key] !== undefined) picked[key] = raw[key];
-  }
-  return typeof picked.url === 'string' || typeof picked.command === 'string' ? picked : null;
+function nonBlank(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {

--- a/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
@@ -11,13 +11,11 @@ import { BUNDLE_FILE, loadRegistry, readBundlePlugin } from './bundle-dialect/bu
  *
  *   plugin.json          → a native plugin (this platform's layout)
  *   plugin.bundle.json   → a bundle (the customer dialect, read-only)
- *   a folder directly    → a native plugin, manifest or not, PROVIDED nothing
- *   under the root         beneath it is a plugin — the layout this platform
- *                          has always read (provisioning seeds `access.md`
- *                          first; an `mcp.json` may sit beside a manifest that
- *                          never got written); a level-one folder that holds
- *                          plugins deeper down is a scope, not a plugin, even
- *                          when it carries an `access.md` of its own
+ *
+ * Nothing else is a plugin. A folder's POSITION means nothing: the legacy
+ * rule "everything directly under the root is a plugin" is retired by the
+ * `plugin-manifests` boot step, which writes the manifest into every such
+ * folder once, so this walker never has to guess.
  *
  * A folder that IS a plugin is not descended into (its `skills/` are its
  * own); every other folder is. When a folder carries both files the manifest
@@ -74,11 +72,7 @@ export class KbPluginSource implements PluginSource {
         .sort((a, b) => a.name.localeCompare(b.name))) {
         beneath += await visit(path.join(dir, entry.name), relFolder ? `${relFolder}/${entry.name}` : entry.name);
       }
-      if (beneath > 0 || isRoot || relFolder.includes('/')) return beneath;
-      // Directly under the root, nothing plugin-shaped beneath: a native plugin
-      // without a manifest — the shape this platform has always read.
-      claim(await readNativePlugin(dir, folder, relFolder, warnings));
-      return 1;
+      return beneath;
     };
 
     await visit(root, '');

--- a/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { PLUGINS_DIR, PLUGIN_MANIFEST_FILE } from '@bevel-software/platform-shared';
+import { PLUGINS_DIR, PLUGIN_MANIFEST_FILE, pluginManifestName } from '@bevel-software/platform-shared';
 import type { DiscoveredPlugin, Discovery, PluginSource } from './plugin-source.js';
 import { readNativePlugin } from './native.source.js';
 import { BUNDLE_FILE, loadRegistry, readBundlePlugin } from './bundle-dialect/bundle.source.js';
@@ -37,13 +37,18 @@ export class KbPluginSource implements PluginSource {
     const registry = await loadRegistry(kbRoot, warnings);
     const seen = new Map<string, string>();
 
+    // Uniqueness is judged on the MANIFEST SLUG, not the raw name: `Sales Team`
+    // and `sales-team` fold to one slug, and the slug is what the compiled
+    // marketplace keys a plugin on — two folders sharing it would be two
+    // plugins with one key and one of them silently overwritten.
     const claim = (plugin: DiscoveredPlugin): void => {
-      const twin = seen.get(plugin.name);
+      const key = pluginManifestName(plugin.name);
+      const twin = seen.get(key);
       if (twin) {
         warnings.push(`${plugin.folder}: plugin name "${plugin.name}" is already used by ${twin} — plugin skipped`);
         return;
       }
-      seen.set(plugin.name, plugin.folder);
+      seen.set(key, plugin.folder);
       plugins.push(plugin);
     };
 

--- a/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/kb-plugin-source.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { PLUGINS_DIR, PLUGIN_MANIFEST_FILE } from '@bevel-software/platform-shared';
+import type { DiscoveredPlugin, Discovery, PluginSource } from './plugin-source.js';
+import { readNativePlugin } from './native.source.js';
+import { BUNDLE_FILE, loadRegistry, readBundlePlugin } from './bundle-dialect/bundle.source.js';
+
+/**
+ * THE plugin source: walk the plugins root to any depth and read every plugin
+ * folder in whichever of the two file shapes it carries.
+ *
+ *   plugin.json          → a native plugin (this platform's layout)
+ *   plugin.bundle.json   → a bundle (the customer dialect, read-only)
+ *   a folder directly    → a native plugin, manifest or not, PROVIDED nothing
+ *   under the root         beneath it is a plugin — the layout this platform
+ *                          has always read (provisioning seeds `access.md`
+ *                          first; an `mcp.json` may sit beside a manifest that
+ *                          never got written); a level-one folder that holds
+ *                          plugins deeper down is a scope, not a plugin, even
+ *                          when it carries an `access.md` of its own
+ *
+ * A folder that IS a plugin is not descended into (its `skills/` are its
+ * own); every other folder is. When a folder carries both files the manifest
+ * wins, so a bundle migrated in place stops being read as a bundle the moment
+ * a `plugin.json` lands beside it. Two plugins with one name keep the first
+ * by path and warn about the second — a name is an identity to people and
+ * URLs, and two folders answering to it would be two plugins with one key.
+ *
+ * No setting picks a dialect. Nothing to configure means nothing to document
+ * and nothing to remove but the `else if` that reads bundles.
+ */
+export class KbPluginSource implements PluginSource {
+  readonly dialect = 'kb';
+
+  async discover(kbRoot: string): Promise<Discovery> {
+    const warnings: string[] = [];
+    const plugins: DiscoveredPlugin[] = [];
+    const root = path.join(kbRoot, PLUGINS_DIR);
+    const registry = await loadRegistry(kbRoot, warnings);
+    const seen = new Map<string, string>();
+
+    const claim = (plugin: DiscoveredPlugin): void => {
+      const twin = seen.get(plugin.name);
+      if (twin) {
+        warnings.push(`${plugin.folder}: plugin name "${plugin.name}" is already used by ${twin} — plugin skipped`);
+        return;
+      }
+      seen.set(plugin.name, plugin.folder);
+      plugins.push(plugin);
+    };
+
+    /** Visit a folder; resolves to how many plugins were found at or beneath it. */
+    const visit = async (dir: string, relFolder: string): Promise<number> => {
+      const folder = relFolder ? `${PLUGINS_DIR}/${relFolder}` : PLUGINS_DIR;
+      const isRoot = relFolder === '';
+      if (!isRoot && (await isFile(path.join(dir, PLUGIN_MANIFEST_FILE)))) {
+        claim(await readNativePlugin(dir, folder, relFolder, warnings));
+        return 1;
+      }
+      if (!isRoot && (await isFile(path.join(dir, BUNDLE_FILE)))) {
+        const bundle = await readBundlePlugin(dir, folder, relFolder, registry, warnings);
+        if (bundle) claim(bundle);
+        return 1; // unreadable: reported, and still not descended into
+      }
+      let entries: import('node:fs').Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        return 0;
+      }
+      let beneath = 0;
+      for (const entry of entries
+        .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
+        .sort((a, b) => a.name.localeCompare(b.name))) {
+        beneath += await visit(path.join(dir, entry.name), relFolder ? `${relFolder}/${entry.name}` : entry.name);
+      }
+      if (beneath > 0 || isRoot || relFolder.includes('/')) return beneath;
+      // Directly under the root, nothing plugin-shaped beneath: a native plugin
+      // without a manifest — the shape this platform has always read.
+      claim(await readNativePlugin(dir, folder, relFolder, warnings));
+      return 1;
+    };
+
+    await visit(root, '');
+    return { plugins, warnings };
+  }
+}
+
+async function isFile(abs: string): Promise<boolean> {
+  return fs.stat(abs).then((s) => s.isFile(), () => false);
+}

--- a/packages/core-backend/src/modules/plugins/discovery/native.source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/native.source.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  PLUGIN_MCP_FILE,
+  isPersonalPluginFolder,
+  linkedSkillRoots,
+} from '@bevel-software/platform-shared';
+import type { DiscoveredPlugin, Discovery, PluginSource } from './plugin-source.js';
+
+/**
+ * The layout this platform writes (see `kb-layout.ts`): one folder per
+ * plugin directly under the plugins root, carrying `plugin.json`, optionally
+ * `mcp.json`, and the `access.md` that makes it exist to the index.
+ */
+export class NativePluginSource implements PluginSource {
+  readonly dialect = 'native';
+
+  async discover(kbRoot: string): Promise<Discovery> {
+    const root = path.join(kbRoot, PLUGINS_DIR);
+    const warnings: string[] = [];
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(root, { withFileTypes: true });
+    } catch {
+      return { plugins: [], warnings }; // no plugins root — nothing to discover
+    }
+    const plugins: DiscoveredPlugin[] = [];
+    for (const entry of entries.filter((e) => e.isDirectory() && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name))) {
+      const dir = path.join(root, entry.name);
+      const manifestText = await readText(path.join(dir, PLUGIN_MANIFEST_FILE));
+      const mcpJsonText = await readText(path.join(dir, PLUGIN_MCP_FILE));
+      const manifest = parseObject(manifestText);
+      if (manifestText !== null && manifest === null) {
+        warnings.push(`${PLUGINS_DIR}/${entry.name}/${PLUGIN_MANIFEST_FILE} is not a JSON object — treated as absent`);
+      }
+      const mcp = parseObject(mcpJsonText);
+      const mcpServers =
+        mcp && typeof mcp.mcpServers === 'object' && mcp.mcpServers !== null && !Array.isArray(mcp.mcpServers)
+          ? (mcp.mcpServers as Record<string, unknown>)
+          : null;
+      const exists = await fs
+        .stat(path.join(dir, 'access.md'))
+        .then((s) => s.isFile(), () => false);
+      plugins.push({
+        name: entry.name,
+        folder: `${PLUGINS_DIR}/${entry.name}`,
+        relFolder: entry.name,
+        personal: isPersonalPluginFolder(entry.name),
+        exists,
+        manifest,
+        manifestText,
+        linkedRoots: linkedSkillRoots(manifest),
+        mcpServers,
+        mcpJsonText,
+        linksAreManaged: true,
+      });
+    }
+    return { plugins, warnings };
+  }
+}
+
+async function readText(abs: string): Promise<string | null> {
+  try {
+    return await fs.readFile(abs, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function parseObject(text: string | null): Record<string, unknown> | null {
+  if (text === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core-backend/src/modules/plugins/discovery/native.source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/native.source.ts
@@ -1,64 +1,52 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
-  PLUGINS_DIR,
   PLUGIN_MANIFEST_FILE,
   PLUGIN_MCP_FILE,
   isPersonalPluginFolder,
   linkedSkillRoots,
 } from '@bevel-software/platform-shared';
-import type { DiscoveredPlugin, Discovery, PluginSource } from './plugin-source.js';
+import type { DiscoveredPlugin } from './plugin-source.js';
 
 /**
- * The layout this platform writes (see `kb-layout.ts`): one folder per
- * plugin directly under the plugins root, carrying `plugin.json`, optionally
- * `mcp.json`, and the `access.md` that makes it exist to the index.
+ * A plugin in the layout this platform writes (see `kb-layout.ts`): a folder
+ * carrying `plugin.json`, optionally `mcp.json`, and the `access.md` that
+ * makes it exist to the index. Called by the walker for every folder it
+ * decides is a native plugin; reads the files, decides nothing else.
  */
-export class NativePluginSource implements PluginSource {
-  readonly dialect = 'native';
-
-  async discover(kbRoot: string): Promise<Discovery> {
-    const root = path.join(kbRoot, PLUGINS_DIR);
-    const warnings: string[] = [];
-    let entries: import('node:fs').Dirent[];
-    try {
-      entries = await fs.readdir(root, { withFileTypes: true });
-    } catch {
-      return { plugins: [], warnings }; // no plugins root — nothing to discover
-    }
-    const plugins: DiscoveredPlugin[] = [];
-    for (const entry of entries.filter((e) => e.isDirectory() && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name))) {
-      const dir = path.join(root, entry.name);
-      const manifestText = await readText(path.join(dir, PLUGIN_MANIFEST_FILE));
-      const mcpJsonText = await readText(path.join(dir, PLUGIN_MCP_FILE));
-      const manifest = parseObject(manifestText);
-      if (manifestText !== null && manifest === null) {
-        warnings.push(`${PLUGINS_DIR}/${entry.name}/${PLUGIN_MANIFEST_FILE} is not a JSON object — treated as absent`);
-      }
-      const mcp = parseObject(mcpJsonText);
-      const mcpServers =
-        mcp && typeof mcp.mcpServers === 'object' && mcp.mcpServers !== null && !Array.isArray(mcp.mcpServers)
-          ? (mcp.mcpServers as Record<string, unknown>)
-          : null;
-      const exists = await fs
-        .stat(path.join(dir, 'access.md'))
-        .then((s) => s.isFile(), () => false);
-      plugins.push({
-        name: entry.name,
-        folder: `${PLUGINS_DIR}/${entry.name}`,
-        relFolder: entry.name,
-        personal: isPersonalPluginFolder(entry.name),
-        exists,
-        manifest,
-        manifestText,
-        linkedRoots: linkedSkillRoots(manifest),
-        mcpServers,
-        mcpJsonText,
-        linksAreManaged: true,
-      });
-    }
-    return { plugins, warnings };
+export async function readNativePlugin(
+  dir: string,
+  folder: string,
+  relFolder: string,
+  warnings: string[],
+): Promise<DiscoveredPlugin> {
+  const name = path.posix.basename(relFolder);
+  const manifestText = await readText(path.join(dir, PLUGIN_MANIFEST_FILE));
+  const mcpJsonText = await readText(path.join(dir, PLUGIN_MCP_FILE));
+  const manifest = parseObject(manifestText);
+  if (manifestText !== null && manifest === null) {
+    warnings.push(`${folder}/${PLUGIN_MANIFEST_FILE} is not a JSON object — treated as absent`);
   }
+  const mcp = parseObject(mcpJsonText);
+  const mcpServers =
+    mcp && typeof mcp.mcpServers === 'object' && mcp.mcpServers !== null && !Array.isArray(mcp.mcpServers)
+      ? (mcp.mcpServers as Record<string, unknown>)
+      : null;
+  const exists = await fs.stat(path.join(dir, 'access.md')).then((s) => s.isFile(), () => false);
+  return {
+    name,
+    folder,
+    relFolder,
+    // Personal folders sit directly under the root; a deeper `personal-x` is just a name.
+    personal: !relFolder.includes('/') && isPersonalPluginFolder(name),
+    exists,
+    manifest,
+    manifestText,
+    linkedRoots: linkedSkillRoots(manifest),
+    mcpServers,
+    mcpJsonText,
+    linksAreManaged: true,
+  };
 }
 
 async function readText(abs: string): Promise<string | null> {

--- a/packages/core-backend/src/modules/plugins/discovery/plugin-source.ts
+++ b/packages/core-backend/src/modules/plugins/discovery/plugin-source.ts
@@ -1,0 +1,68 @@
+/**
+ * Plugin DISCOVERY as an interface — the one seam between "what a plugin is
+ * on disk" and everything that consumes plugins (the plugin index, the link
+ * index, the tool-manual scanner, the compiler).
+ *
+ * Two providers implement it:
+ *
+ *   - `native.source.ts`  — the Agent Plugins layout this platform writes:
+ *                           `Plugins/<Name>/plugin.json` (+ `mcp.json`,
+ *                           `access.md`, the hexis extension block).
+ *   - `bundle-dialect/`   — a customer's source layout: `plugin.bundle.json`
+ *                           files at any depth, pointing at skill roots and at
+ *                           an MCP profile in a registry. Read-only, and
+ *                           deletable as a unit once that customer migrates.
+ *
+ * Consumers see only {@link DiscoveredPlugin}: parsed objects, never files.
+ * A provider that reads a different file shape changes nothing downstream.
+ */
+export interface DiscoveredPlugin {
+  /**
+   * The plugin's identity everywhere a person or a URL names it — the folder
+   * name for a native plugin; the bundle's `name` (or its leaf folder) for a
+   * dialect plugin. Unique per source.
+   */
+  name: string;
+  /** Repo-relative folder holding the plugin, e.g. `Plugins/GTM`. */
+  folder: string;
+  /** The same folder relative to the plugins root, e.g. `GTM` or `functional/x/y`. */
+  relFolder: string;
+  /** A personal folder (`Plugins/personal-<id>`): a place, not a plugin. */
+  personal: boolean;
+  /**
+   * Whether the plugin EXISTS by the index's rule. Native: its folder carries
+   * an `access.md` (a bare directory is a ghost git left behind). Dialect:
+   * always — the bundle file is the existence.
+   */
+  exists: boolean;
+  /** The Agent Plugins manifest, parsed (a dialect synthesises one). Null when absent or unparsable. */
+  manifest: Record<string, unknown> | null;
+  /** The manifest's raw text, for readers that want the extension block verbatim (native only). */
+  manifestText: string | null;
+  /** Repo-relative roots the plugin LINKS skills from — a skill folder or a folder of skills. */
+  linkedRoots: string[];
+  /** The `mcpServers` map of the plugin's `mcp.json`, parsed; null when it has none. */
+  mcpServers: Record<string, unknown> | null;
+  /** The raw `mcp.json` text, when it exists on disk (native only). */
+  mcpJsonText: string | null;
+  /**
+   * Whether hexis manages this plugin's links — writes them, grants the
+   * plugin's principal on the skill, reports a missing grant as needing
+   * repair. False for a dialect, whose links are plain references and whose
+   * skills' own scopes decide readability.
+   */
+  linksAreManaged: boolean;
+}
+
+export interface Discovery {
+  plugins: DiscoveredPlugin[];
+  /** What was skipped and why — unparsable files, unknown profiles. */
+  warnings: string[];
+}
+
+export interface PluginSource {
+  /** A short name for logs and the settings screen. */
+  readonly dialect: string;
+  /** Enumerate the plugins in a KB checkout. Never throws: a broken tree yields warnings. */
+  discover(kbRoot: string): Promise<Discovery>;
+}

--- a/packages/core-backend/src/modules/plugins/index.ts
+++ b/packages/core-backend/src/modules/plugins/index.ts
@@ -11,8 +11,8 @@ export { PluginLinksService, PluginLinkError } from './plugin-links.service.js';
 export { compileMarketplace, type VirtualTree, type CompileInput, type MarketplaceOptions } from './compile/compile-marketplace.js';
 export { MarketplaceCompilerService, type CompileAudience } from './compile/marketplace-compiler.service.js';
 export type { PluginSource, DiscoveredPlugin, Discovery } from './discovery/plugin-source.js';
-export { NativePluginSource } from './discovery/native.source.js';
-export { BundlePluginSource, DEFAULT_REGISTRY_PATH } from './discovery/bundle-dialect/bundle.source.js';
+export { KbPluginSource } from './discovery/kb-plugin-source.js';
+export { DEFAULT_REGISTRY_PATH } from './discovery/bundle-dialect/bundle.source.js';
 export { pendingProposals, type JoinProposal } from './join-proposals.js';
 export { createPluginsRoutes } from './plugins.routes.js';
 export type {

--- a/packages/core-backend/src/modules/plugins/index.ts
+++ b/packages/core-backend/src/modules/plugins/index.ts
@@ -8,6 +8,8 @@ export {
 export { JoinRequestsService, type JoinRequest } from './join-requests.service.js';
 export { PluginLinkIndex, type LinkMembership, type PluginLinks } from './plugin-links.js';
 export { PluginLinksService, PluginLinkError } from './plugin-links.service.js';
+export { compileMarketplace, type VirtualTree, type CompileInput, type MarketplaceOptions } from './compile/compile-marketplace.js';
+export { MarketplaceCompilerService, type CompileAudience } from './compile/marketplace-compiler.service.js';
 export { pendingProposals, type JoinProposal } from './join-proposals.js';
 export { createPluginsRoutes } from './plugins.routes.js';
 export type {

--- a/packages/core-backend/src/modules/plugins/index.ts
+++ b/packages/core-backend/src/modules/plugins/index.ts
@@ -10,6 +10,9 @@ export { PluginLinkIndex, type LinkMembership, type PluginLinks } from './plugin
 export { PluginLinksService, PluginLinkError } from './plugin-links.service.js';
 export { compileMarketplace, type VirtualTree, type CompileInput, type MarketplaceOptions } from './compile/compile-marketplace.js';
 export { MarketplaceCompilerService, type CompileAudience } from './compile/marketplace-compiler.service.js';
+export type { PluginSource, DiscoveredPlugin, Discovery } from './discovery/plugin-source.js';
+export { NativePluginSource } from './discovery/native.source.js';
+export { BundlePluginSource, DEFAULT_REGISTRY_PATH } from './discovery/bundle-dialect/bundle.source.js';
 export { pendingProposals, type JoinProposal } from './join-proposals.js';
 export { createPluginsRoutes } from './plugins.routes.js';
 export type {

--- a/packages/core-backend/src/modules/plugins/index.ts
+++ b/packages/core-backend/src/modules/plugins/index.ts
@@ -6,11 +6,14 @@ export {
   personalAccessMd,
 } from './plugin-provision.service.js';
 export { JoinRequestsService, type JoinRequest } from './join-requests.service.js';
+export { PluginLinkIndex, type LinkMembership, type PluginLinks } from './plugin-links.js';
+export { PluginLinksService, PluginLinkError } from './plugin-links.service.js';
 export { pendingProposals, type JoinProposal } from './join-proposals.js';
 export { createPluginsRoutes } from './plugins.routes.js';
 export type {
   IPluginIndexService,
   PluginCatalogEntry,
+  PluginMembership,
   PluginSummary,
   ResolvedPrincipals,
   ResolvedReaders,

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -1,0 +1,272 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_BRANCH,
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  isPersonalPluginFolder,
+  linkedSkillRoots,
+  normalizeSkillRoot,
+  pluginManifestName,
+  renderPluginManifest,
+  skillUnderRoot,
+  withLinkedSkillRoots,
+  type AuthUser,
+} from '@bevel-software/platform-shared';
+import type { WorkspaceService } from '../workspace/workspace.service.js';
+import type { IAccessControl } from '../access/access-control.interface.js';
+import { AccessMutationService, accessMdPathForFolder } from '../access/access-mutation.service.js';
+import { PLUGIN_TOKEN_PREFIX } from '../access-model/access-grammar.js';
+import type { Principal } from '../access-model/access-splice.js';
+import { WorkspaceMutex } from '../kb-fs/mutex.js';
+import type { ISkillService } from '../skills/skills.contract.js';
+import type { ProvisionCommitDriver } from './plugin-provision.service.js';
+import { linksWorkspaceId, type PluginLinkIndex } from './plugin-links.js';
+
+/** A refusal the route passes through: message + HTTP status + a machine-readable kind. */
+export class PluginLinkError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly payload: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'PluginLinkError';
+  }
+}
+
+/**
+ * Linking shared skills into plugins — the writer behind "add an existing
+ * skill to this plugin".
+ *
+ * A link is TWO edits that only make sense together:
+ *
+ *   1. the skill's root goes into the plugin manifest's
+ *      `extensions["software.bevel.hexis"].skills` list (see
+ *      `HEXIS_LINKED_SKILLS_KEY`), which is what the catalog, the plugin page
+ *      and the compiled distribution read;
+ *   2. the skill folder's own `access.md` grants `read` to
+ *      `plugin/<Name>/read` and `write` to `plugin/<Name>/write`, which is
+ *      what lets the plugin's members actually read it — ownership decides,
+ *      the plugin is a view (see `plugin-principals.ts`).
+ *
+ * Which is why linking needs write on BOTH sides: on the plugin folder (to
+ * edit its manifest) and on the skill's root (to edit its access rules). A
+ * manager who lacks the second gets a 409 the UI turns into "request write
+ * access", not a link that silently shares nothing.
+ *
+ * Unlinking removes the manifest entry, and revokes the two tokens only when
+ * the actor may edit the skill's rules — otherwise the grant stays, and the
+ * skill page says so, for a skill editor to remove.
+ *
+ * Repair re-grants the tokens for a link that exists but whose grant was
+ * hand-removed: the amber dot's one action.
+ *
+ * Every operation is serialised on the plugin's manifest slug (the same key
+ * provisioning locks on) and lands as ordinary default-branch commits through
+ * the pending-commit driver, so the write gate and the per-user push gate
+ * apply exactly as they do to any edit.
+ */
+export class PluginLinksService {
+  private readonly locks = new WorkspaceMutex();
+  private readonly mutation: AccessMutationService;
+
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly commits: ProvisionCommitDriver,
+    private readonly accessControl: IAccessControl,
+    private readonly skillService: ISkillService,
+    private readonly links: PluginLinkIndex,
+    private readonly kbDirName: string,
+    private readonly events?: {
+      emit(event: { kind: 'fs-tree-changed'; workspaceId: string; branch: string }): void;
+    },
+    private readonly onChanged?: () => void,
+  ) {
+    this.mutation = new AccessMutationService(workspaceService, accessControl, kbDirName);
+  }
+
+  async link(user: AuthUser, plugin: string, rawRoot: string): Promise<{ root: string; skills: string[] }> {
+    const folder = await this.pluginFolder(plugin);
+    const root = this.rootOrThrow(rawRoot);
+    const wsId = linksWorkspaceId();
+    await this.requirePluginWrite(wsId, user, folder);
+    const skills = await this.resolvedSkills(root);
+    if (skills.length === 0) {
+      throw new PluginLinkError(
+        `"${root}" holds no released skill. Link a skill folder, or a folder that contains skills.`,
+        422,
+        { kind: 'no-skills', root },
+      );
+    }
+    if (!(await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root)))) {
+      // The manager may edit the plugin but not the skill's rules — the link
+      // would share nothing. The UI offers the request path on this shape.
+      throw new PluginLinkError(
+        `You can't change who may read "${root}". Ask its editors for write access first.`,
+        409,
+        { kind: 'needs-skill-write', root },
+      );
+    }
+    return this.locks.run(`plugin:${pluginManifestName(folder)}`, async () => {
+      const { manifest, manifestRel } = await this.readManifest(wsId, folder);
+      const roots = linkedSkillRoots(manifest);
+      if (!roots.includes(root)) {
+        await this.workspaceService.writeFile(
+          wsId,
+          manifestRel,
+          `${JSON.stringify(withLinkedSkillRoots(manifest, [...roots, root]), null, 2)}\n`,
+        );
+        await this.commits.runPendingCommit(wsId, DEFAULT_BRANCH, manifestRel, user);
+      }
+      await this.grantTokens(wsId, user, folder, root);
+      this.changed(wsId);
+      return { root, skills };
+    });
+  }
+
+  async unlink(user: AuthUser, plugin: string, rawRoot: string): Promise<{ root: string; revoked: boolean }> {
+    const folder = await this.pluginFolder(plugin);
+    const root = this.rootOrThrow(rawRoot);
+    const wsId = linksWorkspaceId();
+    await this.requirePluginWrite(wsId, user, folder);
+    return this.locks.run(`plugin:${pluginManifestName(folder)}`, async () => {
+      const { manifest, manifestRel } = await this.readManifest(wsId, folder);
+      const roots = linkedSkillRoots(manifest);
+      if (!roots.includes(root)) {
+        throw new PluginLinkError(`"${root}" is not linked into ${folder}.`, 404, { kind: 'not-linked', root });
+      }
+      await this.workspaceService.writeFile(
+        wsId,
+        manifestRel,
+        `${JSON.stringify(withLinkedSkillRoots(manifest, roots.filter((r) => r !== root)), null, 2)}\n`,
+      );
+      await this.commits.runPendingCommit(wsId, DEFAULT_BRANCH, manifestRel, user);
+
+      // Revoke only where the actor may edit the skill's rules; otherwise the
+      // grant stays for a skill editor to remove — never a silent no-op that
+      // pretends it happened.
+      let revoked = false;
+      if (await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root))) {
+        let changed = false;
+        for (const principal of this.tokens(folder)) {
+          const r = await this.mutation.revoke(wsId, 'folder', root, principal, user.email, undefined, {
+            tokenMatch: 'exact',
+          });
+          changed ||= r.changed;
+        }
+        if (changed) {
+          await this.commits.runPendingCommit(
+            wsId,
+            DEFAULT_BRANCH,
+            `${this.kbDirName}/${accessMdPathForFolder(root)}`,
+            user,
+          );
+        }
+        revoked = true;
+      }
+      this.changed(wsId);
+      return { root, revoked };
+    });
+  }
+
+  async repair(user: AuthUser, plugin: string, rawRoot: string): Promise<{ root: string }> {
+    const folder = await this.pluginFolder(plugin);
+    const root = this.rootOrThrow(rawRoot);
+    const wsId = linksWorkspaceId();
+    const { manifest } = await this.readManifest(wsId, folder);
+    if (!linkedSkillRoots(manifest).includes(root)) {
+      throw new PluginLinkError(`"${root}" is not linked into ${folder}.`, 404, { kind: 'not-linked', root });
+    }
+    if (!(await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root)))) {
+      throw new PluginLinkError(`You can't change who may read "${root}".`, 403, {
+        kind: 'needs-skill-write',
+        root,
+      });
+    }
+    return this.locks.run(`plugin:${pluginManifestName(folder)}`, async () => {
+      await this.grantTokens(wsId, user, folder, root);
+      this.changed(wsId);
+      return { root };
+    });
+  }
+
+  // --- internal --------------------------------------------------------------
+
+  /** The two grants a link carries: members read, managers write. */
+  private tokens(folder: string): Principal[] {
+    return [
+      { kind: 'role', role: `${PLUGIN_TOKEN_PREFIX}${folder}/read` },
+      { kind: 'role', role: `${PLUGIN_TOKEN_PREFIX}${folder}/write` },
+    ];
+  }
+
+  private async grantTokens(wsId: string, user: AuthUser, folder: string, root: string): Promise<void> {
+    const [read, write] = this.tokens(folder);
+    const a = await this.mutation.grant(wsId, 'folder', root, 'read', read);
+    const b = await this.mutation.grant(wsId, 'folder', root, 'write', write);
+    if (a.changed || b.changed) {
+      await this.commits.runPendingCommit(wsId, DEFAULT_BRANCH, `${this.kbDirName}/${a.editPath}`, user);
+    }
+  }
+
+  private rootOrThrow(raw: string): string {
+    const root = normalizeSkillRoot(raw);
+    if (root === null) {
+      throw new PluginLinkError('A skill path must be a repo-relative folder path.', 422, { kind: 'bad-root' });
+    }
+    return root;
+  }
+
+  /** Released skills under the root — the catalog's answer, not the file system's. */
+  private async resolvedSkills(root: string): Promise<string[]> {
+    return (await this.skillService.listSkills(undefined))
+      .map((s) => s.path)
+      .filter((p) => skillUnderRoot(p, root));
+  }
+
+  /** The exact on-disk plugin folder for `name`, or 404 — personal folders are not plugins. */
+  private async pluginFolder(name: string): Promise<string> {
+    const trimmed = name.trim();
+    if (!trimmed || isPersonalPluginFolder(trimmed) || trimmed.includes('/') || trimmed.includes('\\')) {
+      throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
+    }
+    const membership = await this.links.membership();
+    if (!membership.byPlugin.has(trimmed)) {
+      throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
+    }
+    return trimmed;
+  }
+
+  private async requirePluginWrite(wsId: string, user: AuthUser, folder: string): Promise<void> {
+    if (!(await this.accessControl.canWrite(wsId, user.email, `${PLUGINS_DIR}/${folder}`))) {
+      // Same answer as an unknown plugin, so probing confirms nothing.
+      throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
+    }
+  }
+
+  private async readManifest(
+    wsId: string,
+    folder: string,
+  ): Promise<{ manifest: Record<string, unknown>; manifestRel: string }> {
+    const manifestRel = `${this.kbDirName}/${PLUGINS_DIR}/${folder}/${PLUGIN_MANIFEST_FILE}`;
+    const abs = path.join(await this.workspaceService.getWorkspacePath(wsId), manifestRel);
+    let manifest: Record<string, unknown> | null = null;
+    try {
+      const parsed: unknown = JSON.parse(await fs.readFile(abs, 'utf-8'));
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        manifest = parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* absent or unparsable — a pre-manifest folder gets a fresh minimal manifest */
+    }
+    return { manifest: manifest ?? (JSON.parse(renderPluginManifest(folder)) as Record<string, unknown>), manifestRel };
+  }
+
+  private changed(wsId: string): void {
+    this.links.invalidate();
+    this.accessControl.invalidate(wsId);
+    this.onChanged?.();
+    this.events?.emit({ kind: 'fs-tree-changed', workspaceId: wsId, branch: DEFAULT_BRANCH });
+  }
+}

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -232,8 +232,17 @@ export class PluginLinksService {
       throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
     }
     const membership = await this.links.membership();
-    if (!membership.byPlugin.has(trimmed)) {
+    const links = membership.byPlugin.get(trimmed);
+    if (!links) {
       throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
+    }
+    if (!links.linksAreManaged) {
+      // A dialect plugin's links live in a file this platform does not write.
+      throw new PluginLinkError(
+        `${trimmed} is read from an external plugin format; edit its links in that repository.`,
+        409,
+        { kind: 'read-only-links' },
+      );
     }
     return trimmed;
   }

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -198,6 +198,8 @@ export class PluginLinksService {
           root,
         });
       }
+      // The same retired-skill rule as `link`: a repair re-grants on the root.
+      await this.resolvedSkills(root);
       await this.grantTokens(wsId, user, folder, root);
       this.changed(wsId);
       return { root };
@@ -233,14 +235,23 @@ export class PluginLinksService {
 
   /**
    * Released skills under the root — the catalog's answer, not the file
-   * system's. A RETIRED skill is kept for its owners and never shared onward,
-   * so it does not count as something a link could reach.
+   * system's. A RETIRED skill is kept for its owners and never shared onward:
+   * the grant lands on the ROOT folder, so a root that holds a retired skill
+   * anywhere beneath it cannot be linked at all — the grant would reach the
+   * retired one too. The refusal names them so the manager can link the
+   * active skills individually instead.
    */
   private async resolvedSkills(root: string): Promise<string[]> {
-    return (await this.skillService.listSkills(undefined))
-      .filter((s) => s.lifecycle !== 'retired')
-      .map((s) => s.path)
-      .filter((p) => skillUnderRoot(p, root));
+    const under = (await this.skillService.listSkills(undefined)).filter((s) => skillUnderRoot(s.path, root));
+    const retired = under.filter((s) => s.lifecycle === 'retired').map((s) => s.path);
+    if (retired.length > 0) {
+      throw new PluginLinkError(
+        `"${root}" holds retired skills (${retired.join(', ')}); a retired skill is never shared onward. Link the active skills one by one.`,
+        422,
+        { kind: 'retired-skills', root, retired },
+      );
+    }
+    return under.map((s) => s.path);
   }
 
   /** The exact on-disk plugin folder for `name`, or 404 — personal folders are not plugins. */

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -231,9 +231,14 @@ export class PluginLinksService {
     return root;
   }
 
-  /** Released skills under the root — the catalog's answer, not the file system's. */
+  /**
+   * Released skills under the root — the catalog's answer, not the file
+   * system's. A RETIRED skill is kept for its owners and never shared onward,
+   * so it does not count as something a link could reach.
+   */
   private async resolvedSkills(root: string): Promise<string[]> {
     return (await this.skillService.listSkills(undefined))
+      .filter((s) => s.lifecycle !== 'retired')
       .map((s) => s.path)
       .filter((p) => skillUnderRoot(p, root));
   }
@@ -282,13 +287,33 @@ export class PluginLinksService {
     const manifestRel = `${this.kbDirName}/${folder}/${PLUGIN_MANIFEST_FILE}`;
     const abs = path.join(await this.workspaceService.getWorkspacePath(wsId), manifestRel);
     let manifest: Record<string, unknown> | null = null;
+    let text: string | null = null;
     try {
-      const parsed: unknown = JSON.parse(await fs.readFile(abs, 'utf-8'));
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        manifest = parsed as Record<string, unknown>;
+      text = await fs.readFile(abs, 'utf-8');
+    } catch (err) {
+      // Only a PROVEN absence gets the fresh minimal manifest a pre-manifest
+      // folder deserves. Any other failure must surface: the caller writes the
+      // manifest back, and a skeleton over a real one would erase its
+      // version, description and MCP extension block.
+      const code = (err as { code?: unknown } | null)?.code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw err;
+    }
+    if (text !== null) {
+      try {
+        const parsed: unknown = JSON.parse(text);
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          manifest = parsed as Record<string, unknown>;
+        }
+      } catch {
+        /* unparsable */
       }
-    } catch {
-      /* absent or unparsable — a pre-manifest folder gets a fresh minimal manifest */
+      if (manifest === null) {
+        throw new PluginLinkError(
+          `${manifestRel} is not a JSON object; fix the manifest before changing its links.`,
+          422,
+          { kind: 'bad-manifest' },
+        );
+      }
     }
     return {
       manifest: manifest ?? (JSON.parse(renderPluginManifest(path.posix.basename(folder))) as Record<string, unknown>),

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -110,6 +110,14 @@ export class PluginLinksService {
     return this.locks.run(`plugin:${pluginManifestName(folder)}`, async () => {
       const { manifest, manifestRel } = await this.readManifest(wsId, folder);
       const roots = linkedSkillRoots(manifest);
+      // Manifest FIRST, grant second — two commits, deliberately in this
+      // order. The two files live in different folders and the commit
+      // pipeline is path-scoped, so there is no single commit to be had; what
+      // can be chosen is which half-state a failure leaves. Listed-but-not-
+      // shared is the visible one: the link index reports the missing grant,
+      // the card wears the amber dot, and Repair finishes the job. The other
+      // order would leave shared-but-not-listed — an over-share nothing
+      // surfaces.
       if (!roots.includes(root)) {
         await this.workspaceService.writeFile(
           wsId,
@@ -135,16 +143,13 @@ export class PluginLinksService {
       if (!roots.includes(root)) {
         throw new PluginLinkError(`"${root}" is not linked into ${folder}.`, 404, { kind: 'not-linked', root });
       }
-      await this.workspaceService.writeFile(
-        wsId,
-        manifestRel,
-        `${JSON.stringify(withLinkedSkillRoots(manifest, roots.filter((r) => r !== root)), null, 2)}\n`,
-      );
-      await this.commits.runPendingCommit(wsId, DEFAULT_BRANCH, manifestRel, user);
 
-      // Revoke only where the actor may edit the skill's rules; otherwise the
-      // grant stays for a skill editor to remove — never a silent no-op that
-      // pretends it happened.
+      // Revoke FIRST, manifest second — the mirror of `link`'s ordering and
+      // for the same reason: a failure between the two must leave the
+      // visible half-state (listed, no grant → amber dot, Repair), never the
+      // silent one (unlisted, still shared). Revoke only where the actor may
+      // edit the skill's rules; otherwise the grant stays for a skill editor
+      // to remove — never a silent no-op that pretends it happened.
       let revoked = false;
       if (await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root))) {
         let changed = false;
@@ -164,6 +169,12 @@ export class PluginLinksService {
         }
         revoked = true;
       }
+      await this.workspaceService.writeFile(
+        wsId,
+        manifestRel,
+        `${JSON.stringify(withLinkedSkillRoots(manifest, roots.filter((r) => r !== root)), null, 2)}\n`,
+      );
+      await this.commits.runPendingCommit(wsId, DEFAULT_BRANCH, manifestRel, user);
       this.changed(wsId);
       return { root, revoked };
     });
@@ -173,17 +184,20 @@ export class PluginLinksService {
     const folder = await this.pluginFolder(plugin);
     const root = this.rootOrThrow(rawRoot);
     const wsId = linksWorkspaceId();
-    const { manifest } = await this.readManifest(wsId, folder);
-    if (!linkedSkillRoots(manifest).includes(root)) {
-      throw new PluginLinkError(`"${root}" is not linked into ${folder}.`, 404, { kind: 'not-linked', root });
-    }
-    if (!(await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root)))) {
-      throw new PluginLinkError(`You can't change who may read "${root}".`, 403, {
-        kind: 'needs-skill-write',
-        root,
-      });
-    }
+    // Everything under the lock, the manifest read included: a repair that
+    // checked the link and then waited on an unlink would re-grant a root the
+    // manifest no longer names.
     return this.locks.run(`plugin:${pluginManifestName(folder)}`, async () => {
+      const { manifest } = await this.readManifest(wsId, folder);
+      if (!linkedSkillRoots(manifest).includes(root)) {
+        throw new PluginLinkError(`"${root}" is not linked into ${folder}.`, 404, { kind: 'not-linked', root });
+      }
+      if (!(await this.accessControl.canWrite(wsId, user.email, accessMdPathForFolder(root)))) {
+        throw new PluginLinkError(`You can't change who may read "${root}".`, 403, {
+          kind: 'needs-skill-write',
+          root,
+        });
+      }
       await this.grantTokens(wsId, user, folder, root);
       this.changed(wsId);
       return { root };

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -244,6 +244,17 @@ export class PluginLinksService {
         { kind: 'read-only-links' },
       );
     }
+    if (links.folder !== `${PLUGINS_DIR}/${trimmed}`) {
+      // The plugin principal (`plugin/<Name>/read`) is synthesised for folders
+      // DIRECTLY under the plugins root; a native plugin nested deeper reads
+      // and compiles like any other, but a grant naming it would resolve to
+      // nobody — so linking through hexis stops here rather than share nothing.
+      throw new PluginLinkError(
+        `${trimmed} sits at ${links.folder}; only plugins directly under ${PLUGINS_DIR}/ can link skills through hexis.`,
+        409,
+        { kind: 'nested-plugin' },
+      );
+    }
     return trimmed;
   }
 

--- a/packages/core-backend/src/modules/plugins/plugin-links.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.service.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
   DEFAULT_BRANCH,
-  PLUGINS_DIR,
   PLUGIN_MANIFEST_FILE,
   isPersonalPluginFolder,
   linkedSkillRoots,
@@ -244,22 +243,18 @@ export class PluginLinksService {
         { kind: 'read-only-links' },
       );
     }
-    if (links.folder !== `${PLUGINS_DIR}/${trimmed}`) {
-      // The plugin principal (`plugin/<Name>/read`) is synthesised for folders
-      // DIRECTLY under the plugins root; a native plugin nested deeper reads
-      // and compiles like any other, but a grant naming it would resolve to
-      // nobody — so linking through hexis stops here rather than share nothing.
-      throw new PluginLinkError(
-        `${trimmed} sits at ${links.folder}; only plugins directly under ${PLUGINS_DIR}/ can link skills through hexis.`,
-        409,
-        { kind: 'nested-plugin' },
-      );
-    }
     return trimmed;
   }
 
-  private async requirePluginWrite(wsId: string, user: AuthUser, folder: string): Promise<void> {
-    if (!(await this.accessControl.canWrite(wsId, user.email, `${PLUGINS_DIR}/${folder}`))) {
+  /** The repo-relative folder of a known plugin (any depth). */
+  private async folderOf(plugin: string): Promise<string> {
+    const links = (await this.links.membership()).byPlugin.get(plugin);
+    if (!links) throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
+    return links.folder;
+  }
+
+  private async requirePluginWrite(wsId: string, user: AuthUser, plugin: string): Promise<void> {
+    if (!(await this.accessControl.canWrite(wsId, user.email, await this.folderOf(plugin)))) {
       // Same answer as an unknown plugin, so probing confirms nothing.
       throw new PluginLinkError('Unknown plugin', 404, { kind: 'unknown-plugin' });
     }
@@ -267,9 +262,10 @@ export class PluginLinksService {
 
   private async readManifest(
     wsId: string,
-    folder: string,
+    plugin: string,
   ): Promise<{ manifest: Record<string, unknown>; manifestRel: string }> {
-    const manifestRel = `${this.kbDirName}/${PLUGINS_DIR}/${folder}/${PLUGIN_MANIFEST_FILE}`;
+    const folder = await this.folderOf(plugin);
+    const manifestRel = `${this.kbDirName}/${folder}/${PLUGIN_MANIFEST_FILE}`;
     const abs = path.join(await this.workspaceService.getWorkspacePath(wsId), manifestRel);
     let manifest: Record<string, unknown> | null = null;
     try {
@@ -280,7 +276,10 @@ export class PluginLinksService {
     } catch {
       /* absent or unparsable — a pre-manifest folder gets a fresh minimal manifest */
     }
-    return { manifest: manifest ?? (JSON.parse(renderPluginManifest(folder)) as Record<string, unknown>), manifestRel };
+    return {
+      manifest: manifest ?? (JSON.parse(renderPluginManifest(path.posix.basename(folder))) as Record<string, unknown>),
+      manifestRel,
+    };
   }
 
   private changed(wsId: string): void {

--- a/packages/core-backend/src/modules/plugins/plugin-links.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.ts
@@ -123,14 +123,17 @@ export class PluginLinkIndex {
     // segment says nothing). Personal folders are places, not plugins —
     // their skills belong to nobody's plugin.
     const ownerOf = (skillPath: string) =>
-      discovered.plugins.find((p) => !p.personal && skillPath.startsWith(`${p.folder}/`));
+      discovered.plugins.find((p) => !p.personal && p.exists && skillPath.startsWith(`${p.folder}/`));
     for (const s of skills) {
       const owner = ownerOf(s.path);
       if (owner) add(s.path, { name: owner.name, linked: false, granted: true });
     }
 
     for (const plugin of discovered.plugins) {
-      if (plugin.personal) continue;
+      // Personal folders are places, not plugins; a manifest without the
+      // access.md that makes a plugin EXIST is a ghost the index and the
+      // compiler omit, so it must not be linkable or hold grants either.
+      if (plugin.personal || !plugin.exists) continue;
       const roots = plugin.linkedRoots;
       const linkedSkills: string[] = [];
       const unresolvedRoots: string[] = [];

--- a/packages/core-backend/src/modules/plugins/plugin-links.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { DEFAULT_BRANCH, isPersonalPluginFolder, pluginOfPath, skillUnderRoot } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, skillUnderRoot } from '@bevel-software/platform-shared';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
@@ -8,7 +8,7 @@ import { TtlCache } from '../../shared/ttl-cache.js';
 import { PLUGIN_TOKEN_PREFIX } from '../access-model/access-grammar.js';
 import type { PluginMembership } from './plugins.contract.js';
 import type { PluginSource } from './discovery/plugin-source.js';
-import { NativePluginSource } from './discovery/native.source.js';
+import { KbPluginSource } from './discovery/kb-plugin-source.js';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -65,7 +65,7 @@ export class PluginLinkIndex {
     private readonly accessControl: IAccessControl,
     private readonly kbDirName: string,
     now: () => number = Date.now,
-    private readonly source: PluginSource = new NativePluginSource(),
+    private readonly source: PluginSource = new KbPluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }
@@ -111,17 +111,20 @@ export class PluginLinkIndex {
       bySkill.set(skillPath, list);
     };
 
-    // Inline skills: the folder the path sits in. Personal folders are places,
-    // not plugins — their skills belong to nobody's plugin.
-    for (const s of skills) {
-      const folder = pluginOfPath(s.path);
-      if (folder !== null && !isPersonalPluginFolder(folder)) {
-        add(s.path, { name: folder, linked: false, granted: true });
-      }
-    }
-
     const discovered = await this.source.discover(kbRoot);
     for (const w of discovered.warnings) console.warn(`[plugins] ${w}`);
+
+    // Inline skills: the ones sitting INSIDE a plugin's folder, matched by
+    // folder prefix (a plugin may sit at any depth, so the second path
+    // segment says nothing). Personal folders are places, not plugins —
+    // their skills belong to nobody's plugin.
+    const ownerOf = (skillPath: string) =>
+      discovered.plugins.find((p) => !p.personal && skillPath.startsWith(`${p.folder}/`));
+    for (const s of skills) {
+      const owner = ownerOf(s.path);
+      if (owner) add(s.path, { name: owner.name, linked: false, granted: true });
+    }
+
     for (const plugin of discovered.plugins) {
       if (plugin.personal) continue;
       const roots = plugin.linkedRoots;
@@ -145,7 +148,7 @@ export class PluginLinkIndex {
       for (const skillPath of linkedSkills) {
         // A skill that also sits INSIDE this plugin folder is inline, and its
         // inline membership already stands.
-        if (pluginOfPath(skillPath) === plugin.name) continue;
+        if (skillPath.startsWith(`${plugin.folder}/`)) continue;
         // An unmanaged (dialect) link is a plain reference: nothing to grant,
         // nothing to repair — the skill's own scope decides who reads it.
         const granted = plugin.linksAreManaged ? await this.isGranted(wsId, skillPath, token) : true;

--- a/packages/core-backend/src/modules/plugins/plugin-links.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.ts
@@ -1,14 +1,5 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
-import {
-  DEFAULT_BRANCH,
-  PLUGINS_DIR,
-  PLUGIN_MANIFEST_FILE,
-  isPersonalPluginFolder,
-  linkedSkillRoots,
-  pluginOfPath,
-  skillUnderRoot,
-} from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, isPersonalPluginFolder, pluginOfPath, skillUnderRoot } from '@bevel-software/platform-shared';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
@@ -16,11 +7,16 @@ import type { ISkillService } from '../skills/skills.contract.js';
 import { TtlCache } from '../../shared/ttl-cache.js';
 import { PLUGIN_TOKEN_PREFIX } from '../access-model/access-grammar.js';
 import type { PluginMembership } from './plugins.contract.js';
+import type { PluginSource } from './discovery/plugin-source.js';
+import { NativePluginSource } from './discovery/native.source.js';
 
 const CACHE_TTL_MS = 60_000;
 
 /** One plugin's links, resolved against the released catalog. */
 export interface PluginLinks {
+  /** The plugin's name — its identity to people and URLs. */
+  name: string;
+  /** Repo-relative plugin folder. */
   folder: string;
   /** The roots the manifest declares, normalised. */
   roots: string[];
@@ -28,6 +24,8 @@ export interface PluginLinks {
   linkedSkills: string[];
   /** Roots that resolve to no released skill — a typo, or a skill not yet merged. */
   unresolvedRoots: string[];
+  /** Whether hexis writes these links and checks their grants — see `DiscoveredPlugin`. */
+  linksAreManaged: boolean;
 }
 
 export interface LinkMembership {
@@ -42,10 +40,12 @@ export interface LinkMembership {
  * round — which plugins each skill belongs to, whether by sitting inside the
  * plugin folder or by being linked from its manifest.
  *
- * Resolution runs against the RELEASED catalog (`skillService.listSkills()`,
- * unfiltered), never the file system: the catalog already applies the
- * leaf-folder rule, the `.bevelignore` layers and the global-name dedup, and a
- * second walk here would be a second opinion about what a skill is.
+ * Plugins come from the configured {@link PluginSource} (native manifests, or
+ * a customer dialect); resolution runs against the RELEASED catalog
+ * (`skillService.listSkills()`, unfiltered), never the file system: the
+ * catalog already applies the leaf-folder rule, the `.bevelignore` layers
+ * and the global-name dedup, and a second walk here would be a second
+ * opinion about what a skill is.
  *
  * `granted` is the consistency check the amber dot renders: a linked skill
  * whose own access rules DO grant the plugin's `plugin/<Name>/read`
@@ -65,6 +65,7 @@ export class PluginLinkIndex {
     private readonly accessControl: IAccessControl,
     private readonly kbDirName: string,
     now: () => number = Date.now,
+    private readonly source: PluginSource = new NativePluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }
@@ -119,17 +120,11 @@ export class PluginLinkIndex {
       }
     }
 
-    let folders: string[] = [];
-    try {
-      folders = (await fs.readdir(path.join(kbRoot, PLUGINS_DIR), { withFileTypes: true }))
-        .filter((e) => e.isDirectory() && !e.name.startsWith('.') && !isPersonalPluginFolder(e.name))
-        .map((e) => e.name)
-        .sort();
-    } catch {
-      /* no Plugins/ root — nothing links anything */
-    }
-    for (const folder of folders) {
-      const roots = linkedSkillRoots(await readJson(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MANIFEST_FILE)));
+    const discovered = await this.source.discover(kbRoot);
+    for (const w of discovered.warnings) console.warn(`[plugins] ${w}`);
+    for (const plugin of discovered.plugins) {
+      if (plugin.personal) continue;
+      const roots = plugin.linkedRoots;
       const linkedSkills: string[] = [];
       const unresolvedRoots: string[] = [];
       for (const root of roots) {
@@ -137,14 +132,24 @@ export class PluginLinkIndex {
         if (hits.length === 0) unresolvedRoots.push(root);
         for (const hit of hits) if (!linkedSkills.includes(hit)) linkedSkills.push(hit);
       }
-      byPlugin.set(folder, { folder, roots, linkedSkills, unresolvedRoots });
+      byPlugin.set(plugin.name, {
+        name: plugin.name,
+        folder: plugin.folder,
+        roots,
+        linkedSkills,
+        unresolvedRoots,
+        linksAreManaged: plugin.linksAreManaged,
+      });
       if (linkedSkills.length === 0) continue;
-      const token = `${PLUGIN_TOKEN_PREFIX}${folder}/read`;
+      const token = `${PLUGIN_TOKEN_PREFIX}${plugin.name}/read`;
       for (const skillPath of linkedSkills) {
         // A skill that also sits INSIDE this plugin folder is inline, and its
         // inline membership already stands.
-        if (pluginOfPath(skillPath) === folder) continue;
-        add(skillPath, { name: folder, linked: true, granted: await this.isGranted(wsId, skillPath, token) });
+        if (pluginOfPath(skillPath) === plugin.name) continue;
+        // An unmanaged (dialect) link is a plain reference: nothing to grant,
+        // nothing to repair — the skill's own scope decides who reads it.
+        const granted = plugin.linksAreManaged ? await this.isGranted(wsId, skillPath, token) : true;
+        add(skillPath, { name: plugin.name, linked: true, granted });
       }
     }
     return { bySkill, byPlugin };
@@ -159,14 +164,6 @@ export class PluginLinkIndex {
     } catch {
       return false; // fail closed: an unreadable tree reports the link as needing repair
     }
-  }
-}
-
-async function readJson(p: string): Promise<unknown> {
-  try {
-    return JSON.parse(await fs.readFile(p, 'utf-8')) as unknown;
-  } catch {
-    return null;
   }
 }
 

--- a/packages/core-backend/src/modules/plugins/plugin-links.ts
+++ b/packages/core-backend/src/modules/plugins/plugin-links.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  DEFAULT_BRANCH,
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  isPersonalPluginFolder,
+  linkedSkillRoots,
+  pluginOfPath,
+  skillUnderRoot,
+} from '@bevel-software/platform-shared';
+import type { WorkspaceService } from '../workspace/workspace.service.js';
+import { workspaceIdForBranch } from '../../shared/workspace-id.js';
+import type { IAccessControl } from '../access/access-control.interface.js';
+import type { ISkillService } from '../skills/skills.contract.js';
+import { TtlCache } from '../../shared/ttl-cache.js';
+import { PLUGIN_TOKEN_PREFIX } from '../access-model/access-grammar.js';
+import type { PluginMembership } from './plugins.contract.js';
+
+const CACHE_TTL_MS = 60_000;
+
+/** One plugin's links, resolved against the released catalog. */
+export interface PluginLinks {
+  folder: string;
+  /** The roots the manifest declares, normalised. */
+  roots: string[];
+  /** Skill folders the roots resolve to (released catalog only). */
+  linkedSkills: string[];
+  /** Roots that resolve to no released skill — a typo, or a skill not yet merged. */
+  unresolvedRoots: string[];
+}
+
+export interface LinkMembership {
+  /** skill path → every plugin that holds it, inline or by link. */
+  bySkill: Map<string, PluginMembership[]>;
+  /** plugin folder → its links. Every plugin folder appears, linked or not. */
+  byPlugin: Map<string, PluginLinks>;
+}
+
+/**
+ * The link index: which shared skills each plugin links, and — the other way
+ * round — which plugins each skill belongs to, whether by sitting inside the
+ * plugin folder or by being linked from its manifest.
+ *
+ * Resolution runs against the RELEASED catalog (`skillService.listSkills()`,
+ * unfiltered), never the file system: the catalog already applies the
+ * leaf-folder rule, the `.bevelignore` layers and the global-name dedup, and a
+ * second walk here would be a second opinion about what a skill is.
+ *
+ * `granted` is the consistency check the amber dot renders: a linked skill
+ * whose own access rules DO grant the plugin's `plugin/<Name>/read`
+ * principal (directly or from a scope above it). The link service writes
+ * that grant with the link; only a hand edit takes it away.
+ *
+ * Cached briefly, dropped by `invalidate()` from the same file-change
+ * subscriber that drops the plugin index, so a link committed on the default
+ * branch shows within one round-trip.
+ */
+export class PluginLinkIndex {
+  private readonly cache: TtlCache<LinkMembership>;
+
+  constructor(
+    private readonly workspaceService: WorkspaceService,
+    private readonly skillService: ISkillService,
+    private readonly accessControl: IAccessControl,
+    private readonly kbDirName: string,
+    now: () => number = Date.now,
+  ) {
+    this.cache = new TtlCache(CACHE_TTL_MS, now);
+  }
+
+  invalidate(): void {
+    this.cache.invalidate();
+  }
+
+  async membership(): Promise<LinkMembership> {
+    const cached = this.cache.get();
+    if (cached) return cached;
+    const built = await this.build();
+    // A degraded read (no workspace yet) is served but not stored — the same
+    // reasoning as the plugin index: caching a failure hides every link for
+    // a full TTL after its cause is gone.
+    if (built === null) return { bySkill: new Map(), byPlugin: new Map() };
+    this.cache.set(built);
+    return built;
+  }
+
+  /** Convenience: the memberships of one skill (empty when it is in no plugin). */
+  async pluginsOf(skillPath: string): Promise<PluginMembership[]> {
+    return (await this.membership()).bySkill.get(skillPath) ?? [];
+  }
+
+  // --- internal --------------------------------------------------------------
+
+  private async build(): Promise<LinkMembership | null> {
+    let wsId: string;
+    let kbRoot: string;
+    try {
+      wsId = (await this.workspaceService.getOrCreateForBranch(DEFAULT_BRANCH)).id;
+      kbRoot = path.join(await this.workspaceService.getWorkspacePath(wsId), this.kbDirName);
+    } catch {
+      return null;
+    }
+    const skills = await this.skillService.listSkills(undefined);
+    const bySkill = new Map<string, PluginMembership[]>();
+    const byPlugin = new Map<string, PluginLinks>();
+    const add = (skillPath: string, m: PluginMembership) => {
+      const list = bySkill.get(skillPath) ?? [];
+      if (!list.some((x) => x.name === m.name)) list.push(m);
+      bySkill.set(skillPath, list);
+    };
+
+    // Inline skills: the folder the path sits in. Personal folders are places,
+    // not plugins — their skills belong to nobody's plugin.
+    for (const s of skills) {
+      const folder = pluginOfPath(s.path);
+      if (folder !== null && !isPersonalPluginFolder(folder)) {
+        add(s.path, { name: folder, linked: false, granted: true });
+      }
+    }
+
+    let folders: string[] = [];
+    try {
+      folders = (await fs.readdir(path.join(kbRoot, PLUGINS_DIR), { withFileTypes: true }))
+        .filter((e) => e.isDirectory() && !e.name.startsWith('.') && !isPersonalPluginFolder(e.name))
+        .map((e) => e.name)
+        .sort();
+    } catch {
+      /* no Plugins/ root — nothing links anything */
+    }
+    for (const folder of folders) {
+      const roots = linkedSkillRoots(await readJson(path.join(kbRoot, PLUGINS_DIR, folder, PLUGIN_MANIFEST_FILE)));
+      const linkedSkills: string[] = [];
+      const unresolvedRoots: string[] = [];
+      for (const root of roots) {
+        const hits = skills.filter((s) => skillUnderRoot(s.path, root)).map((s) => s.path);
+        if (hits.length === 0) unresolvedRoots.push(root);
+        for (const hit of hits) if (!linkedSkills.includes(hit)) linkedSkills.push(hit);
+      }
+      byPlugin.set(folder, { folder, roots, linkedSkills, unresolvedRoots });
+      if (linkedSkills.length === 0) continue;
+      const token = `${PLUGIN_TOKEN_PREFIX}${folder}/read`;
+      for (const skillPath of linkedSkills) {
+        // A skill that also sits INSIDE this plugin folder is inline, and its
+        // inline membership already stands.
+        if (pluginOfPath(skillPath) === folder) continue;
+        add(skillPath, { name: folder, linked: true, granted: await this.isGranted(wsId, skillPath, token) });
+      }
+    }
+    return { bySkill, byPlugin };
+  }
+
+  /** Whether the skill folder's effective readers include the plugin's read principal. */
+  private async isGranted(wsId: string, skillPath: string, token: string): Promise<boolean> {
+    try {
+      const readers = await this.accessControl.eligibleReaders(wsId, skillPath);
+      if (!readers.restricted) return true; // readable by everyone — the plugin's members included
+      return (readers.principals ?? []).some((p) => p.kind === 'plugin' && p.name === token);
+    } catch {
+      return false; // fail closed: an unreadable tree reports the link as needing repair
+    }
+  }
+}
+
+async function readJson(p: string): Promise<unknown> {
+  try {
+    return JSON.parse(await fs.readFile(p, 'utf-8')) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** The default-branch workspace id every link resolution runs against. */
+export function linksWorkspaceId(): string {
+  return workspaceIdForBranch(DEFAULT_BRANCH);
+}

--- a/packages/core-backend/src/modules/plugins/plugins.contract.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.contract.ts
@@ -33,6 +33,8 @@
  * change requests; only the UI dresses them up.
  */
 
+export type { PluginMembership } from '../skills/skills.contract.js';
+
 /** Access-rule principals as the resolver hands them back. */
 export interface ResolvedPrincipals {
   roles: string[];

--- a/packages/core-backend/src/modules/plugins/plugins.routes.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.routes.ts
@@ -13,6 +13,7 @@ import { WorkflowDomainError } from '../../shared/domain-errors.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { pluginsWorkspaceId } from './plugins.service.js';
 import { PluginProvisionError, type PluginProvisionService } from './plugin-provision.service.js';
+import { PluginLinkError, type PluginLinksService } from './plugin-links.service.js';
 import type { JoinRequestsService } from './join-requests.service.js';
 import type {
   PluginCatalogEntry,
@@ -61,8 +62,62 @@ export function createPluginsRoutes(
   provision: PluginProvisionService,
   kbDirName: string,
   resolveUser: (req: express.Request) => Promise<AuthUser | null>,
+  /** Optional: a host without the link machinery simply has no link routes. */
+  links?: PluginLinksService,
 ): express.Router {
   const router = express.Router();
+
+  /**
+   * Linking shared skills — see `PluginLinksService` for the two-sided write.
+   *
+   *   POST   /api/plugins/:name/links          { skillPath }  → { root, skills }
+   *   DELETE /api/plugins/:name/links?skillPath=              → { root, revoked }
+   *   POST   /api/plugins/:name/links/repair   { skillPath }  → { root }
+   *
+   * Refusals carry a `kind` the UI branches on — `needs-skill-write` (409) is
+   * the one that becomes "request write access".
+   */
+  if (links) {
+    const linkOp = async (
+      req: express.Request,
+      res: express.Response,
+      op: (user: AuthUser, plugin: string, skillPath: string) => Promise<unknown>,
+      skillPathOf: (req: express.Request) => unknown,
+    ) => {
+      const user = await resolveUser(req);
+      if (!user) {
+        res.status(401).json({ error: 'Unauthenticated' });
+        return;
+      }
+      const skillPath = skillPathOf(req);
+      if (typeof skillPath !== 'string' || !skillPath.trim()) {
+        res.status(400).json({ error: 'skillPath is required' });
+        return;
+      }
+      try {
+        res.json(await op(user, String(req.params.name), skillPath));
+      } catch (err) {
+        if (err instanceof PluginLinkError) {
+          res.status(err.status).json({ error: err.message, ...err.payload });
+          return;
+        }
+        if (err instanceof WorkflowDomainError) {
+          res.status(err.status).json({ error: err.message, ...(err.payload ?? {}) });
+          return;
+        }
+        console.error('[plugins] link operation failed:', err);
+        res.status(500).json({ error: 'Failed to update the plugin\'s links' });
+      }
+    };
+    const bodyPath = (req: express.Request) => ((req.body ?? {}) as { skillPath?: unknown }).skillPath;
+    router.post('/plugins/:name/links', (req, res) => linkOp(req, res, (u, p, s) => links.link(u, p, s), bodyPath));
+    router.post('/plugins/:name/links/repair', (req, res) =>
+      linkOp(req, res, (u, p, s) => links.repair(u, p, s), bodyPath),
+    );
+    router.delete('/plugins/:name/links', (req, res) =>
+      linkOp(req, res, (u, p, s) => links.unlink(u, p, s), (r) => r.query.skillPath),
+    );
+  }
 
   /** The folder-chain probe for MEMBERSHIP — the folder itself. */
   const memberProbe = (folder: string) => folder;

--- a/packages/core-backend/src/modules/plugins/plugins.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.service.ts
@@ -14,6 +14,7 @@ import type { ISkillService } from '../skills/skills.contract.js';
 import type { IToolManualService } from '../tool-manuals/tool-manuals.contract.js';
 import { TtlCache } from '../../shared/ttl-cache.js';
 import type { PluginCatalogEntry, IPluginIndexService } from './plugins.contract.js';
+import type { PluginLinkIndex } from './plugin-links.js';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -52,6 +53,12 @@ export class PluginIndexService implements IPluginIndexService {
     private readonly toolManualService: IToolManualService,
     private readonly kbDirName: string,
     now: () => number = Date.now,
+    /**
+     * The link index, when the deployment has one: a plugin's skill count is
+     * then inline PLUS linked. Optional so hosts composing their own service
+     * set (and older tests) keep the inline-only count.
+     */
+    private readonly links?: PluginLinkIndex,
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }
@@ -168,7 +175,15 @@ export class PluginIndexService implements IPluginIndexService {
   private async countSkills(): Promise<Map<string, number>> {
     // `undefined` is the documented GLOBAL, unfiltered mode — counts are a
     // property of the plugin, not of who is asking.
-    return bucketByPlugin(await this.skillService.listSkills(undefined));
+    if (!this.links) return bucketByPlugin(await this.skillService.listSkills(undefined));
+    // With links, a skill counts for EVERY plugin that holds it — inline in
+    // its folder, or linked from a manifest. Personal folders are already
+    // absent from the membership (they are places, not plugins).
+    const counts = new Map<string, number>();
+    for (const memberships of (await this.links.membership()).bySkill.values()) {
+      for (const m of memberships) counts.set(m.name, (counts.get(m.name) ?? 0) + 1);
+    }
+    return counts;
   }
 
   private async countTools(): Promise<Map<string, number>> {

--- a/packages/core-backend/src/modules/plugins/plugins.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.service.ts
@@ -12,7 +12,7 @@ import { TtlCache } from '../../shared/ttl-cache.js';
 import type { PluginCatalogEntry, IPluginIndexService } from './plugins.contract.js';
 import type { PluginLinkIndex } from './plugin-links.js';
 import type { PluginSource } from './discovery/plugin-source.js';
-import { NativePluginSource } from './discovery/native.source.js';
+import { KbPluginSource } from './discovery/kb-plugin-source.js';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -58,7 +58,7 @@ export class PluginIndexService implements IPluginIndexService {
      */
     private readonly links?: PluginLinkIndex,
     /** Where plugins come from — native manifests unless a dialect is configured. */
-    private readonly source: PluginSource = new NativePluginSource(),
+    private readonly source: PluginSource = new KbPluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }

--- a/packages/core-backend/src/modules/plugins/plugins.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.service.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import {
   DEFAULT_BRANCH,
-  pluginOfPath,
 } from '@bevel-software/platform-shared';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
@@ -108,7 +107,7 @@ export class PluginIndexService implements IPluginIndexService {
       if (folders.size === 0) return [];
 
       const [skillCounts, toolCounts] = await Promise.all([
-        this.countSkills(),
+        this.countSkills(folders),
         this.countTools(folders),
       ]);
 
@@ -159,10 +158,10 @@ export class PluginIndexService implements IPluginIndexService {
     return byName;
   }
 
-  private async countSkills(): Promise<Map<string, number>> {
+  private async countSkills(folders: Map<string, string[]>): Promise<Map<string, number>> {
     // `undefined` is the documented GLOBAL, unfiltered mode — counts are a
     // property of the plugin, not of who is asking.
-    if (!this.links) return bucketByPlugin(await this.skillService.listSkills(undefined));
+    if (!this.links) return bucketByFolder(await this.skillService.listSkills(undefined), folders);
     // With links, a skill counts for EVERY plugin that holds it — inline in
     // its folder, or linked from a manifest. Personal folders are already
     // absent from the membership (they are places, not plugins).
@@ -191,13 +190,18 @@ export class PluginIndexService implements IPluginIndexService {
   }
 }
 
-/** Count items per plugin folder name; ungrouped items (`null`) count nowhere. */
-function bucketByPlugin(items: { path: string }[]): Map<string, number> {
+/**
+ * Count items per plugin by FOLDER PREFIX against the discovered folders —
+ * not by `pluginOfPath`'s second-segment rule, which would file a nested
+ * plugin's skills under its grouping folder. Items in no plugin count nowhere.
+ */
+function bucketByFolder(items: { path: string }[], folders: Map<string, string[]>): Map<string, number> {
   const counts = new Map<string, number>();
+  const byFolder = [...folders.entries()].map(([name, [folder]]) => ({ name, prefix: `${folder}/` }));
   for (const item of items) {
-    const plugin = pluginOfPath(item.path);
-    if (plugin === null) continue;
-    counts.set(plugin, (counts.get(plugin) ?? 0) + 1);
+    const owner = byFolder.find((f) => item.path.startsWith(f.prefix));
+    if (!owner) continue;
+    counts.set(owner.name, (counts.get(owner.name) ?? 0) + 1);
   }
   return counts;
 }

--- a/packages/core-backend/src/modules/plugins/plugins.service.ts
+++ b/packages/core-backend/src/modules/plugins/plugins.service.ts
@@ -1,11 +1,7 @@
 import path from 'node:path';
-import fs from 'node:fs/promises';
-import type { Dirent } from 'node:fs';
 import {
   DEFAULT_BRANCH,
-  PLUGINS_DIR,
   pluginOfPath,
-  isPersonalPluginFolder,
 } from '@bevel-software/platform-shared';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
@@ -15,6 +11,8 @@ import type { IToolManualService } from '../tool-manuals/tool-manuals.contract.j
 import { TtlCache } from '../../shared/ttl-cache.js';
 import type { PluginCatalogEntry, IPluginIndexService } from './plugins.contract.js';
 import type { PluginLinkIndex } from './plugin-links.js';
+import type { PluginSource } from './discovery/plugin-source.js';
+import { NativePluginSource } from './discovery/native.source.js';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -59,6 +57,8 @@ export class PluginIndexService implements IPluginIndexService {
      * set (and older tests) keep the inline-only count.
      */
     private readonly links?: PluginLinkIndex,
+    /** Where plugins come from — native manifests unless a dialect is configured. */
+    private readonly source: PluginSource = new NativePluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }
@@ -106,7 +106,7 @@ export class PluginIndexService implements IPluginIndexService {
 
       const [skillCounts, toolCounts] = await Promise.all([
         this.countSkills(),
-        this.countTools(),
+        this.countTools(folders),
       ]);
 
       const entries: PluginCatalogEntry[] = [];
@@ -137,38 +137,22 @@ export class PluginIndexService implements IPluginIndexService {
     }
   }
 
-  /** name → repo-relative plugin folder (always a single-element list). */
+  /**
+   * name → repo-relative plugin folder (always a single-element list), from
+   * the configured source. Personal folders live under Plugins/ but are not
+   * plugins: one exists per person, private by construction, and listing them
+   * would put a locked row per employee in everyone's index. `exists` is the
+   * source's existence rule (see `DiscoveredPlugin`) — for native plugins,
+   * the `access.md` the class doc describes.
+   */
   private async scanFolders(kbRoot: string): Promise<Map<string, string[]>> {
     const byName = new Map<string, string[]>();
-    let children: Dirent[];
-    try {
-      children = await fs.readdir(path.join(kbRoot, PLUGINS_DIR), { withFileTypes: true });
-    } catch {
-      return byName; // a KB without a `Plugins/` root simply has no plugins
+    const discovered = await this.source.discover(kbRoot);
+    for (const w of discovered.warnings) console.warn(`[plugins] ${w}`);
+    for (const plugin of discovered.plugins) {
+      if (plugin.personal || !plugin.exists) continue;
+      byName.set(plugin.name, [plugin.folder]);
     }
-    const candidates = children.filter(
-      (child) =>
-        child.isDirectory() &&
-        !child.name.startsWith('.') &&
-        // Personal folders live under Plugins/ but are not plugins: one exists
-        // per person, private by construction, and listing them would put a
-        // locked row per employee in everyone's index.
-        !isPersonalPluginFolder(child.name),
-    );
-    // A plugin exists exactly when its folder carries an `access.md` (see the
-    // class doc) — stat that file, don't trust the directory.
-    const verdicts = await Promise.all(
-      candidates.map(async (child) => {
-        try {
-          return (await fs.stat(path.join(kbRoot, PLUGINS_DIR, child.name, 'access.md'))).isFile();
-        } catch {
-          return false;
-        }
-      }),
-    );
-    candidates.forEach((child, i) => {
-      if (verdicts[i]) byName.set(child.name, [`${PLUGINS_DIR}/${child.name}`]);
-    });
     return byName;
   }
 
@@ -186,8 +170,21 @@ export class PluginIndexService implements IPluginIndexService {
     return counts;
   }
 
-  private async countTools(): Promise<Map<string, number>> {
-    return bucketByPlugin(await this.toolManualService.listAllSummaries());
+  /**
+   * Tools belong to the plugin whose FOLDER holds them — matched by path
+   * prefix against the discovered folders, not by `pluginOfPath`'s
+   * second-segment rule, so a dialect plugin nested three folders deep still
+   * counts the servers its bundle expands.
+   */
+  private async countTools(folders: Map<string, string[]>): Promise<Map<string, number>> {
+    const counts = new Map<string, number>();
+    const byFolder = [...folders.entries()].map(([name, [folder]]) => ({ name, prefix: `${folder}/` }));
+    for (const tool of await this.toolManualService.listAllSummaries()) {
+      const owner = byFolder.find((f) => tool.path.startsWith(f.prefix));
+      if (!owner) continue;
+      counts.set(owner.name, (counts.get(owner.name) ?? 0) + 1);
+    }
+    return counts;
   }
 }
 

--- a/packages/core-backend/src/modules/settings/__tests__/deployment-settings.service.test.ts
+++ b/packages/core-backend/src/modules/settings/__tests__/deployment-settings.service.test.ts
@@ -150,6 +150,63 @@ describe('DeploymentSettingsService — secrets', () => {
   });
 });
 
+describe('DeploymentSettingsService — KB layout', () => {
+  it('resolves the three roots to their defaults when nothing names them', () => {
+    const { db } = makeDb();
+    const settings = new DeploymentSettingsService(db, ENC_KEY);
+    expect(settings.resolveKbLayout()).toEqual({
+      knowledgeBaseDir: 'KnowledgeBase',
+      skillsDir: 'Skills',
+      pluginsDir: 'Plugins',
+    });
+  });
+
+  it('takes a renamed root from the environment first, then the store', async () => {
+    const { db } = makeDb();
+    const settings = new DeploymentSettingsService(db, ENC_KEY);
+    await settings.save({ skillsDir: 'skills', pluginsDir: 'plugins' }, null);
+    expect(settings.resolveKbLayout()).toMatchObject({ skillsDir: 'skills', pluginsDir: 'plugins' });
+    process.env.KB_SKILLS_DIR = 'capabilities';
+    expect(settings.resolveKbLayout().skillsDir).toBe('capabilities');
+  });
+
+  /**
+   * The trio rule is judged on the layout the save WOULD produce: a plugins
+   * folder renamed to collide with the skills folder already in effect is a
+   * collision even though the batch names only one of them.
+   */
+  it('refuses two roots that share a name, case-insensitively', async () => {
+    const { db } = makeDb();
+    const settings = new DeploymentSettingsService(db, ENC_KEY);
+    await expect(settings.save({ pluginsDir: 'skills' }, null)).rejects.toBeInstanceOf(
+      SettingsValidationError,
+    );
+    await expect(settings.save({ pluginsDir: 'SKILLS' }, null)).rejects.toBeInstanceOf(
+      SettingsValidationError,
+    );
+    await expect(
+      settings.save({ knowledgeBaseDir: 'Content', skillsDir: 'content' }, null),
+    ).rejects.toBeInstanceOf(SettingsValidationError);
+  });
+
+  it('refuses a root that is not a single plain folder name', async () => {
+    const { db } = makeDb();
+    const settings = new DeploymentSettingsService(db, ENC_KEY);
+    for (const bad of ['a/b', '..', '.hidden', 'x\\y']) {
+      await expect(settings.save({ skillsDir: bad }, null)).rejects.toBeInstanceOf(
+        SettingsValidationError,
+      );
+    }
+  });
+
+  it('marks a layout change as restart-to-apply', async () => {
+    const { db } = makeDb();
+    const settings = new DeploymentSettingsService(db, ENC_KEY);
+    const { restartRequired } = await settings.save({ pluginsDir: 'Bundles' }, null);
+    expect(restartRequired).toBe(true);
+  });
+});
+
 describe('DeploymentSettingsService — validation', () => {
   it('rejects the whole batch when one field is wrong', async () => {
     const { db, rows } = makeDb();

--- a/packages/core-backend/src/modules/settings/deployment-settings.service.ts
+++ b/packages/core-backend/src/modules/settings/deployment-settings.service.ts
@@ -1,7 +1,12 @@
 import { eq, inArray } from 'drizzle-orm';
 import type { Database } from '../database/connection.js';
 import { deploymentSettings } from '../database/core-schema.js';
-import { validateBranchModel } from '@bevel-software/platform-shared';
+import {
+  DEFAULT_KB_LAYOUT,
+  validateBranchModel,
+  validateKbLayout,
+  validateKbRootName,
+} from '@bevel-software/platform-shared';
 import { TokenCrypto } from '../../shared/token-crypto.js';
 
 /**
@@ -82,6 +87,37 @@ export const CORE_SETTINGS: SettingDef[] = [
         : 'Use a single folder name — no slashes.',
     // Copied into a dozen services when they are constructed. A running server
     // keeps the name it started with.
+    restartToApply: true,
+  },
+
+  /**
+   * The KB layout: the three root folders a deployment may rename so hexis can
+   * read a repository laid out by someone else (`skills/` and `plugins/` in
+   * lowercase, say). Restart-to-apply like the branch model — the names are
+   * applied once at boot through `configureKbLayout` and served to the browser
+   * once by `/api/config`. Each has a default, so an unset field means the
+   * default, not an unconfigured deployment. Checked as a trio in `save`: the
+   * three must differ, and one field alone cannot see the other two.
+   */
+  {
+    key: 'knowledgeBaseDir',
+    envVar: 'KB_KNOWLEDGE_BASE_DIR',
+    section: 'knowledge-base',
+    validate: validateKbRootName,
+    restartToApply: true,
+  },
+  {
+    key: 'skillsDir',
+    envVar: 'KB_SKILLS_DIR',
+    section: 'knowledge-base',
+    validate: validateKbRootName,
+    restartToApply: true,
+  },
+  {
+    key: 'pluginsDir',
+    envVar: 'KB_PLUGINS_DIR',
+    section: 'knowledge-base',
+    validate: validateKbRootName,
     restartToApply: true,
   },
 
@@ -266,6 +302,18 @@ export class DeploymentSettingsService {
     return (this.stored.get(key) ?? '').trim();
   }
 
+  /**
+   * The KB layout in effect: each root from the environment, else the stored
+   * row, else its default. The composition root applies this once at boot.
+   */
+  resolveKbLayout(): { knowledgeBaseDir: string; skillsDir: string; pluginsDir: string } {
+    return {
+      knowledgeBaseDir: this.resolve('knowledgeBaseDir') || DEFAULT_KB_LAYOUT.knowledgeBaseDir,
+      skillsDir: this.resolve('skillsDir') || DEFAULT_KB_LAYOUT.skillsDir,
+      pluginsDir: this.resolve('pluginsDir') || DEFAULT_KB_LAYOUT.pluginsDir,
+    };
+  }
+
   /** Where {@link resolve} got its answer — what the setup screen labels the field with. */
   sourceOf(key: string): SettingSource {
     const def = this.defs.get(key);
@@ -354,6 +402,26 @@ export class DeploymentSettingsService {
       // Reported against the protected list: it is the field with room to hold
       // the answer, and "add it to this list" is the usual fix.
       if (problem) problems.protectedBranches = problem;
+    }
+
+    // The layout trio is the other cross-field rule: three names that must
+    // differ. Judged on the layout this save WOULD produce, with the default
+    // standing in for anything neither written nor stored.
+    const layoutKeys = ['knowledgeBaseDir', 'skillsDir', 'pluginsDir'] as const;
+    if (toWrite.some((w) => (layoutKeys as readonly string[]).includes(w.key))) {
+      const effective = (key: (typeof layoutKeys)[number]) =>
+        toWrite.find((w) => w.key === key)?.value || this.resolve(key) || DEFAULT_KB_LAYOUT[key];
+      const problem = validateKbLayout({
+        knowledgeBaseDir: effective('knowledgeBaseDir'),
+        skillsDir: effective('skillsDir'),
+        pluginsDir: effective('pluginsDir'),
+      });
+      // Against the field being written — the first one in the batch — since
+      // any of the three could be the one that collides.
+      if (problem) {
+        const first = toWrite.find((w) => (layoutKeys as readonly string[]).includes(w.key))!;
+        problems[first.key] = problem;
+      }
     }
 
     if (Object.keys(problems).length > 0) throw new SettingsValidationError(problems);

--- a/packages/core-backend/src/modules/settings/deployment-settings.service.ts
+++ b/packages/core-backend/src/modules/settings/deployment-settings.service.ts
@@ -122,6 +122,31 @@ export const CORE_SETTINGS: SettingDef[] = [
   },
 
   /**
+   * Plugin DIALECT: which source format the plugins root is read in.
+   * `native` (the default) is the Agent Plugins layout this platform writes;
+   * `bundle` reads a customer's `plugin.bundle.json` files and MCP registry
+   * (see modules/plugins/discovery/bundle-dialect). Restart-to-apply: the
+   * source is handed to the scanners at construction.
+   */
+  {
+    key: 'pluginDialect',
+    envVar: 'KB_PLUGIN_DIALECT',
+    section: 'knowledge-base',
+    validate: (v) => (v === 'native' || v === 'bundle' ? null : 'Use "native" or "bundle".'),
+    restartToApply: true,
+  },
+  {
+    key: 'mcpRegistryPath',
+    envVar: 'KB_MCP_REGISTRY_PATH',
+    section: 'knowledge-base',
+    validate: (v) =>
+      v && !v.startsWith('/') && !v.includes('\\') && !v.split('/').includes('..')
+        ? null
+        : 'A repository-relative file path, e.g. configs/mcp/registry.json.',
+    restartToApply: true,
+  },
+
+  /**
    * The branch model. Both are restart-to-apply and could not be otherwise:
    * the backend hands `DEFAULT_BRANCH` to services at construction, and the
    * browser is served the pair once at boot — a live swap would leave half the

--- a/packages/core-backend/src/modules/settings/deployment-settings.service.ts
+++ b/packages/core-backend/src/modules/settings/deployment-settings.service.ts
@@ -121,30 +121,6 @@ export const CORE_SETTINGS: SettingDef[] = [
     restartToApply: true,
   },
 
-  /**
-   * Plugin DIALECT: which source format the plugins root is read in.
-   * `native` (the default) is the Agent Plugins layout this platform writes;
-   * `bundle` reads a customer's `plugin.bundle.json` files and MCP registry
-   * (see modules/plugins/discovery/bundle-dialect). Restart-to-apply: the
-   * source is handed to the scanners at construction.
-   */
-  {
-    key: 'pluginDialect',
-    envVar: 'KB_PLUGIN_DIALECT',
-    section: 'knowledge-base',
-    validate: (v) => (v === 'native' || v === 'bundle' ? null : 'Use "native" or "bundle".'),
-    restartToApply: true,
-  },
-  {
-    key: 'mcpRegistryPath',
-    envVar: 'KB_MCP_REGISTRY_PATH',
-    section: 'knowledge-base',
-    validate: (v) =>
-      v && !v.startsWith('/') && !v.includes('\\') && !v.split('/').includes('..')
-        ? null
-        : 'A repository-relative file path, e.g. configs/mcp/registry.json.',
-    restartToApply: true,
-  },
 
   /**
    * The branch model. Both are restart-to-apply and could not be otherwise:

--- a/packages/core-backend/src/modules/settings/deployment-settings.service.ts
+++ b/packages/core-backend/src/modules/settings/deployment-settings.service.ts
@@ -429,7 +429,12 @@ export class DeploymentSettingsService {
 
     let restartRequired = false;
     for (const { key, value, def } of toWrite) {
-      if (def.restartToApply && this.resolve(key) !== value) restartRequired = true;
+      // Compared against the EFFECTIVE value: a layout root that was unset
+      // was already running on its default, so saving that default changes
+      // nothing a restart would pick up.
+      const effective =
+        this.resolve(key) || (DEFAULT_KB_LAYOUT as Record<string, string | undefined>)[key] || '';
+      if (def.restartToApply && effective !== value) restartRequired = true;
       const encrypted = def.secret === true;
       const stored = encrypted ? this.crypto!.encrypt(value) : value;
       await this.db

--- a/packages/core-backend/src/modules/skills/__tests__/skills.service.test.ts
+++ b/packages/core-backend/src/modules/skills/__tests__/skills.service.test.ts
@@ -67,6 +67,62 @@ describe('SkillService', () => {
   });
   afterEach(() => rm(root, { recursive: true, force: true }));
 
+  test('lists shared skills under the Skills root alongside plugin skills', async () => {
+    const shared = join(root, wsId, KB_DIR, 'Skills', 'Engineering', 'deploy');
+    await mkdir(shared, { recursive: true });
+    await writeFile(join(shared, 'SKILL.md'), '---\ndescription: Ship it.\n---\n\n# Deploy\n');
+    // A skill directly under the root, no scope folder — also a skill.
+    const bare = join(root, wsId, KB_DIR, 'Skills', 'triage');
+    await mkdir(bare, { recursive: true });
+    await writeFile(join(bare, 'SKILL.md'), '---\ndescription: Triage.\n---\n');
+
+    const list = await svc().listSkills();
+    expect(list.find((s) => s.name === 'deploy')?.path).toBe('Skills/Engineering/deploy');
+    expect(list.find((s) => s.name === 'triage')?.path).toBe('Skills/triage');
+    // The plugin tree is still scanned: the union is the catalog.
+    expect(list.find((s) => s.name === 'rfi')?.path).toBe('Plugins/rfi');
+
+    const res = await svc().getSkill('u@x.io', 'deploy');
+    expect(res.ok && res.kind === 'skill' && res.skill.body).toContain('# Deploy');
+  });
+
+  test('honours a .bevelignore inside a root, so a build output never shadows the source', async () => {
+    // A repository that commits a compiled copy of every skill beside the
+    // source: without the ignore, `dist/…/rfi` would collide with `Plugins/rfi`.
+    const dist = join(root, wsId, KB_DIR, 'Skills', 'dist', 'rfi');
+    await mkdir(dist, { recursive: true });
+    await writeFile(join(dist, 'SKILL.md'), '---\ndescription: compiled copy\n---\n');
+    await writeFile(join(root, wsId, KB_DIR, 'Skills', '.bevelignore'), 'dist/\n');
+
+    const list = await svc().listSkills();
+    expect(list.filter((s) => s.name === 'rfi').map((s) => s.path)).toEqual(['Plugins/rfi']);
+    expect(list.some((s) => s.path.includes('/dist/'))).toBe(false);
+  });
+
+  test('ignores the repo-root .bevelignore: hiding a root from the file tree must not empty the catalog', async () => {
+    // The seeded template hides `Plugins/` (and `Skills/`) from the Knowledge
+    // tree with exactly this file. The catalog is what those roots exist for.
+    await writeFile(join(root, wsId, KB_DIR, '.bevelignore'), 'Plugins/\nSkills/\n');
+    const shared = join(root, wsId, KB_DIR, 'Skills', 'deploy');
+    await mkdir(shared, { recursive: true });
+    await writeFile(join(shared, 'SKILL.md'), '---\ndescription: Ship it.\n---\n');
+
+    const list = await svc().listSkills();
+    expect(list.map((s) => s.name).sort()).toEqual(['coding-guidelines', 'deploy', 'rfi']);
+  });
+
+  test('a nested .bevelignore applies beneath the folder that carries it', async () => {
+    const scope = join(root, wsId, KB_DIR, 'Skills', 'Sales');
+    await mkdir(join(scope, 'drafts', 'pitch'), { recursive: true });
+    await mkdir(join(scope, 'pitch'), { recursive: true });
+    await writeFile(join(scope, 'drafts', 'pitch', 'SKILL.md'), '---\ndescription: draft\n---\n');
+    await writeFile(join(scope, 'pitch', 'SKILL.md'), '---\ndescription: released\n---\n');
+    await writeFile(join(scope, '.bevelignore'), 'drafts/\n');
+
+    const list = await svc().listSkills();
+    expect(list.filter((s) => s.name === 'pitch').map((s) => s.path)).toEqual(['Skills/Sales/pitch']);
+  });
+
   test('lists skills with a block-scalar description parsed correctly', async () => {
     const skills = await svc().listSkills();
     expect(skills).toHaveLength(2);

--- a/packages/core-backend/src/modules/skills/index.ts
+++ b/packages/core-backend/src/modules/skills/index.ts
@@ -2,6 +2,7 @@ export { SkillService } from './skills.service.js';
 export { PendingSkillsService } from './pending-skills.service.js';
 export { registerSkillsTools } from './skills.tools.js';
 export { createSkillsRoutes } from './skills.routes.js';
+export { createSkillAccessRequestRoutes } from './skill-access-requests.routes.js';
 export type {
   ISkillService,
   IPendingSkillService,

--- a/packages/core-backend/src/modules/skills/pending-skills.service.ts
+++ b/packages/core-backend/src/modules/skills/pending-skills.service.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_BRANCH,
   PLUGINS_DIR,
+  SKILLS_DIR,
   type ChangeRequest,
   type IWorkflowService,
 } from '@bevel-software/platform-shared';
@@ -156,11 +157,10 @@ export class PendingSkillsService implements IPendingSkillService {
  */
 function isSkillDoc(repoRelPath: string): boolean {
   const segments = repoRelPath.split('/');
-  return (
-    segments.length >= 4 &&
-    segments[0] === PLUGINS_DIR &&
-    segments[segments.length - 1] === SKILL_DOC
-  );
+  if (segments[segments.length - 1] !== SKILL_DOC) return false;
+  // Under `Skills/` a skill may sit directly below the root: `Skills/<skill>/SKILL.md`.
+  if (segments[0] === SKILLS_DIR) return segments.length >= 3;
+  return segments.length >= 4 && segments[0] === PLUGINS_DIR;
 }
 
 /** The skill folder holding a SKILL.md. */

--- a/packages/core-backend/src/modules/skills/pending-skills.service.ts
+++ b/packages/core-backend/src/modules/skills/pending-skills.service.ts
@@ -119,6 +119,8 @@ export class PendingSkillsService implements IPendingSkillService {
         name: isSafeSkillName(declared) ? declared : folderName,
         description: fm.description,
         version: fm.version,
+        owner: fm.owner,
+        lifecycle: fm.lifecycle,
         path: folder,
         changeRequestNumber: cr.number,
         branch: cr.branch,

--- a/packages/core-backend/src/modules/skills/skill-access-requests.routes.ts
+++ b/packages/core-backend/src/modules/skills/skill-access-requests.routes.ts
@@ -92,7 +92,13 @@ export function createSkillAccessRequestRoutes(deps: {
       }
       const ws = await workspaceService.getOrCreateForBranch(branch);
       const accessPath = `${kbDirName}/${rulesOf(folder)}`;
-      const current = await workspaceService.readFile(ws.id, accessPath).catch(() => '');
+      // Only a PROVEN absence reads as "no rules yet": any other failure must
+      // not be turned into an empty file that a splice then overwrites.
+      const current = await workspaceService.readFile(ws.id, accessPath).catch((err: unknown) => {
+        const code = (err as { code?: unknown } | null)?.code;
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') throw err;
+        return '';
+      });
       const spliced = spliceGrant(
         current,
         'write',

--- a/packages/core-backend/src/modules/skills/skill-access-requests.routes.ts
+++ b/packages/core-backend/src/modules/skills/skill-access-requests.routes.ts
@@ -1,0 +1,175 @@
+import express from 'express';
+import '../auth/auth.middleware.js'; // Express Request.userId / userEmail augmentation
+import {
+  DEFAULT_BRANCH,
+  joinBranchFor,
+  type AuthUser,
+  type IWorkflowService,
+} from '@bevel-software/platform-shared';
+import type { IAccessControl } from '../access/access-control.interface.js';
+import { spliceGrant } from '../access-model/access-splice.js';
+import { WorkflowDomainError } from '../../shared/domain-errors.js';
+import { workspaceIdForBranch } from '../../shared/workspace-id.js';
+import type { WorkspaceService } from '../workspace/workspace.service.js';
+import type { JoinRequestsService } from '../plugins/join-requests.service.js';
+import type { ISkillService } from './skills.contract.js';
+
+/**
+ * Asking for WRITE on a shared skill — the same machinery as asking to join a
+ * plugin, pointed at a skill folder instead of a plugin folder.
+ *
+ *   POST /api/skills/:name/access-request               → { ok, number }
+ *   GET  /api/skills/:name/access-requests              → { requests }   (skill editors)
+ *   POST /api/skills/:name/access-requests/:n/reconcile → { closed }
+ *
+ * Why it exists: linking a skill into a plugin needs write on the skill's
+ * rules (the link grants the plugin's principal there), and a plugin manager
+ * often has no say over a skill some other scope owns. The request is a plain
+ * change request whose branch splices `write: <requester>` into the skill
+ * folder's `access.md`; the skill's editors see its proposals and accept
+ * through the ordinary grant path, and it retires itself once the default
+ * branch carries the grant (`JoinRequestsService`, keyed on the skill FOLDER
+ * path rather than a plugin name — the branch-name convention takes any
+ * exact string).
+ *
+ * Fail-closed like the skill catalog: a skill the caller cannot read answers
+ * as unknown, and the editors' listing answers `[]` to anyone else.
+ */
+export function createSkillAccessRequestRoutes(deps: {
+  skillService: ISkillService;
+  accessControl: IAccessControl;
+  workflow: IWorkflowService;
+  workspaceService: WorkspaceService;
+  joinRequests: JoinRequestsService;
+  kbDirName: string;
+  resolveUser: (req: express.Request) => Promise<AuthUser | null>;
+}): express.Router {
+  const { skillService, accessControl, workflow, workspaceService, joinRequests, kbDirName, resolveUser } = deps;
+  const router = express.Router();
+  const wsId = () => workspaceIdForBranch(DEFAULT_BRANCH);
+  const rulesOf = (folder: string) => `${folder}/access.md`;
+
+  /** The skill the caller may read, by name — or null after answering 404. */
+  async function readableSkill(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<{ user: AuthUser; folder: string; name: string } | null> {
+    const user = await resolveUser(req);
+    if (!user) {
+      res.status(401).json({ error: 'Unauthenticated' });
+      return null;
+    }
+    const name = String(req.params.name);
+    const skill = (await skillService.listSkills(user.email)).find((s) => s.name === name);
+    if (!skill) {
+      res.status(404).json({ error: 'Unknown skill', kind: 'unknown-skill' });
+      return null;
+    }
+    return { user, folder: skill.path, name };
+  }
+
+  router.post('/skills/:name/access-request', async (req, res) => {
+    try {
+      const ctx = await readableSkill(req, res);
+      if (!ctx) return;
+      const { user, folder, name } = ctx;
+      if (await accessControl.canWrite(wsId(), user.email, rulesOf(folder))) {
+        res.status(409).json({ error: 'You can already edit this skill', kind: 'already-writable' });
+        return;
+      }
+      const branch = joinBranchFor(user.email, folder);
+      const existing = (await workflow.listChangeRequestsAuthoredBy(user.email)).find(
+        (cr) => cr.state === 'open' && cr.branch === branch,
+      );
+      if (existing) {
+        res.json({ ok: true, number: existing.number });
+        return;
+      }
+      try {
+        await workflow.createBranch(wsId(), branch, DEFAULT_BRANCH);
+      } catch {
+        // exists (or raced) — proceed against it
+      }
+      const ws = await workspaceService.getOrCreateForBranch(branch);
+      const accessPath = `${kbDirName}/${rulesOf(folder)}`;
+      const current = await workspaceService.readFile(ws.id, accessPath).catch(() => '');
+      const spliced = spliceGrant(
+        current,
+        'write',
+        { kind: 'user', email: user.email, displayName: user.name },
+        { target: 'folder' },
+      );
+      if (spliced.changed) {
+        await workspaceService.writeFile(ws.id, accessPath, spliced.text);
+        await workflow.commitChanges(ws.id, user, `Request write access to ${name}`);
+      }
+      const detail = await workflow.openChangeRequest(ws.id, user, {
+        sourceBranch: branch,
+        targetBranch: DEFAULT_BRANCH,
+        title: `Access request: ${name}`,
+        description:
+          `${user.name} asked to edit the skill ${name}. An editor of the skill accepts by ` +
+          `granting the access this branch proposes; the request closes itself once ` +
+          `every proposal has landed.`,
+      });
+      res.json({ ok: true, number: detail.number });
+    } catch (err) {
+      if (err instanceof WorkflowDomainError) {
+        res.status(err.status).json({ error: err.message, ...(err.payload ?? {}) });
+        return;
+      }
+      console.error('[skills] failed to open an access request:', err);
+      res.status(500).json({ error: 'Failed to request access' });
+    }
+  });
+
+  /** The caller as an EDITOR of the skill's rules, or null after answering. */
+  async function requireEditor(
+    req: express.Request,
+    res: express.Response,
+    onDenied: () => void,
+  ): Promise<{ user: AuthUser; folder: string } | null> {
+    const ctx = await readableSkill(req, res);
+    if (!ctx) return null;
+    if (!(await accessControl.canWrite(wsId(), ctx.user.email, rulesOf(ctx.folder)))) {
+      onDenied();
+      return null;
+    }
+    return ctx;
+  }
+
+  router.get('/skills/:name/access-requests', async (req, res) => {
+    try {
+      const ctx = await requireEditor(req, res, () => res.json({ requests: [] }));
+      if (!ctx) return;
+      const crs = await workflow.listChangeRequests();
+      res.json({ requests: await joinRequests.list(ctx.folder, ctx.folder, crs, ctx.user) });
+    } catch (err) {
+      console.error('[skills] failed to list access requests:', err);
+      res.status(500).json({ error: 'Failed to list access requests' });
+    }
+  });
+
+  router.post('/skills/:name/access-requests/:number/reconcile', async (req, res) => {
+    try {
+      const ctx = await requireEditor(req, res, () => res.status(404).json({ error: 'Not found' }));
+      if (!ctx) return;
+      const crNumber = Number(req.params.number);
+      if (!Number.isSafeInteger(crNumber) || crNumber <= 0) {
+        res.status(400).json({ error: 'Invalid change request number' });
+        return;
+      }
+      const cr = await workflow.getChangeRequest(crNumber);
+      if (!cr) {
+        res.status(404).json({ error: 'Not found' });
+        return;
+      }
+      res.json({ closed: await joinRequests.reconcile(ctx.folder, ctx.folder, cr, ctx.user) });
+    } catch (err) {
+      console.error('[skills] failed to reconcile an access request:', err);
+      res.status(500).json({ error: 'Failed to reconcile the request' });
+    }
+  });
+
+  return router;
+}

--- a/packages/core-backend/src/modules/skills/skills.contract.ts
+++ b/packages/core-backend/src/modules/skills/skills.contract.ts
@@ -7,6 +7,21 @@
  * bundled file's content (level 3).
  */
 
+/**
+ * One plugin a skill belongs to — by sitting INSIDE the plugin folder
+ * (`linked: false`) or by being LINKED from the plugin's manifest
+ * (`linked: true`). For a link, `granted` says whether the skill's own access
+ * rules name the plugin's `plugin/<Name>/read` principal, which is what makes
+ * the link work for the plugin's members; the link service writes that grant
+ * with the link, so `false` means a hand edit took it away.
+ */
+export interface PluginMembership {
+  /** The plugin folder name. */
+  name: string;
+  linked: boolean;
+  granted: boolean;
+}
+
 export interface SkillSummary {
   /** Canonical id = the skill's folder name (e.g. `rfi`). */
   name: string;
@@ -14,6 +29,12 @@ export interface SkillSummary {
   version?: string;
   /** Repo-root-relative skill folder, e.g. `Plugins/Everyone/rfi`. */
   path: string;
+  /**
+   * The plugins this skill belongs to, decorated onto the catalog by the
+   * browser route (the catalog itself is plugin-unaware). Absent on the agent
+   * surfaces, which load skills by name and never by plugin.
+   */
+  plugins?: PluginMembership[];
 }
 
 export interface Skill extends SkillSummary {

--- a/packages/core-backend/src/modules/skills/skills.contract.ts
+++ b/packages/core-backend/src/modules/skills/skills.contract.ts
@@ -27,6 +27,14 @@ export interface SkillSummary {
   name: string;
   description: string;
   version?: string;
+  /** The governance owner from `metadata.owner`, when the skill declares one. */
+  owner?: string;
+  /**
+   * The governance lifecycle from `metadata.lifecycle`, lowercased — `active`
+   * (or absent), `deprecated` (still served, flagged), `retired` (served to the
+   * catalog for its owners, never compiled into a distribution).
+   */
+  lifecycle?: string;
   /** Repo-root-relative skill folder, e.g. `Plugins/Everyone/rfi`. */
   path: string;
   /**

--- a/packages/core-backend/src/modules/skills/skills.routes.ts
+++ b/packages/core-backend/src/modules/skills/skills.routes.ts
@@ -59,7 +59,8 @@ export function createSkillsRoutes(
       return;
     }
     let bySkill: Map<string, PluginMembership[]>;
-    let discoverable: (plugin: string) => boolean = () => true;
+    // Fail closed: memberships without a gate to judge them by name nothing.
+    let discoverable: (plugin: string) => boolean = () => false;
     try {
       const membership = await links.membership();
       bySkill = membership.bySkill;

--- a/packages/core-backend/src/modules/skills/skills.routes.ts
+++ b/packages/core-backend/src/modules/skills/skills.routes.ts
@@ -1,10 +1,20 @@
 import express from 'express';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import '../auth/auth.middleware.js'; // Express Request.userId / userEmail augmentation
+import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IPendingSkillService, ISkillService, PluginMembership } from './skills.contract.js';
 
 /** The slice of the plugin link index this surface reads — see `PluginLinkIndex`. */
 export interface SkillMembershipSource {
-  membership(): Promise<{ bySkill: Map<string, PluginMembership[]> }>;
+  membership(): Promise<{
+    bySkill: Map<string, PluginMembership[]>;
+    byPlugin: Map<string, { folder: string }>;
+  }>;
+}
+
+/** The one access verdict this surface needs: may the caller read a path on the default branch? */
+export interface SkillMembershipGate {
+  canReadBatch(workspaceId: string, userEmail: string, paths: string[]): Promise<Map<string, boolean>>;
 }
 
 /**
@@ -28,6 +38,12 @@ export function createSkillsRoutes(
   skillService: ISkillService,
   pendingSkills?: IPendingSkillService,
   links?: SkillMembershipSource,
+  /**
+   * With `links`: the memberships a caller sees name only plugins they may
+   * DISCOVER (read the plugin's access.md — the plugin index's own listing
+   * verdict), so this surface never reveals a plugin `/api/plugins` omits.
+   */
+  gate?: SkillMembershipGate,
 ): express.Router {
   const router = express.Router();
 
@@ -43,12 +59,28 @@ export function createSkillsRoutes(
       return;
     }
     let bySkill: Map<string, PluginMembership[]>;
+    let discoverable: (plugin: string) => boolean = () => true;
     try {
-      bySkill = (await links.membership()).bySkill;
+      const membership = await links.membership();
+      bySkill = membership.bySkill;
+      if (gate) {
+        const folders = [...membership.byPlugin.entries()];
+        const verdicts = folders.length
+          ? await gate.canReadBatch(
+              workspaceIdForBranch(DEFAULT_BRANCH),
+              email,
+              folders.map(([, p]) => `${p.folder}/access.md`),
+            )
+          : new Map<string, boolean>();
+        const visible = new Set(folders.filter(([, p]) => verdicts.get(`${p.folder}/access.md`) === true).map(([name]) => name));
+        discoverable = (plugin) => visible.has(plugin);
+      }
     } catch {
       bySkill = new Map(); // membership is a decoration; the shelf must not fall with it
     }
-    res.json({ skills: skills.map((s) => ({ ...s, plugins: bySkill.get(s.path) ?? [] })) });
+    res.json({
+      skills: skills.map((s) => ({ ...s, plugins: (bySkill.get(s.path) ?? []).filter((m) => discoverable(m.name)) })),
+    });
   });
 
   /**

--- a/packages/core-backend/src/modules/skills/skills.routes.ts
+++ b/packages/core-backend/src/modules/skills/skills.routes.ts
@@ -1,6 +1,11 @@
 import express from 'express';
 import '../auth/auth.middleware.js'; // Express Request.userId / userEmail augmentation
-import type { IPendingSkillService, ISkillService } from './skills.contract.js';
+import type { IPendingSkillService, ISkillService, PluginMembership } from './skills.contract.js';
+
+/** The slice of the plugin link index this surface reads — see `PluginLinkIndex`. */
+export interface SkillMembershipSource {
+  membership(): Promise<{ bySkill: Map<string, PluginMembership[]> }>;
+}
 
 /**
  * Browser-facing (JWT) skill routes for the `/`-command menu, mounted behind
@@ -8,14 +13,21 @@ import type { IPendingSkillService, ISkillService } from './skills.contract.js';
  * so discovery, default-branch pinning, and per-user `canRead` filtering live
  * ONCE — the frontend never re-implements skill discovery or bypasses access.
  *
- *   GET /api/skills            → { skills: SkillSummary[] }   (filtered to this user)
+ *   GET /api/skills            → { skills: SkillSummary[] }   (filtered to this user,
+ *                                                              each with its `plugins`)
  *   GET /api/skills/pending    → { skills: PendingSkill[] }   (proposed, not released)
  *   GET /api/skills/:name      → GetSkillResult               (body + files)
  *   GET /api/skills/:name?file=… → GetSkillResult             (a bundled file's content)
+ *
+ * `plugins` is decorated HERE, not in the catalog: the catalog is what agents
+ * load by name and it stays plugin-unaware; the browser is the surface that
+ * groups skills by plugin. Optional dependency, so a host without the link
+ * index gets undecorated summaries rather than a 500.
  */
 export function createSkillsRoutes(
   skillService: ISkillService,
   pendingSkills?: IPendingSkillService,
+  links?: SkillMembershipSource,
 ): express.Router {
   const router = express.Router();
 
@@ -25,7 +37,18 @@ export function createSkillsRoutes(
       res.status(401).json({ error: 'Unauthenticated' });
       return;
     }
-    res.json({ skills: await skillService.listSkills(email) });
+    const skills = await skillService.listSkills(email);
+    if (!links) {
+      res.json({ skills });
+      return;
+    }
+    let bySkill: Map<string, PluginMembership[]>;
+    try {
+      bySkill = (await links.membership()).bySkill;
+    } catch {
+      bySkill = new Map(); // membership is a decoration; the shelf must not fall with it
+    }
+    res.json({ skills: skills.map((s) => ({ ...s, plugins: bySkill.get(s.path) ?? [] })) });
   });
 
   /**

--- a/packages/core-backend/src/modules/skills/skills.service.ts
+++ b/packages/core-backend/src/modules/skills/skills.service.ts
@@ -1,13 +1,14 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { parseDocument } from 'yaml';
-import { DEFAULT_BRANCH, PLUGINS_DIR } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, PLUGINS_DIR, SKILLS_DIR } from '@bevel-software/platform-shared';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
 import { extractFrontmatter, resolveDeclaredId, dedupeById } from '../../shared/frontmatter-id.js';
 import { walkFiles } from '../../shared/fs-walk.js';
 import { TtlCache } from '../../shared/ttl-cache.js';
+import { BevelIgnoreStack } from '../workspace/bevel-ignore.js';
 import type {
   ISkillService,
   GetSkillResult,
@@ -103,9 +104,10 @@ export class SkillService implements ISkillService {
   }
 
   private async scanDisk(): Promise<ParsedSkill[]> {
-    // Ensure the default-branch clone exists, then scan its Plugins/ dir. Any
-    // failure (no workspace, no Plugins/ dir) degrades to an empty catalog — the
-    // manual/tools must never break because skills can't be read.
+    // Ensure the default-branch clone exists, then scan its Skills/ and
+    // Plugins/ roots. Any failure (no workspace, no such dir) degrades to an
+    // empty catalog — the manual/tools must never break because skills can't
+    // be read.
     let wsId: string;
     try {
       wsId = (await this.workspaceService.getOrCreateForBranch(DEFAULT_BRANCH)).id;
@@ -115,19 +117,29 @@ export class SkillService implements ISkillService {
     const kbRoot = path.join(await this.workspaceService.getWorkspacePath(wsId), this.kbDirName);
 
     // Skills may be grouped in category subfolders (each carrying its own
-    // access.md), so a SKILL.md can live at any depth under the root. Walk the
-    // tree and treat every folder that directly contains a SKILL.md as a skill;
-    // don't descend past it — its inner files are bundled assets, not nested
-    // skills. The skill name is the leaf folder name; its path is the full
-    // repo-relative folder (e.g. `Plugins/Development/coding-guidelines`).
+    // access.md), so a SKILL.md can live at any depth under either root. Walk
+    // the tree and treat every folder that directly contains a SKILL.md as a
+    // skill; don't descend past it — its inner files are bundled assets, not
+    // nested skills. The skill name is the leaf folder name; its path is the
+    // full repo-relative folder (e.g. `Skills/Engineering/deploy`).
+    //
+    // `.bevelignore` files INSIDE a root are honoured on the way down, the
+    // same layered rules the file tree applies: a repository that carries a
+    // build output beside its source (a `dist/` holding compiled copies of
+    // every skill) would otherwise list each skill twice and refuse the
+    // duplicate — the wrong one, half the time. The REPO-ROOT file is
+    // deliberately not consulted: it is where the template hides `Plugins/`
+    // from the Knowledge tree, and a rule that hides a root from the browser
+    // must not empty the catalog that root exists to feed.
     const out: ParsedSkill[] = [];
-    const walk = async (dir: string, relFolder: string): Promise<void> => {
+    const walk = async (dir: string, relFolder: string, ignore: BevelIgnoreStack): Promise<void> => {
       let entries: import('node:fs').Dirent[];
       try {
         entries = await fs.readdir(dir, { withFileTypes: true });
       } catch {
         return;
       }
+      ignore = await ignore.extendedWith(dir);
       if (entries.some((e) => e.isFile() && e.name === 'SKILL.md')) {
         let raw: string;
         try {
@@ -153,10 +165,16 @@ export class SkillService implements ISkillService {
       }
       for (const entry of entries) {
         if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-        await walk(path.join(dir, entry.name), `${relFolder}/${entry.name}`);
+        const abs = path.join(dir, entry.name);
+        if (ignore.isIgnored(abs, true)) continue;
+        await walk(abs, `${relFolder}/${entry.name}`, ignore);
       }
     };
-    await walk(path.join(kbRoot, PLUGINS_DIR), PLUGINS_DIR);
+    // Each root starts its own ignore stack (the walk extends it with the
+    // root's own file first). Order is cosmetic: the sort below is by name
+    // then path, so a same-named pair resolves the same way regardless.
+    await walk(path.join(kbRoot, SKILLS_DIR), SKILLS_DIR, BevelIgnoreStack.empty());
+    await walk(path.join(kbRoot, PLUGINS_DIR), PLUGINS_DIR, BevelIgnoreStack.empty());
     // A skill's id (frontmatter `id`/`name`, else folder name) is how getSkill()
     // resolves it, so it must be unique. Sort by (name, path) for a deterministic
     // winner, then REFUSE later duplicates via the shared dedup — the same rule

--- a/packages/core-backend/src/modules/skills/skills.service.ts
+++ b/packages/core-backend/src/modules/skills/skills.service.ts
@@ -144,7 +144,11 @@ export class SkillService implements ISkillService {
         return;
       }
       ignore = await ignore.extendedWith(dir);
-      if (entries.some((e) => e.isFile() && e.name === 'SKILL.md')) {
+      // A rule may name the skill's own file, not only a folder above it.
+      if (
+        entries.some((e) => e.isFile() && e.name === 'SKILL.md') &&
+        !ignore.isIgnored(path.join(dir, 'SKILL.md'), false)
+      ) {
         let raw: string;
         try {
           raw = await fs.readFile(path.join(dir, 'SKILL.md'), 'utf-8');

--- a/packages/core-backend/src/modules/skills/skills.service.ts
+++ b/packages/core-backend/src/modules/skills/skills.service.ts
@@ -156,7 +156,14 @@ export class SkillService implements ISkillService {
         const declared = resolveDeclaredId(fm.frontmatter, path.basename(dir));
         const name = isSafeSkillName(declared) ? declared : path.basename(dir);
         out.push({
-          summary: { name, description: fm.description, version: fm.version, path: relFolder },
+          summary: {
+            name,
+            description: fm.description,
+            version: fm.version,
+            owner: fm.owner,
+            lifecycle: fm.lifecycle,
+            path: relFolder,
+          },
           body: fm.body,
           allowedTools: fm.allowedTools,
           files: await listBundledFiles(dir, relFolder),
@@ -227,6 +234,10 @@ function scalarToString(value: unknown): string | undefined {
 export function parseSkillFrontmatter(raw: string): {
   description: string;
   version?: string;
+  /** `metadata.owner` (or a top-level `owner`) — the governance record's owner, verbatim. */
+  owner?: string;
+  /** `metadata.lifecycle` (or top-level) — e.g. `active`, `deprecated`, `retired`; lowercased. */
+  lifecycle?: string;
   allowedTools?: string[];
   body: string;
   /** The parsed frontmatter object (for shared id resolution: `id`/`name`). */
@@ -251,6 +262,11 @@ export function parseSkillFrontmatter(raw: string): {
   const description = typeof data.description === 'string' ? data.description.trim() : '';
   const metadata = (data.metadata ?? {}) as Record<string, unknown>;
   const version = scalarToString(data.version) ?? scalarToString(metadata.version);
+  // The governance record: `metadata.owner` / `metadata.lifecycle` first (the
+  // agentskills convention this catalog reads), a top-level spelling second.
+  const owner = (scalarToString(metadata.owner) ?? scalarToString(data.owner))?.trim() || undefined;
+  const lifecycle =
+    (scalarToString(metadata.lifecycle) ?? scalarToString(data.lifecycle))?.trim().toLowerCase() || undefined;
 
   // `allowed-tools` is a space-separated string (agentskills) or a YAML list.
   const at = data['allowed-tools'];
@@ -260,7 +276,7 @@ export function parseSkillFrontmatter(raw: string): {
       ? at.split(/\s+/).filter(Boolean)
       : undefined;
 
-  return { description, version, allowedTools, body, frontmatter: data };
+  return { description, version, owner, lifecycle, allowedTools, body, frontmatter: data };
 }
 
 /** Repo-root-relative paths of every bundled file under a skill folder (excludes SKILL.md). */

--- a/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.cli.test.ts
+++ b/packages/core-backend/src/modules/tool-manuals/__tests__/tool-manuals.cli.test.ts
@@ -192,6 +192,8 @@ describe('manual namespaces are unique, not merely manual names', () => {
    */
   async function writeMcpServer(folder: string, serverName: string): Promise<void> {
     await mkdir(join(pluginsDir(), folder), { recursive: true });
+    // A plugin is a folder with a manifest; the servers ride in its mcp.json.
+    await writeFile(join(pluginsDir(), folder, 'plugin.json'), `{"name":"${folder.toLowerCase()}"}`);
     await writeFile(
       join(pluginsDir(), folder, 'mcp.json'),
       JSON.stringify({ mcpServers: { [serverName]: { type: 'streamable-http', url: 'https://v.example/mcp' } } }),

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
@@ -18,7 +18,7 @@ import {
 } from '@bevel-software/platform-shared';
 import { descriptorsFromMcpJson } from './mcp-json-discovery.js';
 import type { PluginSource } from '../plugins/discovery/plugin-source.js';
-import { NativePluginSource } from '../plugins/discovery/native.source.js';
+import { KbPluginSource } from '../plugins/discovery/kb-plugin-source.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
@@ -151,7 +151,7 @@ export class ToolManualService implements IToolManualService {
     private readonly kbDirName: string,
     now: () => number = Date.now,
     /** Where plugins (and their MCP servers) come from — native manifests unless a dialect is configured. */
-    private readonly source: PluginSource = new NativePluginSource(),
+    private readonly source: PluginSource = new KbPluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }

--- a/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
+++ b/packages/core-backend/src/modules/tool-manuals/tool-manuals.service.ts
@@ -15,10 +15,10 @@ import {
 import {
   DEFAULT_BRANCH,
   PLUGINS_DIR,
-  PLUGIN_MANIFEST_FILE,
-  PLUGIN_MCP_FILE,
 } from '@bevel-software/platform-shared';
 import { descriptorsFromMcpJson } from './mcp-json-discovery.js';
+import type { PluginSource } from '../plugins/discovery/plugin-source.js';
+import { NativePluginSource } from '../plugins/discovery/native.source.js';
 import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
@@ -150,6 +150,8 @@ export class ToolManualService implements IToolManualService {
     private readonly accessControl: IAccessControl,
     private readonly kbDirName: string,
     now: () => number = Date.now,
+    /** Where plugins (and their MCP servers) come from — native manifests unless a dialect is configured. */
+    private readonly source: PluginSource = new NativePluginSource(),
   ) {
     this.cache = new TtlCache(CACHE_TTL_MS, now);
   }
@@ -654,27 +656,13 @@ export class ToolManualService implements IToolManualService {
     // shape. Listed BEFORE the `.tool` files: on a name collision (a legacy
     // mcp `.tool` the migration has not converted yet), the shared dedup keeps
     // the first occurrence, and the authoritative source must be the one kept.
+    // The plugins (and their mcp.json text) come from the configured source, so
+    // a dialect that expands servers from a registry lands here unchanged.
     const parsed: ToolManualDescriptor[] = [];
-    let pluginFolders: string[] = [];
-    try {
-      pluginFolders = (await fs.readdir(root, { withFileTypes: true }))
-        .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
-        .map((e) => e.name)
-        .sort();
-    } catch {
-      /* no Plugins/ root — nothing to scan */
-    }
-    for (const folder of pluginFolders) {
-      let mcpJson: string;
-      try {
-        mcpJson = await fs.readFile(path.join(root, folder, PLUGIN_MCP_FILE), 'utf-8');
-      } catch {
-        continue; // no mcp.json is the common case, not an error
-      }
-      const pluginJson = await fs
-        .readFile(path.join(root, folder, PLUGIN_MANIFEST_FILE), 'utf-8')
-        .catch(() => null);
-      parsed.push(...descriptorsFromMcpJson(folder, mcpJson, pluginJson));
+    const discovered = await this.source.discover(kbRoot);
+    for (const plugin of discovered.plugins) {
+      if (plugin.mcpJsonText === null) continue; // no servers is the common case, not an error
+      parsed.push(...descriptorsFromMcpJson(plugin.relFolder, plugin.mcpJsonText, plugin.manifestText));
     }
 
     for (const f of files) {

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.routes.read-gate.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.routes.read-gate.test.ts
@@ -182,11 +182,10 @@ describe('read-permission gates on human read routes', () => {
 
   it('keeps the structural root folders visible even when nothing is readable', async () => {
     // A user with no read grants: the access batch denies everything. The
-    // structural top-level folders (KnowledgeBase, Data, Agents, Pipelines,
-    // Plugins) must still resolve readable (so the explorer renders its
-    // section view), while their contents stay gated. The retired Skills/
-    // and Tools/ roots get NO structural treatment — they are ordinary
-    // (denied) folders now.
+    // structural top-level folders (KnowledgeBase, Skills, Data, Agents,
+    // Pipelines, Plugins) must still resolve readable (so the explorer renders
+    // its section view), while their contents stay gated. The retired Tools/
+    // root gets NO structural treatment — it is an ordinary (denied) folder.
     h = await makeHarness({ allowFn: () => false });
     expect((await get('/files')).status).toBe(200);
     const filter = h.listFilesFilter();
@@ -208,8 +207,8 @@ describe('read-permission gates on human read routes', () => {
     expect(verdict.get(`${KB}/Agents`)).toBe(true);
     expect(verdict.get(`${KB}/Pipelines`)).toBe(true);
     expect(verdict.get(`${KB}/Plugins`)).toBe(true);
-    // Retired roots: no override, the deny-all batch verdict stands.
-    expect(verdict.get(`${KB}/Skills`)).toBe(false);
+    expect(verdict.get(`${KB}/Skills`)).toBe(true);
+    // Retired root: no override, the deny-all batch verdict stands.
     expect(verdict.get(`${KB}/Tools`)).toBe(false);
     // Their contents: still gated (the override matches only the exact folder).
     expect(verdict.get(`${KB}/KnowledgeBase/Open/a.md`)).toBe(false);

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -122,6 +122,7 @@ async function fullScaffold(): Promise<Record<string, string>> {
     '.gitignore': await template('gitignore.template'),
     'KnowledgeBase/.gitkeep': '',
     'Plugins/.gitkeep': '',
+    'Skills/.gitkeep': '',
   };
 }
 
@@ -144,6 +145,7 @@ describe('TemplateFilesStep', () => {
       // Reserved roots materialize as <dir>/.gitkeep.
       expect(await exists(dir, 'KnowledgeBase/.gitkeep')).toBe(true);
       expect(await exists(dir, 'Plugins/.gitkeep')).toBe(true);
+      expect(await exists(dir, 'Skills/.gitkeep')).toBe(true);
       const subject = (await git(dir, ['log', '--format=%s', '-1'])).trim();
       expect(subject).toMatch(/^Add missing KB scaffolding: /);
       expect(subject).toContain('.gitignore');
@@ -294,7 +296,7 @@ describe('buildSeedTree', () => {
     expect(await fs.readFile(path.join(dest, 'docs/guide.md'), 'utf8')).toBe('guide');
     expect(await fs.readFile(path.join(dest, 'access.md'), 'utf8')).toBe('policy');
     // The generated paths — what the runner force-adds past a template .gitignore.
-    expect(generated.sort()).toEqual(['KnowledgeBase/.gitkeep', 'Plugins/.gitkeep', 'roles.yaml']);
+    expect(generated.sort()).toEqual(['KnowledgeBase/.gitkeep', 'Plugins/.gitkeep', 'Skills/.gitkeep', 'roles.yaml']);
     expect(await exists(dest, 'roles.yaml')).toBe(true);
   });
 });

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { KbStartupRunner } from '../../kb-startup-runner.js';
 import type { OnServerStart, ServerStartContext, StepResult } from '../../on-server-start.js';
 import { GroupsToPluginsStep } from '../groups-to-plugins.step.js';
+import { PluginManifestsStep } from '../plugin-manifests.step.js';
 import { RolesYamlStep } from '../roles-yaml.step.js';
 import { renderRolesYaml } from '../../../../access-model/render-roles-yaml.js';
 import { TemplateFilesStep } from '../template-files.step.js';
@@ -319,6 +320,49 @@ describe('buildSeedTree', () => {
     // The generated paths — what the runner force-adds past a template .gitignore.
     expect(generated.sort()).toEqual(['KnowledgeBase/.gitkeep', 'Plugins/.gitkeep', 'Skills/.gitkeep', 'roles.yaml']);
     expect(await exists(dest, 'roles.yaml')).toBe(true);
+  });
+});
+
+describe('PluginManifestsStep', () => {
+  it('writes plugin.json into legacy plugin folders on every branch, and leaves scopes and real plugins alone', async () => {
+    const scaffold = await fullScaffold();
+    await seedUpstream({
+      ...scaffold,
+      // Legacy shapes: access.md only; mcp.json only; a bare skill tree.
+      'Plugins/GTM/access.md': '---\n---\nread:\n  - everyone\n',
+      'Plugins/GTM/outreach/SKILL.md': '---\ndescription: x\n---\n',
+      'Plugins/Servers/mcp.json': '{"mcpServers":{}}',
+      'Plugins/Bare/deploy/SKILL.md': '---\ndescription: y\n---\n',
+      // Already a plugin, both shapes.
+      'Plugins/Modern/plugin.json': '{"name":"modern"}',
+      'Plugins/functional/cluster/example/plugin.bundle.json': '{"name":"example"}',
+      // A scope with rules of its own above a bundle: not a plugin.
+      'Plugins/functional/access.md': '---\n---\nread:\n  - everyone\n',
+      // Nothing plugin-shaped at all.
+      'Plugins/notes/README.md': 'just a folder',
+    });
+
+    await makeRunner([new PluginManifestsStep()]).runAll();
+
+    for (const branch of PROTECTED) {
+      const dir = await checkout(branch);
+      for (const legacy of ['GTM', 'Servers', 'Bare']) {
+        const manifest = JSON.parse(await fs.readFile(path.join(dir, `Plugins/${legacy}/plugin.json`), 'utf8'));
+        expect(manifest.name).toBe(legacy.toLowerCase());
+      }
+      expect(await exists(dir, 'Plugins/functional/plugin.json')).toBe(false);
+      expect(await exists(dir, 'Plugins/notes/plugin.json')).toBe(false);
+      expect(await fs.readFile(path.join(dir, 'Plugins/Modern/plugin.json'), 'utf8')).toBe('{"name":"modern"}');
+    }
+    const dir = await checkout(DEFAULT_BRANCH);
+    const log = (await git(dir, ['log', '-1', '--format=%B'])).trim();
+    expect(log).toContain('Add plugin manifests to 3 legacy plugin folders');
+    expect(log).toContain('Plugins/GTM: plugin.json written');
+
+    // Idempotent: nothing left to write on the next boot.
+    await makeRunner([new PluginManifestsStep()]).runAll();
+    const again = await checkout(DEFAULT_BRANCH);
+    expect((await git(again, ['rev-list', '--count', 'HEAD'])).trim()).toBe('2'); // init + one migration commit
   });
 });
 

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -186,20 +186,41 @@ describe('TemplateFilesStep', () => {
     const lines = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8')).split('\n').map((l) => l.trim());
     expect(lines).toContain('MyStuff/'); // the operator's rules survive
     expect(lines).toContain('AGENTS.md'); // the platform's rule was appended
+    expect(lines).toContain('Skills/'); // and the shared-skills root's
+  });
+
+  it('hides the Skills/ root on an existing KB whose ignore file predates it, keeping every other rule', async () => {
+    // A knowledge base seeded before `Skills/` existed: its ignore file names
+    // `Plugins/` and knows nothing of the new root. The top-up appends the
+    // one line, so the root stays the Library's and out of the agent view.
+    const scaffold = await fullScaffold();
+    scaffold['.bevelignore'] = '# mine\n.git/\nAGENTS.md\nPlugins/\n';
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    const text = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'));
+    expect(text.startsWith('# mine\n.git/\nAGENTS.md\nPlugins/\n')).toBe(true);
+    expect(text.split('\n').map((l) => l.trim())).toContain('Skills/');
+    // Idempotent: a second boot has nothing to add.
+    await makeRunner([new TemplateFilesStep()]).runAll();
+    const again = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(again, '.bevelignore'), 'utf8'))).toBe(text);
   });
 
   it('respects an explicit !AGENTS.md negation — hiding the doc is a default, not a mandate', async () => {
     // Appending the positive rule after the negation would WIN under ordered
     // matching and silently defeat the operator's stated choice to show it.
     const scaffold = await fullScaffold();
-    scaffold['.bevelignore'] = '# operator wants the doc visible\n!AGENTS.md\n';
+    scaffold['.bevelignore'] = '# operator wants the doc visible\n!AGENTS.md\nSkills/\n';
     await seedUpstream(scaffold);
 
     await makeRunner([new TemplateFilesStep()]).runAll();
 
     const dir = await checkout(DEFAULT_BRANCH);
     expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe(
-      '# operator wants the doc visible\n!AGENTS.md\n',
+      '# operator wants the doc visible\n!AGENTS.md\nSkills/\n',
     );
   });
 

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -13,6 +13,7 @@ import { renderRolesYaml } from '../../../../access-model/render-roles-yaml.js';
 import { TemplateFilesStep } from '../template-files.step.js';
 import { buildSeedTree } from '../seed-tree.js';
 import { defaultKbTemplateDir } from '../../../../../assets.js';
+import { DEFAULT_KB_LAYOUT, configureKbLayout, renderKbLayoutPlaceholders } from '@bevel-software/platform-shared';
 
 const execFileAsync = promisify(execFile);
 
@@ -55,6 +56,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  configureKbLayout({ ...DEFAULT_KB_LAYOUT });
   await fs.rm(root, { recursive: true, force: true });
 });
 
@@ -110,8 +112,9 @@ async function exists(dir: string, rel: string): Promise<boolean> {
 
 const norm = (text: string) => text.replace(/\r\n?/g, '\n');
 
+/** The template as the step writes it under the default layout — placeholders rendered. */
 async function template(name: string): Promise<string> {
-  return fs.readFile(path.join(TEMPLATE_DIR, name), 'utf8');
+  return renderKbLayoutPlaceholders(await fs.readFile(path.join(TEMPLATE_DIR, name), 'utf8'), DEFAULT_KB_LAYOUT);
 }
 
 /** Every required file + reserved root already present, from the real template. */
@@ -151,6 +154,31 @@ describe('TemplateFilesStep', () => {
       expect(subject).toMatch(/^Add missing KB scaffolding: /);
       expect(subject).toContain('.gitignore');
     }
+  });
+
+  it('renders the managed files with the deployment\'s own root names', async () => {
+    // A deployment that renamed its roots must hand the agent a guide naming
+    // the folders it will find, and an ignore file hiding the real ones.
+    configureKbLayout({ knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' });
+    await seedUpstream({ 'marker.txt': 'seeded' });
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    const agents = norm(await fs.readFile(path.join(dir, 'AGENTS.md'), 'utf8'));
+    expect(agents).toContain('plugins/<Plugin>/plugin.json');
+    expect(agents).toContain('`docs/`');
+    expect(agents).not.toContain('{{');
+    expect(agents).not.toContain('KnowledgeBase/');
+    const ignore = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8')).split('\n').map((l) => l.trim());
+    expect(ignore).toContain('plugins/');
+    expect(ignore).toContain('skills/');
+    expect(ignore).not.toContain('Plugins/');
+    expect(await exists(dir, 'docs/.gitkeep')).toBe(true);
+
+    // And a second boot sees the rendered guide as current: no churn commit.
+    await makeRunner([new TemplateFilesStep()]).runAll();
+    const again = await checkout(DEFAULT_BRANCH);
+    expect((await git(again, ['rev-list', '--count', 'HEAD'])).trim()).toBe('2'); // init + scaffolding
   });
 
   it('replaces a drifted AGENTS.md, and says so when that is the only change', async () => {

--- a/packages/core-backend/src/modules/workspace/startup/steps/plugin-manifests.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/plugin-manifests.step.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  HEXIS_EXTENSION_NS,
+  PLUGINS_DIR,
+  PLUGIN_MANIFEST_FILE,
+  PLUGIN_MCP_FILE,
+  PLUGIN_SKILLS_DIR,
+  renderPluginManifest,
+} from '@bevel-software/platform-shared';
+import { BUNDLE_FILE } from '../../../plugins/discovery/bundle-dialect/bundle.source.js';
+import type { KbBranch, OnServerStart, ServerStartContext, StepResult } from '../on-server-start.js';
+
+/**
+ * Give every legacy plugin folder its manifest, as an {@link OnServerStart}
+ * step.
+ *
+ * A plugin IS a folder carrying `plugin.json` (or a `plugin.bundle.json`, the
+ * read-only customer dialect) — discovery reads nothing else, at any depth.
+ * Folders from before the manifest existed have `access.md`, an `mcp.json`,
+ * a `skills/` tree or `.tool` manuals and no `plugin.json` beside them; the
+ * old scanners read those by position (directly under the plugins root),
+ * and this step is what retires that rule: it writes the minimal manifest
+ * into each such folder, once, so the position never has to mean anything
+ * again.
+ *
+ * WHICH folders: walk the plugins root; a folder holding either file is a
+ * plugin and is not entered. Any other folder is entered first. A folder
+ * DIRECTLY under the root — the only place the legacy layout ever put a
+ * plugin — becomes one when nothing plugin-shaped lives beneath it and its
+ * own content is legacy content: a scope folder (the dialect's
+ * `plugins/functional/…`) can carry an `access.md` of its own and must stay
+ * a scope, and a skill folder inside a legacy plugin must not become a
+ * plugin of its own. "Legacy content" is the set of things provisioning and
+ * the old migration ever put in a plugin folder: `access.md`, `mcp.json`,
+ * `skills/`, the hexis extension directory, a `.tool` file, or a `SKILL.md`
+ * anywhere beneath (the pre-`skills/` shape).
+ *
+ * Every branch, drafts included, like the Groups→Plugins migration and for
+ * the same reason: a draft migrated alongside its target diffs by the user's
+ * own changes only. Idempotent: a folder that has its manifest is skipped.
+ */
+export class PluginManifestsStep implements OnServerStart {
+  readonly name = 'plugin-manifests';
+
+  async run(ctx: ServerStartContext): Promise<StepResult> {
+    for (const branch of await ctx.allBranches()) {
+      await addManifests(branch);
+    }
+    return { outcome: 'ok' };
+  }
+}
+
+async function addManifests(branch: KbBranch): Promise<void> {
+  const repoDir = await branch.repoDir();
+  const root = path.join(repoDir, PLUGINS_DIR);
+  const added: string[] = [];
+
+  /** Resolves to how many plugins sit at or beneath `dir`. */
+  const visit = async (dir: string, rel: string): Promise<number> => {
+    if (rel && ((await isFile(path.join(dir, PLUGIN_MANIFEST_FILE))) || (await isFile(path.join(dir, BUNDLE_FILE))))) {
+      return 1;
+    }
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return 0;
+    }
+    let beneath = 0;
+    for (const entry of entries.filter((e) => e.isDirectory() && !e.name.startsWith('.'))) {
+      beneath += await visit(path.join(dir, entry.name), rel ? `${rel}/${entry.name}` : entry.name);
+    }
+    if (beneath > 0 || !rel || rel.includes('/')) return beneath;
+    if (!(await looksLikeLegacyPlugin(dir, entries))) return 0;
+    const manifestRel = `${PLUGINS_DIR}/${rel}/${PLUGIN_MANIFEST_FILE}`;
+    branch.write(manifestRel, renderPluginManifest(path.posix.basename(rel)));
+    added.push(rel);
+    return 1;
+  };
+
+  await visit(root, '');
+  if (added.length === 0) return;
+  branch.note(`Add plugin manifests to ${added.length === 1 ? 'a legacy plugin folder' : `${added.length} legacy plugin folders`}`);
+  for (const rel of added) branch.note(`${PLUGINS_DIR}/${rel}: ${PLUGIN_MANIFEST_FILE} written`);
+}
+
+async function looksLikeLegacyPlugin(dir: string, entries: import('node:fs').Dirent[]): Promise<boolean> {
+  for (const entry of entries) {
+    if (entry.isFile() && (entry.name === 'access.md' || entry.name === PLUGIN_MCP_FILE || entry.name.toLowerCase().endsWith('.tool'))) {
+      return true;
+    }
+    if (entry.isDirectory() && (entry.name === PLUGIN_SKILLS_DIR || entry.name === HEXIS_EXTENSION_NS)) return true;
+  }
+  return hasSkillBeneath(dir);
+}
+
+/** The pre-`skills/` shape: `Plugins/<Plugin>/<skill>/SKILL.md`, at any depth. */
+async function hasSkillBeneath(dir: string): Promise<boolean> {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  if (entries.some((e) => e.isFile() && e.name === 'SKILL.md')) return true;
+  for (const entry of entries) {
+    if (entry.isDirectory() && !entry.name.startsWith('.') && (await hasSkillBeneath(path.join(dir, entry.name)))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function isFile(abs: string): Promise<boolean> {
+  return fs.stat(abs).then((s) => s.isFile(), () => false);
+}

--- a/packages/core-backend/src/modules/workspace/startup/steps/plugin-manifests.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/plugin-manifests.step.ts
@@ -64,8 +64,11 @@ async function addManifests(branch: KbBranch): Promise<void> {
     let entries: import('node:fs').Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return 0;
+    } catch (err) {
+      // Absence is the plugins root not existing yet; anything else must stop
+      // the boot rather than quietly leave legacy plugins without manifests.
+      if (isAbsence(err)) return 0;
+      throw err;
     }
     let beneath = 0;
     for (const entry of entries.filter((e) => e.isDirectory() && !e.name.startsWith('.'))) {
@@ -100,8 +103,9 @@ async function hasSkillBeneath(dir: string): Promise<boolean> {
   let entries: import('node:fs').Dirent[];
   try {
     entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch {
-    return false;
+  } catch (err) {
+    if (isAbsence(err)) return false;
+    throw err;
   }
   if (entries.some((e) => e.isFile() && e.name === 'SKILL.md')) return true;
   for (const entry of entries) {
@@ -113,5 +117,16 @@ async function hasSkillBeneath(dir: string): Promise<boolean> {
 }
 
 async function isFile(abs: string): Promise<boolean> {
-  return fs.stat(abs).then((s) => s.isFile(), () => false);
+  return fs.stat(abs).then(
+    (s) => s.isFile(),
+    (err: unknown) => {
+      if (isAbsence(err)) return false;
+      throw err; // a probe that fails for another reason is not "no manifest"
+    },
+  );
+}
+
+function isAbsence(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }

--- a/packages/core-backend/src/modules/workspace/startup/steps/seed-tree.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/seed-tree.ts
@@ -90,7 +90,7 @@ async function copyTemplateTree(templateDir: string, dest: string): Promise<void
 }
 
 /** Template files that are TEXT and may carry layout placeholders; anything else is copied byte for byte. */
-const TEXT_TEMPLATE = /(\.(md|markdown|ya?ml|json|txt|template)|\/?\.[^/]+)$/i;
+const TEXT_TEMPLATE = /(\.(md|markdown|ya?ml|json|txt|template)|(?:^|[/\\])\.[^/\\]+)$/i;
 
 /**
  * Copy one template file (by repo-relative path) into `dest`, creating

--- a/packages/core-backend/src/modules/workspace/startup/steps/seed-tree.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/seed-tree.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { renderKbLayoutPlaceholders } from '@bevel-software/platform-shared';
 import { renderRolesYaml } from '../../../access-model/render-roles-yaml.js';
 import { TEMPLATE_SOURCE_FALLBACKS, reservedRootDirs, templateSource } from './template-files.step.js';
 
@@ -88,12 +89,24 @@ async function copyTemplateTree(templateDir: string, dest: string): Promise<void
   await walk('');
 }
 
-/** Copy one template file (by repo-relative path) into `dest`, creating parents. */
+/** Template files that are TEXT and may carry layout placeholders; anything else is copied byte for byte. */
+const TEXT_TEMPLATE = /(\.(md|markdown|ya?ml|json|txt|template)|\/?\.[^/]+)$/i;
+
+/**
+ * Copy one template file (by repo-relative path) into `dest`, creating
+ * parents. Text files are RENDERED — the managed guide and the ignore file
+ * name the three root folders, which a deployment may have renamed — and a
+ * file without placeholders comes out byte-identical to its source.
+ */
 async function copyTemplateFile(templateDir: string, relPath: string, dest: string): Promise<void> {
   const from = await templateSource(templateDir, relPath);
   const to = path.join(dest, relPath);
   await fs.mkdir(path.dirname(to), { recursive: true });
-  await fs.copyFile(from, to);
+  if (TEXT_TEMPLATE.test(relPath)) {
+    await fs.writeFile(to, renderKbLayoutPlaceholders(await fs.readFile(from, 'utf8')), 'utf8');
+  } else {
+    await fs.copyFile(from, to);
+  }
 }
 
 async function exists(p: string): Promise<boolean> {

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { KNOWLEDGE_BASE_DIR, PLUGINS_DIR } from '@bevel-software/platform-shared';
+import { KNOWLEDGE_BASE_DIR, PLUGINS_DIR, SKILLS_DIR } from '@bevel-software/platform-shared';
 import { IGNORE_FILENAME } from '../../bevel-ignore.js';
 import type { KbBranch, OnServerStart, ServerStartContext, StepResult } from '../on-server-start.js';
 
@@ -43,8 +43,8 @@ export const TEMPLATE_SOURCE_FALLBACKS: Readonly<Record<string, string>> = {
 };
 
 /**
- * The two roots CORE gives a knowledge base: the ontologies, and the plugins
- * that hold skills and tools.
+ * The three roots CORE gives a knowledge base: the ontologies, the shared
+ * skills, and the plugins that hold tools and link the skills.
  *
  * `Data/`, `Agents/` and `Pipelines/` are deliberately absent. They scaffold
  * the agentic execution layer, which is not part of this platform — a core
@@ -54,8 +54,13 @@ export const TEMPLATE_SOURCE_FALLBACKS: Readonly<Record<string, string>> = {
  * READMEs); the names stay reserved in `kb-layout.ts` either way, so a KB
  * that has them still renders them as roots rather than folding them into
  * Knowledge.
+ *
+ * A function: the three names are deployment-configurable live bindings, and
+ * a module-scope array would snapshot the defaults before configuration.
  */
-const CORE_REQUIRED_DIRS: readonly string[] = [KNOWLEDGE_BASE_DIR, PLUGINS_DIR];
+function coreRequiredDirs(): readonly string[] {
+  return [KNOWLEDGE_BASE_DIR, SKILLS_DIR, PLUGINS_DIR];
+}
 
 /**
  * A reserved root must be ONE path segment — `Data`, not `Data/x`, `../x` or
@@ -102,7 +107,7 @@ export function reservedRootDirs(extraRootDirs: readonly string[]): readonly str
       );
     }
   }
-  return [...CORE_REQUIRED_DIRS, ...extraRootDirs];
+  return [...coreRequiredDirs(), ...extraRootDirs];
 }
 
 /**

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { KNOWLEDGE_BASE_DIR, PLUGINS_DIR, SKILLS_DIR } from '@bevel-software/platform-shared';
+import {
+  KNOWLEDGE_BASE_DIR,
+  PLUGINS_DIR,
+  SKILLS_DIR,
+  renderKbLayoutPlaceholders,
+} from '@bevel-software/platform-shared';
 import { IGNORE_FILENAME } from '../../bevel-ignore.js';
 import type { KbBranch, OnServerStart, ServerStartContext, StepResult } from '../on-server-start.js';
 
@@ -205,17 +210,14 @@ export class TemplateFilesStep implements OnServerStart {
             'Remove or rename it — the platform requires this name to be a readable file.',
         );
       }
-      let content: Uint8Array | string = await readTemplate(templateDir, rel);
+      let content = await readTemplate(templateDir, rel);
       // The on-disk merge below only runs against an EXISTING ignore file; a
       // freshly-declared one was merely assumed to carry the AGENTS.md rule —
       // true of the packaged template, not necessarily of a distribution's
       // custom one. Make it true here, so the managed conventions doc is
       // hidden from the file tree from the first boot either way.
       if (rel === IGNORE_FILENAME) {
-        content = withIgnorePattern(
-          withIgnorePattern(new TextDecoder().decode(content), 'AGENTS.md'),
-          `${SKILLS_DIR}/`,
-        );
+        content = withIgnorePattern(withIgnorePattern(content, 'AGENTS.md'), `${SKILLS_DIR}/`);
       }
       branch.write(rel, content);
       added.push(rel);
@@ -308,21 +310,29 @@ export class TemplateFilesStep implements OnServerStart {
   }
 }
 
-/** The template's content for `relPath`, bytes as shipped. */
-async function readTemplate(templateDir: string, relPath: string): Promise<Uint8Array> {
-  return fs.readFile(await templateSource(templateDir, relPath));
+/**
+ * The template's content for `relPath`, RENDERED: the managed files name the
+ * three root folders, and a deployment may have renamed those, so the
+ * placeholders the template carries (`{{pluginsDir}}` …) are filled with the
+ * names in effect. Every required file is text; a template without
+ * placeholders passes through unchanged.
+ */
+async function readTemplate(templateDir: string, relPath: string): Promise<string> {
+  return renderKbLayoutPlaceholders(await fs.readFile(await templateSource(templateDir, relPath), 'utf8'));
 }
 
 /**
- * Whether the repo's copy of `relPath` differs from the template's, modulo
- * line endings — a CRLF checkout of identical content must read as "same",
- * or the managed-file refresh would commit churn on every boot forever.
+ * Whether the repo's copy of `relPath` differs from the RENDERED template's,
+ * modulo line endings — a CRLF checkout of identical content must read as
+ * "same", or the managed-file refresh would commit churn on every boot
+ * forever. Rendered, so a renamed root is compared against the guide that
+ * names it, not against the placeholders.
  */
 async function templateDiffers(templateDir: string, repoDir: string, relPath: string): Promise<boolean> {
   const norm = (text: string) => text.replace(/\r\n?/g, '\n');
   const [current, template] = await Promise.all([
     fs.readFile(path.join(repoDir, relPath), 'utf8'),
-    templateSource(templateDir, relPath).then((from) => fs.readFile(from, 'utf8')),
+    readTemplate(templateDir, relPath),
   ]);
   return norm(current) !== norm(template);
 }

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -370,7 +370,7 @@ async function mergeIgnorePatterns(repoDir: string, branch: KbBranch, patterns: 
 /**
  * `text` with `pattern` guaranteed present as a LINE — appended under a
  * comment naming its origin when absent, returned unchanged when present.
- * Line-wise match, same rationale as {@link mergeIgnorePattern}.
+ * Line-wise match, same rationale as {@link mergeIgnorePatterns}.
  *
  * An explicit `!pattern` line also returns the text unchanged: that is the
  * operator choosing to SHOW the file, and ordered matching means a positive

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -232,14 +232,14 @@ export class TemplateFilesStep implements OnServerStart {
     // LINE PRESENCE, not effective outcome: a later `!AGENTS.md` negation is
     // the operator explicitly choosing to SHOW the file, and hiding it is a
     // default this step provides, not a mandate it re-imposes every boot.
-    added.push(...(await mergeIgnorePattern(repoDir, branch, 'AGENTS.md')));
-
-    // The shared-skills root is the Library's, like `Plugins/`: a KB whose
-    // ignore file predates it would show `Skills/` in the Knowledge tree and
-    // the agent view. Same idempotent, line-presence merge as above — and
-    // spelled with the CONFIGURED root name, since a deployment may have
-    // renamed it.
-    added.push(...(await mergeIgnorePattern(repoDir, branch, `${SKILLS_DIR}/`)));
+    //
+    // The shared-skills root rides the same merge: it is the Library's, like
+    // `Plugins/`, and a KB whose ignore file predates it would show `Skills/`
+    // in the Knowledge tree and the agent view. Spelled with the CONFIGURED
+    // root name, since a deployment may have renamed it. ONE read-modify-
+    // write for both patterns: two merges would each read the on-disk file
+    // and the second declared write would drop the first's line.
+    added.push(...(await mergeIgnorePatterns(repoDir, branch, ['AGENTS.md', `${SKILLS_DIR}/`])));
 
     // AGENTS.md is MANAGED, not merely seeded: the platform owns its content,
     // and a stale copy is replaced with the packaged template's every startup
@@ -328,7 +328,7 @@ async function templateDiffers(templateDir: string, repoDir: string, relPath: st
 }
 
 /**
- * Ensure `.bevelignore` carries `pattern`, declaring the appended content when
+ * Ensure `.bevelignore` carries every `pattern`, declaring the appended content when
  * absent. Returns the paths changed, for the note.
  *
  * APPENDS — never rewrites. The file is the operator's, and every rule
@@ -341,17 +341,17 @@ async function templateDiffers(templateDir: string, repoDir: string, relPath: st
  * is not a rule for the root `AGENTS.md`, and treating it as one would leave
  * the mismatch this exists to close.
  */
-async function mergeIgnorePattern(repoDir: string, branch: KbBranch, pattern: string): Promise<string[]> {
+async function mergeIgnorePatterns(repoDir: string, branch: KbBranch, patterns: string[]): Promise<string[]> {
   let current: string;
   try {
     current = await fs.readFile(path.join(repoDir, IGNORE_FILENAME), 'utf8');
   } catch {
     // No ignore file — the copy declared from the template arrives with the
-    // pattern in it (guaranteed at declaration time, see the required-files
+    // patterns in it (guaranteed at declaration time, see the required-files
     // loop above).
     return [];
   }
-  const merged = withIgnorePattern(current, pattern);
+  const merged = patterns.reduce((text, pattern) => withIgnorePattern(text, pattern), current);
   if (merged === current) return [];
   branch.write(IGNORE_FILENAME, merged);
   return [IGNORE_FILENAME];

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -212,7 +212,10 @@ export class TemplateFilesStep implements OnServerStart {
       // custom one. Make it true here, so the managed conventions doc is
       // hidden from the file tree from the first boot either way.
       if (rel === IGNORE_FILENAME) {
-        content = withIgnorePattern(new TextDecoder().decode(content), 'AGENTS.md');
+        content = withIgnorePattern(
+          withIgnorePattern(new TextDecoder().decode(content), 'AGENTS.md'),
+          `${SKILLS_DIR}/`,
+        );
       }
       branch.write(rel, content);
       added.push(rel);
@@ -230,6 +233,13 @@ export class TemplateFilesStep implements OnServerStart {
     // the operator explicitly choosing to SHOW the file, and hiding it is a
     // default this step provides, not a mandate it re-imposes every boot.
     added.push(...(await mergeIgnorePattern(repoDir, branch, 'AGENTS.md')));
+
+    // The shared-skills root is the Library's, like `Plugins/`: a KB whose
+    // ignore file predates it would show `Skills/` in the Knowledge tree and
+    // the agent view. Same idempotent, line-presence merge as above — and
+    // spelled with the CONFIGURED root name, since a deployment may have
+    // renamed it.
+    added.push(...(await mergeIgnorePattern(repoDir, branch, `${SKILLS_DIR}/`)));
 
     // AGENTS.md is MANAGED, not merely seeded: the platform owns its content,
     // and a stale copy is replaced with the packaged template's every startup

--- a/packages/core-backend/src/modules/workspace/workspace.routes.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.routes.ts
@@ -4,15 +4,7 @@ import { IGNORE_FILENAME } from './bevel-ignore.js';
 import type { IAdminAccessService } from '../admin/admin.interface.js';
 import express from 'express';
 import type { AuthUser, IWorkflowService } from '@bevel-software/platform-shared';
-import {
-  AGENTS_DIR,
-  DATA_DIR,
-  DEFAULT_BRANCH,
-  KNOWLEDGE_BASE_DIR,
-  KNOWLEDGE_DIR,
-  PIPELINES_DIR,
-  PLUGINS_DIR,
-} from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, KNOWLEDGE_DIR, reservedRootDirNames } from '@bevel-software/platform-shared';
 import { FolderTooLargeError, type ReadTreeFilter } from './workspace.service.js';
 import { branchForWorkspaceId } from '../../shared/workspace-id.js';
 import type { WorkspaceService } from './workspace.service.js';
@@ -476,14 +468,7 @@ export function createWorkspaceRoutes(
       // same treatment so legacy clones don't collapse. Only the folders
       // themselves are forced visible — their contents stay gated by the
       // verdict above.
-      const structuralRoots = new Set([
-        KNOWLEDGE_BASE_DIR,
-        DATA_DIR,
-        AGENTS_DIR,
-        PIPELINES_DIR,
-        PLUGINS_DIR,
-        KNOWLEDGE_DIR,
-      ]);
+      const structuralRoots = new Set([...reservedRootDirNames(), KNOWLEDGE_DIR]);
       for (const wp of wsRelPaths) {
         const rel = toKbRelative(wp, kbDirName);
         if (rel !== null && structuralRoots.has(rel)) verdict.set(wp, true);

--- a/packages/core-frontend/src/core/__tests__/bootstrap.test.ts
+++ b/packages/core-frontend/src/core/__tests__/bootstrap.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { configureBranchModel, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
+import {
+  configureBranchModel,
+  configureKbLayout,
+  DEFAULT_BRANCH,
+  DEFAULT_KB_LAYOUT,
+  PLUGINS_DIR,
+  SKILLS_DIR,
+} from '@bevel-software/platform-shared';
 import { loadServerConfig } from '../bootstrap';
 import { mcpEndpointUrl } from '../../shared/mcp';
 
@@ -26,6 +33,7 @@ afterEach(() => {
   // The model is module-global; restore what the shared test setup applied so
   // a later suite is not left with whatever a case here configured.
   configureBranchModel(CONFIGURED);
+  configureKbLayout({ ...DEFAULT_KB_LAYOUT });
 });
 
 const respond = (branchModel: unknown, rest: Record<string, unknown> = {}) =>
@@ -70,6 +78,30 @@ describe('loadServerConfig', () => {
    * one the OAuth metadata publishes, and that is the one that decides
    * whether a connector works.
    */
+  describe('the KB layout', () => {
+    it('applies the root names the server runs with', async () => {
+      respond(CONFIGURED, {
+        kbLayout: { knowledgeBaseDir: 'docs', skillsDir: 'skills', pluginsDir: 'plugins' },
+      });
+      await loadServerConfig();
+      expect(SKILLS_DIR).toBe('skills');
+      expect(PLUGINS_DIR).toBe('plugins');
+    });
+
+    it('keeps the defaults when an older server sends none', async () => {
+      respond(CONFIGURED);
+      await loadServerConfig();
+      expect(SKILLS_DIR).toBe('Skills');
+      expect(PLUGINS_DIR).toBe('Plugins');
+    });
+
+    it('keeps the defaults rather than applying a layout that cannot be valid', async () => {
+      respond(CONFIGURED, { kbLayout: { knowledgeBaseDir: 'x', skillsDir: 'x', pluginsDir: 'x' } });
+      await loadServerConfig();
+      expect(SKILLS_DIR).toBe('Skills');
+    });
+  });
+
   describe('the MCP endpoint', () => {
     it('applies what the server said', async () => {
       respond(CONFIGURED, { mcpUrl: 'https://kb.acme.com/api/mcp' });

--- a/packages/core-frontend/src/core/bootstrap.ts
+++ b/packages/core-frontend/src/core/bootstrap.ts
@@ -70,7 +70,16 @@ export async function loadServerConfig(): Promise<void> {
   // The KB layout has defaults, so an absent or invalid one is not a boot
   // failure either: the module keeps its defaults, which is exactly what an
   // older server that omits the field is running with.
-  if (config.kbLayout && !validateKbLayout(config.kbLayout)) configureKbLayout(config.kbLayout);
+  const layout = config.kbLayout;
+  if (
+    layout &&
+    typeof layout.knowledgeBaseDir === 'string' &&
+    typeof layout.skillsDir === 'string' &&
+    typeof layout.pluginsDir === 'string' &&
+    !validateKbLayout(layout)
+  ) {
+    configureKbLayout(layout);
+  }
 
   /**
    * Unconditional, and deliberately not guarded by the branch-model check

--- a/packages/core-frontend/src/core/bootstrap.ts
+++ b/packages/core-frontend/src/core/bootstrap.ts
@@ -1,4 +1,10 @@
-import { configureBranchModel, validateBranchModel } from '@bevel-software/platform-shared';
+import {
+  configureBranchModel,
+  configureKbLayout,
+  validateBranchModel,
+  validateKbLayout,
+  type KbLayout,
+} from '@bevel-software/platform-shared';
 // The pure module, NOT the `shared/mcp` barrel — the same reason `test-setup.ts`
 // avoids it. This runs BEFORE React renders, and the barrel would drag the
 // components and their icon imports into the boot path to set one string.
@@ -14,6 +20,11 @@ interface ServerConfig {
    * is what every connect surface did before this existed.
    */
   mcpUrl?: string;
+  /**
+   * Optional for the same version-skew reason: a server that predates the
+   * field leaves the defaults in place, which is what it was running with.
+   */
+  kbLayout?: KbLayout;
 }
 
 /**
@@ -52,6 +63,11 @@ export async function loadServerConfig(): Promise<void> {
    */
   const problem = validateBranchModel(config.branchModel);
   if (!problem) configureBranchModel(config.branchModel);
+
+  // The KB layout has defaults, so an absent or invalid one is not a boot
+  // failure either: the module keeps its defaults, which is exactly what an
+  // older server that omits the field is running with.
+  if (config.kbLayout && !validateKbLayout(config.kbLayout)) configureKbLayout(config.kbLayout);
 
   /**
    * Unconditional, and deliberately not guarded by the branch-model check

--- a/packages/core-frontend/src/core/bootstrap.ts
+++ b/packages/core-frontend/src/core/bootstrap.ts
@@ -9,6 +9,7 @@ import {
 // avoids it. This runs BEFORE React renders, and the barrel would drag the
 // components and their icon imports into the boot path to set one string.
 import { configureMcpUrl } from '../shared/mcp/connect-snippets';
+import { configureMarketplaceGitUrl } from '../shared/marketplace-url';
 
 /** What `GET /api/config` serves. Unauthenticated — see the route's comment. */
 interface ServerConfig {
@@ -25,6 +26,8 @@ interface ServerConfig {
    * field leaves the defaults in place, which is what it was running with.
    */
   kbLayout?: KbLayout;
+  /** The per-user marketplace git remote; absent from an older server. */
+  marketplaceGitUrl?: string;
 }
 
 /**
@@ -77,6 +80,7 @@ export async function loadServerConfig(): Promise<void> {
    * origin rather than taking down the boot for a snippet.
    */
   configureMcpUrl(config.mcpUrl);
+  configureMarketplaceGitUrl(config.marketplaceGitUrl);
 }
 
 /**

--- a/packages/core-frontend/src/modules/access/api.ts
+++ b/packages/core-frontend/src/modules/access/api.ts
@@ -1,10 +1,42 @@
 import { authFetch } from '../../lib/api';
 import { GitApiError, handleApiResponse } from '../git/services/git.api';
 
-/** A collective grantee with WHAT it is — role (capability) or group (audience). */
+/**
+ * A collective grantee with WHAT it is — role (capability), group (audience),
+ * or plugin (everyone holding a verb on a plugin folder: the name is the
+ * `plugin/<Name>/<verb>` token).
+ */
 export interface ResolvedPrincipal {
   name: string;
-  kind: 'role' | 'group';
+  kind: 'role' | 'group' | 'plugin';
+}
+
+/** The verbs a plugin principal can stand for — each is its own grantee. */
+export type PluginPrincipalVerb = 'read' | 'write' | 'owner';
+export const PLUGIN_PRINCIPAL_VERBS: readonly PluginPrincipalVerb[] = ['read', 'write', 'owner'];
+
+/** How a plugin principal is spelled in access rules and resolver output. */
+export function pluginPrincipalToken(plugin: string, verb: PluginPrincipalVerb): string {
+  return `plugin/${plugin}/${verb}`;
+}
+
+/** The parts of a `plugin/<Name>/<verb>` token, or null when it is not one. */
+export function parsePluginPrincipalToken(
+  token: string,
+): { plugin: string; verb: PluginPrincipalVerb } | null {
+  if (!token.toLowerCase().startsWith('plugin/')) return null;
+  const rest = token.slice('plugin/'.length);
+  const cut = rest.lastIndexOf('/');
+  if (cut <= 0) return null;
+  const verb = rest.slice(cut + 1).toLowerCase();
+  if (!(PLUGIN_PRINCIPAL_VERBS as readonly string[]).includes(verb)) return null;
+  return { plugin: rest.slice(0, cut), verb: verb as PluginPrincipalVerb };
+}
+
+/** "GTM · readers" — the human spelling of a plugin principal. */
+export function pluginPrincipalLabel(plugin: string, verb: PluginPrincipalVerb): string {
+  const who = verb === 'read' ? 'readers' : verb === 'write' ? 'writers' : 'owners';
+  return `${plugin} · ${who}`;
 }
 
 export interface AccessEligible {
@@ -113,7 +145,9 @@ export function asInheritedError(err: unknown): InheritedRevokeError | null {
 export type Principal =
   | { kind: 'user'; email: string; displayName: string }
   | { kind: 'role'; role: string }
-  | { kind: 'group'; group: string };
+  | { kind: 'group'; group: string }
+  /** Everyone holding `verb` on the plugin folder — written as `plugin/<Name>/<verb>`. */
+  | { kind: 'plugin'; plugin: string; verb: PluginPrincipalVerb };
 
 /** Verbs the share dialog can grant. */
 export type GrantVerb = 'read' | 'write' | 'owner' | 'download';
@@ -129,6 +163,12 @@ export interface SuggestResponse {
   roles?: string[];
   /** Active-source groups. A name shared with a role is offered as BOTH. */
   groups?: string[];
+  /**
+   * Plugin FOLDER names the caller can discover; each stands for three
+   * grantable principals (`plugin/<Name>/read|write|owner`). Not `plugins`,
+   * which was the retired alias of `roles`.
+   */
+  pluginPrincipals?: string[];
   people?: { name: string; email: string }[];
   /** True when the query was too short to return people (roles/groups still shown). */
   peopleWithheld?: boolean;

--- a/packages/core-frontend/src/modules/access/components/ManageAccessDialog.tsx
+++ b/packages/core-frontend/src/modules/access/components/ManageAccessDialog.tsx
@@ -24,6 +24,11 @@ import {
   grantAccess,
   revokeAccess,
   suggestPrincipals,
+  PLUGIN_PRINCIPAL_VERBS,
+  parsePluginPrincipalToken,
+  pluginPrincipalLabel,
+  pluginPrincipalToken,
+  type ResolvedPrincipal,
   asInheritedError,
   type AccessEligible,
   type AccessResponse,
@@ -83,7 +88,7 @@ interface PrincipalRow {
    * (grant audience). Decides the badge ("Role" vs "Group") and which
    * principal kind mutations round-trip with.
    */
-  kind: 'user' | 'role' | 'group';
+  kind: 'user' | 'role' | 'group' | 'plugin';
   isYou: boolean;
   /** The principal to send on grant / revoke. */
   principal: Principal;
@@ -164,7 +169,10 @@ function principalKey(p: Principal): string {
     ? `r:${p.role.toLowerCase()}`
     : p.kind === 'group'
       ? `g:${p.group.toLowerCase()}`
-      : `u:${p.email.toLowerCase()}`;
+      : p.kind === 'plugin'
+        // The server keys plugin principals by their full token (`p:plugin/gtm/read`).
+        ? `p:${pluginPrincipalToken(p.plugin, p.verb).toLowerCase()}`
+        : `u:${p.email.toLowerCase()}`;
 }
 
 /**
@@ -527,25 +535,35 @@ export function ManageAccessDialog({
     // Kinded collective list for one eligible set. Older servers omit
     // `principals` (version skew) — fall back to the name-only `roles`,
     // treating everything as a role (the pre-groups display).
-    const collectivesOf = (list: AccessEligible): { name: string; kind: 'role' | 'group' }[] =>
+    const collectivesOf = (list: AccessEligible): ResolvedPrincipal[] =>
       list.principals ?? list.roles.map((name) => ({ name, kind: 'role' as const }));
-    const touchCollective = (c: { name: string; kind: 'role' | 'group' }): PrincipalRow => {
-      // Rows are keyed by KIND + name (`g:`/`r:`) — the backend treats a bare
-      // `Product` (group) and `role/Product` (role) as DIFFERENT principals,
-      // so a group and a role sharing a name are two rows, each mutating its
-      // own grant. Collapsing them to one row silently pointed every edit at
-      // the group and hid the role's grant entirely.
+    const touchCollective = (c: ResolvedPrincipal): PrincipalRow => {
+      // Rows are keyed by KIND + name (`g:`/`r:`/`p:`) — the backend treats a
+      // bare `Product` (group) and `role/Product` (role) as DIFFERENT
+      // principals, so a group and a role sharing a name are two rows, each
+      // mutating its own grant. Collapsing them to one row silently pointed
+      // every edit at the group and hid the role's grant entirely. A plugin
+      // principal's name is its full `plugin/<Name>/<verb>` token.
       const key =
-        c.kind === 'group' ? `g:${c.name.toLowerCase()}` : `r:${c.name.toLowerCase()}`;
+        c.kind === 'group'
+          ? `g:${c.name.toLowerCase()}`
+          : c.kind === 'plugin'
+            ? `p:${c.name.toLowerCase()}`
+            : `r:${c.name.toLowerCase()}`;
       let row = rows.get(key);
       if (!row) {
+        const plugin = c.kind === 'plugin' ? parsePluginPrincipalToken(c.name) : null;
         row = {
           key,
-          label: c.name,
+          label: plugin ? pluginPrincipalLabel(plugin.plugin, plugin.verb) : c.name,
           kind: c.kind,
           isYou: false,
           principal:
-            c.kind === 'group' ? { kind: 'group', group: c.name } : { kind: 'role', role: c.name },
+            c.kind === 'group'
+              ? { kind: 'group', group: c.name }
+              : plugin
+                ? { kind: 'plugin', plugin: plugin.plugin, verb: plugin.verb }
+                : { kind: 'role', role: c.name },
           verbs: { owner: false, write: false, read: false, download: false },
           manage: 'direct',
           ancestors: [],
@@ -687,7 +705,13 @@ export function ManageAccessDialog({
   }, [query, suggest]);
 
   const principalLabel = (p: Principal): string =>
-    p.kind === 'role' ? p.role : p.kind === 'group' ? p.group : p.displayName || p.email;
+    p.kind === 'role'
+      ? p.role
+      : p.kind === 'group'
+        ? p.group
+        : p.kind === 'plugin'
+          ? pluginPrincipalLabel(p.plugin, p.verb)
+          : p.displayName || p.email;
 
   const addChip = useCallback((p: Principal) => {
     setPickedChips((chips) =>
@@ -1036,7 +1060,7 @@ export function ManageAccessDialog({
               // The same chip vocabulary as the suggest menu's trailing tags:
               // a role is a capability, a group is an audience — badge which.
               <Badge tone="outline" size="xs" className="shrink-0 uppercase">
-                {p.kind === 'group' ? 'Group' : 'Role'}
+                {p.kind === 'group' ? 'Group' : p.kind === 'plugin' ? 'Plugin' : 'Role'}
               </Badge>
             )}
           </div>
@@ -1202,7 +1226,7 @@ export function ManageAccessDialog({
                     `roles` or `groups` (version skew) must degrade to an empty
                     section, never a crash. Groups lead — they are the audience
                     concept grants are meant for; roles remain grantable below. */}
-                {query.trim() && suggest && ((suggest.groups?.length ?? 0) > 0 || (suggest.roles?.length ?? 0) > 0 || (suggest.people?.length ?? 0) > 0) && (
+                {query.trim() && suggest && ((suggest.groups?.length ?? 0) > 0 || (suggest.roles?.length ?? 0) > 0 || (suggest.pluginPrincipals?.length ?? 0) > 0 || (suggest.people?.length ?? 0) > 0) && (
                   <AnchoredMenu width="anchor" align="left" className="max-h-56 overflow-auto">
                     {(suggest.groups ?? []).map((g) => (
                       <MenuItem
@@ -1232,6 +1256,24 @@ export function ManageAccessDialog({
                         <span className="min-w-0 flex-1 truncate">{g}</span>
                       </MenuItem>
                     ))}
+                    {/* A plugin is three grantees — its readers, its writers, its
+                        owners — each following the plugin's own roster live. */}
+                    {(suggest.pluginPrincipals ?? []).flatMap((name) =>
+                      PLUGIN_PRINCIPAL_VERBS.map((verb) => (
+                        <MenuItem
+                          key={`pl:${name}/${verb}`}
+                          onClick={() => addChip({ kind: 'plugin', plugin: name, verb })}
+                          trailing={
+                            <span className="text-label uppercase text-ink-faint">plugin</span>
+                          }
+                        >
+                          <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-sunken text-label font-bold text-ink-muted">
+                            {initials(name)}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">{pluginPrincipalLabel(name, verb)}</span>
+                        </MenuItem>
+                      )),
+                    )}
                     {(suggest.people ?? []).map((p) => {
                       const tone = avatarTone(p.name || p.email);
                       return (

--- a/packages/core-frontend/src/modules/library/__tests__/LinkSkillPanel.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LinkSkillPanel.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LibraryToastProvider } from '../state/toast';
+import type { LibraryItem } from '../state/library-data';
+
+/**
+ * The link picker: offers what is not yet in the plugin, links on click, and
+ * turns the server's "you may edit the plugin but not the skill" refusal into
+ * the request path — never deciding that client-side.
+ */
+
+const api = vi.hoisted(() => ({
+  linkSkill: vi.fn(),
+  requestSkillAccess: vi.fn(),
+}));
+vi.mock('../services/plugins.api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/plugins.api')>()),
+  linkSkill: api.linkSkill,
+}));
+vi.mock('../services/library.api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/library.api')>()),
+  requestSkillAccess: api.requestSkillAccess,
+}));
+
+import { NeedsSkillWriteError } from '../services/plugins.api';
+import { LinkSkillPanel } from '../components/LinkSkillPanel';
+
+const OK = { state: 'ok' as const, text: 'Ready' };
+const items: LibraryItem[] = [
+  { kind: 'skill', id: 'deploy', name: 'deploy', description: 'Ship it.', owned: false, plugin: null, shared: true, plugins: [], path: 'Skills/Eng/deploy', status: OK },
+  { kind: 'skill', id: 'outreach', name: 'outreach', description: '', owned: true, plugin: 'GTM', plugins: [{ name: 'GTM', linked: false, granted: true }], path: 'Plugins/GTM/skills/outreach', status: OK },
+  { kind: 'skill', id: 'pitch', name: 'pitch', description: 'Sales pitch.', owned: false, plugin: 'Sales', plugins: [{ name: 'Sales', linked: false, granted: true }], path: 'Plugins/Sales/skills/pitch', status: OK },
+  { kind: 'integration', id: 'notion', name: 'Notion', description: '', owned: false, plugin: 'GTM', path: 'Plugins/GTM/mcp.json', status: OK },
+];
+
+function renderPanel() {
+  const onLinked = vi.fn();
+  render(
+    <LibraryToastProvider>
+      <LinkSkillPanel plugin="GTM" items={items} onLinked={onLinked} />
+    </LibraryToastProvider>,
+  );
+  return { onLinked };
+}
+
+beforeEach(() => {
+  api.linkSkill.mockReset();
+  api.requestSkillAccess.mockReset();
+});
+
+describe('LinkSkillPanel', () => {
+  it('offers released skills not already in the plugin — never tools, never its own', () => {
+    renderPanel();
+    expect(screen.getByText('deploy')).toBeInTheDocument();
+    expect(screen.getByText('pitch')).toBeInTheDocument();
+    expect(screen.queryByText('outreach')).not.toBeInTheDocument();
+    expect(screen.queryByText('Notion')).not.toBeInTheDocument();
+  });
+
+  it('narrows by the search box', () => {
+    renderPanel();
+    fireEvent.change(screen.getByLabelText('Search skills to link'), { target: { value: 'pit' } });
+    expect(screen.queryByText('deploy')).not.toBeInTheDocument();
+    expect(screen.getByText('pitch')).toBeInTheDocument();
+  });
+
+  it('links by the skill\'s path and reports back', async () => {
+    api.linkSkill.mockResolvedValue({ root: 'Skills/Eng/deploy', skills: ['Skills/Eng/deploy'] });
+    const { onLinked } = renderPanel();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Link' })[0]);
+    await waitFor(() => expect(api.linkSkill).toHaveBeenCalledWith('GTM', 'Skills/Eng/deploy'));
+    await waitFor(() => expect(onLinked).toHaveBeenCalled());
+  });
+
+  it('turns the server\'s needs-skill-write refusal into a request, and says when it is sent', async () => {
+    api.linkSkill.mockRejectedValue(new NeedsSkillWriteError('Skills/Eng/deploy'));
+    api.requestSkillAccess.mockResolvedValue({ number: 7 });
+    const { onLinked } = renderPanel();
+    fireEvent.click(screen.getAllByRole('button', { name: 'Link' })[0]);
+    const request = await screen.findByRole('button', { name: 'Request write access' });
+    expect(onLinked).not.toHaveBeenCalled();
+    fireEvent.click(request);
+    await waitFor(() => expect(api.requestSkillAccess).toHaveBeenCalledWith('deploy'));
+    expect(await screen.findByText('Requested')).toBeInTheDocument();
+  });
+});

--- a/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillPage.test.tsx
@@ -33,6 +33,10 @@ vi.mock('../services/library.api', () => ({
   getSkillFile: apiMock.getSkillFile,
   proposeChange: apiMock.proposeChange,
   listSkills: vi.fn(),
+  // The write-access request surface: nothing pending, nothing asked.
+  listSkillAccessRequests: vi.fn(async () => []),
+  reconcileSkillAccessRequest: vi.fn(async () => false),
+  requestSkillAccess: vi.fn(async () => ({ number: 1 })),
   // Real behaviour, not a stub: the page resolves the caller's own request by
   // this branch name, so a `vi.fn()` returning undefined would quietly disable
   // the very lookup these tests are checking.

--- a/packages/core-frontend/src/modules/library/__tests__/link-membership.test.ts
+++ b/packages/core-frontend/src/modules/library/__tests__/link-membership.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterLibraryItems,
+  isInPlugin,
+  isUngrouped,
+  pluginCounts,
+  pluginsOfItem,
+  withLinkHealth,
+  type AttentionStatus,
+} from '../utils/status';
+
+/**
+ * Membership by LINK, alongside membership by folder. A shared skill under
+ * `Skills/` has no folder plugin, yet belongs to every plugin whose manifest
+ * links it — and the gallery, the sidebar counts and the plugin page all have
+ * to agree on that.
+ */
+
+const OK: AttentionStatus = { state: 'ok', text: 'Ready' };
+
+const shared = {
+  kind: 'skill' as const,
+  name: 'deploy',
+  description: 'Ship it.',
+  owned: false,
+  plugin: null,
+  shared: true,
+  plugins: [
+    { name: 'GTM', linked: true, granted: true },
+    { name: 'Ops', linked: true, granted: false },
+  ],
+  status: OK,
+};
+const inline = {
+  kind: 'skill' as const,
+  name: 'outreach',
+  description: '',
+  owned: true,
+  plugin: 'GTM',
+  plugins: [{ name: 'GTM', linked: false, granted: true }],
+  status: OK,
+};
+const personal = { kind: 'skill' as const, name: 'mine', description: '', owned: true, plugin: null, status: OK };
+
+describe('membership by link', () => {
+  it('a linked skill belongs to the plugins that link it, and to no folder plugin', () => {
+    expect(isInPlugin(shared, 'GTM')).toBe(true);
+    expect(isInPlugin(shared, 'Ops')).toBe(true);
+    expect(isInPlugin(shared, 'Sales')).toBe(false);
+    expect(pluginsOfItem(shared).sort()).toEqual(['GTM', 'Ops']);
+    // Shared is not "yours alone" — only the personal skill is.
+    expect(isUngrouped(shared)).toBe(false);
+    expect(isUngrouped(personal)).toBe(true);
+  });
+
+  it('the plugin view and the sidebar counts follow links', () => {
+    const items = [shared, inline, personal];
+    expect(filterLibraryItems(items, { kind: 'group', plugin: 'GTM' }, '').map((i) => i.name)).toEqual([
+      'deploy',
+      'outreach',
+    ]);
+    expect(filterLibraryItems(items, { kind: 'ungrouped' }, '').map((i) => i.name)).toEqual(['mine']);
+    expect(pluginCounts(items)).toEqual([
+      { plugin: 'GTM', count: 2 },
+      { plugin: 'Ops', count: 1 },
+    ]);
+  });
+
+  it('a link whose grant is missing wears the amber note on THAT plugin\'s page only', () => {
+    // Granted on GTM: untouched.
+    expect(withLinkHealth(shared, 'GTM').status).toBe(OK);
+    // Not granted on Ops: needs setup, and says whose job it is.
+    expect(withLinkHealth(shared, 'Ops').status).toMatchObject({ state: 'warn', text: 'Needs setup' });
+    expect(withLinkHealth({ ...shared, owned: true }, 'Ops').status.text).toBe(
+      'Needs setup: share with plugin members',
+    );
+    // Inline membership never wears it.
+    expect(withLinkHealth(inline, 'GTM').status).toBe(OK);
+  });
+});

--- a/packages/core-frontend/src/modules/library/components/AddToPluginDialog.tsx
+++ b/packages/core-frontend/src/modules/library/components/AddToPluginDialog.tsx
@@ -1,6 +1,8 @@
 import { Button, Dialog, Surface } from '../../../shared/components';
 import { useAdmin } from '../../admin/state/admin.context';
 import { NewSkillPanel } from './NewSkillPanel';
+import { LinkSkillPanel } from './LinkSkillPanel';
+import type { LibraryItem } from '../state/library-data';
 import { useLibraryToast } from '../state/toast.context';
 import { COPIED_TOAST, COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
 
@@ -18,6 +20,13 @@ export interface AddToPluginDialogProps {
   canWrite: boolean | null;
   /** Every skill name already in the catalog. The admin create half rejects collisions. */
   existingSkills: string[];
+  /**
+   * The caller's catalog, for the "link an existing skill" half. Optional
+   * together with `onLinked`: a caller without them gets the dialog as it was
+   * before linking existed.
+   */
+  linkable?: LibraryItem[];
+  onLinked?(): void;
   onClose(): void;
 }
 
@@ -43,6 +52,8 @@ export function AddToPluginDialog({
   primaryPath,
   canWrite,
   existingSkills,
+  linkable,
+  onLinked,
   onClose,
 }: AddToPluginDialogProps) {
   const { isAdmin } = useAdmin();
@@ -84,6 +95,28 @@ export function AddToPluginDialog({
             ? `Use the prompt below to have your agent draft the skill and add it to ${name} for everyone in the plugin.`
             : `Use the prompt below to have your agent draft the skill and send it to ${name} as a change request for an owner to review.`}
       </p>
+
+      {/* Linking is the MANAGER's half: it edits this plugin's manifest, and the
+          server refuses anyone else. A non-manager only gets the prompt below. */}
+      {canWrite && linkable && onLinked && (
+        <>
+          <div className="mt-3">
+            <LinkSkillPanel
+              plugin={name}
+              items={linkable}
+              onLinked={() => {
+                onLinked();
+                onClose();
+              }}
+            />
+          </div>
+          <div className="my-3.5 flex items-center gap-3">
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+            <span className="text-meta text-ink-faint">or</span>
+            <span aria-hidden="true" className="h-px flex-1 bg-line" />
+          </div>
+        </>
+      )}
 
       {isAdmin && (
         <>

--- a/packages/core-frontend/src/modules/library/components/LibraryCard.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryCard.tsx
@@ -42,6 +42,13 @@ export interface LibraryCardCommonProps {
    * person who has to decide (being waited on).
    */
   pending?: { authorName: string; mine: boolean };
+  /**
+   * A skill's governance lifecycle (`metadata.lifecycle`). Only the two states
+   * that need a reader's attention are shown — `deprecated` (still works,
+   * find the replacement) and `retired` (kept for its owners, never
+   * distributed); `active` and absence render nothing.
+   */
+  lifecycle?: string;
   /** Open the item. The whole card is the target. */
   onOpen(): void;
 }
@@ -75,6 +82,7 @@ export function LibraryCard({
   status,
   version,
   pending,
+  lifecycle,
   onOpen,
   flavor,
 }: LibraryCardProps) {
@@ -140,6 +148,11 @@ export function LibraryCard({
         {owned && !pending && (
           <Badge tone="outline" size="xs" className="shrink-0 uppercase">
             Owner
+          </Badge>
+        )}
+        {(lifecycle === 'deprecated' || lifecycle === 'retired') && (
+          <Badge tone="wait" size="xs" className="shrink-0 uppercase">
+            {lifecycle === 'retired' ? 'Retired' : 'Deprecated'}
           </Badge>
         )}
       </span>

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -12,7 +12,7 @@ import {
   pathForPluginsIndex,
   pathForLibraryFilter,
 } from '../routes/library-paths';
-import { isUngrouped, pluginCounts, type LibraryFilter } from '../utils/status';
+import { isUngrouped, pluginCounts, pluginsOfItem, type LibraryFilter } from '../utils/status';
 import { primaryFolderOf } from '../utils/plugin-summary';
 import { LINK_COPIED_TOAST, LINK_COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
 import { useLibraryToast } from '../state/toast.context';
@@ -127,7 +127,10 @@ export function LibraryLayout() {
    * which is what keeps the row and the page it opens in agreement.
    */
   const lockedPlugins = useMemo(() => {
-    const visible = new Set(items.map((i) => i.plugin).filter((g): g is string => g !== null));
+    // Membership by folder AND by link: a shared skill linked into a plugin
+    // the caller cannot open still sits in the gallery under that plugin, so
+    // the plugin is visible, not locked — or it would be listed twice.
+    const visible = new Set(items.flatMap((i) => pluginsOfItem(i)));
     return pluginSummaries
       // A manager (canWrite via admin-rescue) is not locked out — their plugin
       // belongs with the ones they run, not below the gap.

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -12,7 +12,7 @@ import {
   pathForPluginsIndex,
   pathForLibraryFilter,
 } from '../routes/library-paths';
-import { pluginCounts, type LibraryFilter } from '../utils/status';
+import { isUngrouped, pluginCounts, type LibraryFilter } from '../utils/status';
 import { primaryFolderOf } from '../utils/plugin-summary';
 import { LINK_COPIED_TOAST, LINK_COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
 import { useLibraryToast } from '../state/toast.context';
@@ -146,7 +146,7 @@ export function LibraryLayout() {
     () => items.filter((i) => i.owned && i.status.state !== 'ok').length,
     [items],
   );
-  const ungroupedCount = useMemo(() => items.filter((i) => i.plugin === null).length, [items]);
+  const ungroupedCount = useMemo(() => items.filter(isUngrouped).length, [items]);
   const attentionCount = useMemo(
     () => items.filter((i) => i.kind === 'integration' && i.status.state !== 'ok').length,
     [items],

--- a/packages/core-frontend/src/modules/library/components/LinkSkillPanel.tsx
+++ b/packages/core-frontend/src/modules/library/components/LinkSkillPanel.tsx
@@ -39,7 +39,9 @@ export function LinkSkillPanel({
   const candidates = useMemo(() => {
     const q = query.trim().toLowerCase();
     return items
-      .filter((i): i is LibraryItem => i.kind === 'skill' && !i.pending && !isInPlugin(i, plugin))
+      // Retired skills are kept for their owners and never shared onward; the
+      // server refuses them too, this just keeps them out of the list.
+      .filter((i): i is LibraryItem => i.kind === 'skill' && !i.pending && i.lifecycle !== 'retired' && !isInPlugin(i, plugin))
       .filter((i) => !q || i.name.toLowerCase().includes(q) || i.description.toLowerCase().includes(q))
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [items, plugin, query]);

--- a/packages/core-frontend/src/modules/library/components/LinkSkillPanel.tsx
+++ b/packages/core-frontend/src/modules/library/components/LinkSkillPanel.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react';
+import { Button, Badge } from '../../../shared/components';
+import type { LibraryItem } from '../state/library-data';
+import { useLibraryToast } from '../state/toast.context';
+import { NeedsSkillWriteError, linkSkill } from '../services/plugins.api';
+import { requestSkillAccess } from '../services/library.api';
+import { isInPlugin } from '../utils/status';
+
+/**
+ * "Link an existing skill" — the picker behind adding a shared skill to a
+ * plugin without copying it.
+ *
+ * Every released skill the caller can read is offered, minus the ones already
+ * in this plugin. Linking needs write on the skill's rules as well as on the
+ * plugin (the link grants the plugin's principal on the skill), and the server
+ * is the one that knows: a refusal of that shape turns the row's action into
+ * "Request write access", which opens the same kind of change request as
+ * asking to join a plugin. Nothing is decided client-side from a stale verdict.
+ *
+ * Prop-driven (the caller hands it the catalog) so it renders anywhere the
+ * plugin page's data is, without reaching for the library context itself.
+ */
+export function LinkSkillPanel({
+  plugin,
+  items,
+  onLinked,
+}: {
+  plugin: string;
+  /** The caller's catalog; the panel offers its released skills not yet in `plugin`. */
+  items: LibraryItem[];
+  onLinked(): void;
+}) {
+  const toast = useLibraryToast();
+  const [query, setQuery] = useState('');
+  const [busy, setBusy] = useState<string | null>(null);
+  /** Per skill: the server said write on the skill is missing / a request is open. */
+  const [needsWrite, setNeedsWrite] = useState<Record<string, 'ask' | 'requested'>>({});
+
+  const candidates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return items
+      .filter((i): i is LibraryItem => i.kind === 'skill' && !i.pending && !isInPlugin(i, plugin))
+      .filter((i) => !q || i.name.toLowerCase().includes(q) || i.description.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [items, plugin, query]);
+
+  async function link(item: LibraryItem) {
+    setBusy(item.id);
+    try {
+      const result = await linkSkill(plugin, item.path);
+      toast(
+        result.skills.length === 1
+          ? `${item.name} is now in ${plugin}. Its members can read it; its managers can edit it.`
+          : `${result.skills.length} skills are now in ${plugin}.`,
+      );
+      onLinked();
+    } catch (err) {
+      if (err instanceof NeedsSkillWriteError) {
+        setNeedsWrite((m) => ({ ...m, [item.id]: 'ask' }));
+      } else {
+        toast(err instanceof Error ? err.message : "Couldn't link that skill.", 'danger');
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function request(item: LibraryItem) {
+    setBusy(item.id);
+    try {
+      await requestSkillAccess(item.name);
+      setNeedsWrite((m) => ({ ...m, [item.id]: 'requested' }));
+      toast(`Asked ${item.name}'s editors for write access. Link it once they say yes.`);
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Couldn't request access.", 'danger');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div data-testid="link-skill-panel">
+      <p className="text-ui text-ink-muted">
+        {`Link a skill that already exists. It stays where it is; ${plugin}'s members get to read it and its managers get to edit it.`}
+      </p>
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search skills…"
+        aria-label="Search skills to link"
+        className="mt-2.5 w-full rounded-md border border-line bg-surface px-2.5 py-1.5 text-ui text-ink placeholder:text-ink-faint focus:outline-none"
+      />
+      <ul className="mt-2 max-h-64 divide-y divide-line overflow-auto rounded-md border border-line">
+        {candidates.length === 0 && (
+          <li className="px-3 py-3 text-detail text-ink-faint">
+            {query.trim() ? 'No skill matches.' : 'Every skill you can see is already in this plugin.'}
+          </li>
+        )}
+        {candidates.map((item) => {
+          const state = needsWrite[item.id];
+          return (
+            <li key={item.id} className="flex items-center gap-3 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate text-ui font-medium text-ink">{item.name}</span>
+                  {item.shared ? (
+                    <Badge tone="outline" size="xs" className="shrink-0 uppercase">
+                      Shared
+                    </Badge>
+                  ) : item.plugin ? (
+                    <Badge tone="outline" size="xs" className="shrink-0 uppercase">
+                      {item.plugin}
+                    </Badge>
+                  ) : null}
+                </div>
+                {item.description && (
+                  <div className="truncate text-detail text-ink-muted">{item.description}</div>
+                )}
+                {state === 'ask' && (
+                  <div className="text-detail text-wait">
+                    {"You can't change who may read this skill yet. Ask its editors first."}
+                  </div>
+                )}
+              </div>
+              {state === 'requested' ? (
+                <span className="shrink-0 text-detail text-ink-faint">Requested</span>
+              ) : state === 'ask' ? (
+                <Button
+                  variant="outline"
+                  size="tiny"
+                  disabled={busy === item.id}
+                  onClick={() => void request(item)}
+                >
+                  Request write access
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="tiny"
+                  disabled={busy !== null}
+                  onClick={() => void link(item)}
+                >
+                  Link
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/core-frontend/src/modules/library/components/PersonalPluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PersonalPluginPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { isUngrouped } from '../utils/status';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../auth/state/auth.context';
 import { useLibrary, type LibraryItem } from '../state/library-data';
@@ -46,7 +47,7 @@ export function PersonalPluginPage() {
   const [removing, setRemoving] = useState<LibraryItem | null>(null);
 
   const name = personalPluginName(user?.name);
-  const items = useMemo(() => data.items.filter((i) => i.plugin === null), [data.items]);
+  const items = useMemo(() => data.items.filter(isUngrouped), [data.items]);
   /**
    * For the add dialog's name check. Every skill, not only the ungrouped ones:
    * a skill's id is its name and ids are global, so a new skill here collides

--- a/packages/core-frontend/src/modules/library/components/PluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Banner, Button } from '../../../shared/components';
 import { attentionOf, useLibrary, type LibraryItem } from '../state/library-data';
 import { useLibraryToast } from '../state/toast.context';
+import { isInPlugin, withLinkHealth } from '../utils/status';
 import {
   decodePluginSegment,
   pathForPluginsIndex,
@@ -120,8 +121,11 @@ export function PluginPage() {
     () => data.pluginSummaries.find((g) => g.name === plugin) ?? null,
     [data.pluginSummaries, plugin],
   );
+  // Inline AND linked: a shared skill linked from this plugin's manifest is
+  // one of its skills. A link whose grant went missing carries the amber
+  // "needs setup" foot note here — the one place the plugin's members look.
   const pluginItems = useMemo(
-    () => data.items.filter((i) => i.plugin === plugin),
+    () => data.items.filter((i) => isInPlugin(i, plugin)).map((i) => withLinkHealth(i, plugin)),
     [data.items, plugin],
   );
   /** For the add dialog's name check — global, because a skill's id is global. */
@@ -289,6 +293,16 @@ export function PluginPage() {
         </Banner>
       )}
 
+      {/* Ownership decides readability, the plugin is a view: a linked skill
+          the caller may not read is simply absent from their list, and the
+          plugin's own total says how many. */}
+      {summary && summary.skillCount > skillItems.length && (
+        <p className="mb-2 text-detail text-ink-faint">
+          {summary.skillCount - skillItems.length === 1
+            ? '1 skill in this plugin is not shared with you.'
+            : `${summary.skillCount - skillItems.length} skills in this plugin are not shared with you.`}
+        </p>
+      )}
       <PluginItemSections
         skillItems={shownSkills}
         toolItems={toolItems}
@@ -367,6 +381,11 @@ export function PluginPage() {
           // Every skill, not just this plugin's: a skill's id is its name and
           // ids are global, so the collision that matters is with any of them.
           existingSkills={allSkillNames}
+          linkable={data.items}
+          onLinked={() => {
+            data.reload();
+            data.reloadPlugins();
+          }}
           onClose={() => setAddOpen(false)}
         />
       )}

--- a/packages/core-frontend/src/modules/library/components/PluginsIndexPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsIndexPage.tsx
@@ -244,7 +244,8 @@ function countsText(skills: number, tools: number): string {
 }
 
 function countKind(items: LibraryItem[], plugin: string | null, kind: LibraryItem['kind']): number {
-  return items.filter((i) => i.plugin === plugin && i.kind === kind).length;
+  // The `null` bucket is "yours alone": shared skills have no folder plugin but are not yours.
+  return items.filter((i) => i.plugin === plugin && i.kind === kind && (plugin !== null || !i.shared)).length;
 }
 
 /** Section label with an optional count cap beside it, not inside it — the

--- a/packages/core-frontend/src/modules/library/components/plugin-page-parts.tsx
+++ b/packages/core-frontend/src/modules/library/components/plugin-page-parts.tsx
@@ -156,6 +156,7 @@ export function CardGrid({
             owned={item.owned}
             status={item.status}
             version={item.version}
+            lifecycle={item.lifecycle}
             pending={
               item.pending && {
                 authorName: item.pending.authorName,

--- a/packages/core-frontend/src/modules/library/components/skill-page/SharedViaPlugins.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SharedViaPlugins.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Badge, Button } from '../../../../shared/components';
+import { useLibrary } from '../../state/library-data';
+import { useLibraryToast } from '../../state/toast.context';
+import { NeedsSkillWriteError, linkSkill, repairSkillLink, unlinkSkill } from '../../services/plugins.api';
+import { requestSkillAccess, type PluginMembership } from '../../services/library.api';
+import { pathForPlugin } from '../../routes/library-paths';
+import { StatusDot } from '../StatusDot';
+
+/**
+ * "In plugins" — every plugin this skill belongs to, and the two ways the
+ * relationship is managed from the skill's side.
+ *
+ * A row is INLINE (the skill sits in the plugin's folder) or LINKED (the
+ * plugin's manifest points at it). A link is healthy when the skill's own
+ * access rules still name the plugin's principal; when a hand edit removed
+ * that grant, the row shows the amber dot and — to someone who can edit the
+ * skill — a Repair button, because until it is back the plugin's members
+ * cannot read the skill. Unlink is the plugin MANAGER's verb (it edits the
+ * plugin's manifest), so it appears only on plugins the caller manages.
+ *
+ * "Add to plugin" links this skill into a plugin the caller manages. It
+ * needs write on the skill too; a refusal of that shape offers the request.
+ */
+export function SharedViaPlugins({
+  skillName,
+  skillPath,
+  memberships,
+  owned,
+  onChanged,
+}: {
+  skillName: string;
+  skillPath: string;
+  memberships: PluginMembership[];
+  /** The caller may edit the skill (its SKILL.md) — the repair verb. */
+  owned: boolean;
+  onChanged(): void;
+}) {
+  const data = useLibrary();
+  const toast = useLibraryToast();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [needsWrite, setNeedsWrite] = useState<'ask' | 'requested' | null>(null);
+
+  const managed = useMemo(
+    () => new Set(data.pluginSummaries.filter((p) => p.canWrite).map((p) => p.name)),
+    [data.pluginSummaries],
+  );
+  const addable = useMemo(
+    () => [...managed].filter((name) => !memberships.some((m) => m.name === name)).sort(),
+    [managed, memberships],
+  );
+
+  async function run(label: string, op: () => Promise<unknown>, done: string) {
+    setBusy(label);
+    try {
+      await op();
+      toast(done);
+      onChanged();
+    } catch (err) {
+      if (err instanceof NeedsSkillWriteError) setNeedsWrite('ask');
+      else toast(err instanceof Error ? err.message : `Couldn't ${label}.`, 'danger');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (memberships.length === 0 && addable.length === 0) return null;
+
+  return (
+    <section className="mt-6" data-testid="shared-via-plugins">
+      <h2 className="mb-2.5 text-label font-semibold uppercase text-ink-faint">In plugins</h2>
+      <div className="grid gap-2">
+        {memberships.length === 0 && (
+          <p className="text-detail text-ink-faint">This skill is in no plugin yet.</p>
+        )}
+        {memberships.map((m) => {
+          const broken = m.linked && !m.granted;
+          return (
+            <div
+              key={m.name}
+              className="flex items-center gap-3 rounded-md border border-line bg-sunken px-3 py-2"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <Link to={pathForPlugin(m.name)} className="truncate text-detail font-semibold text-ink underline-offset-2 hover:underline">
+                    {m.name}
+                  </Link>
+                  <Badge tone="outline" size="xs" className="shrink-0 uppercase">
+                    {m.linked ? 'Linked' : 'Inline'}
+                  </Badge>
+                </div>
+                <small className="block text-meta text-ink-faint">
+                  {broken
+                    ? owned
+                      ? `Needs setup: ${m.name}'s members can't read this skill until the link is repaired.`
+                      : `Needs setup: ${m.name}'s members can't read this skill. Ask an editor to repair the link.`
+                    : m.linked
+                      ? `${m.name}'s members can read it; its managers can edit it.`
+                      : `Lives in ${m.name}'s folder.`}
+                </small>
+              </div>
+              <div className="ml-auto flex shrink-0 items-center gap-2">
+                {broken && <StatusDot state="warn" />}
+                {broken && owned && (
+                  <Button
+                    variant="outline"
+                    size="tiny"
+                    disabled={busy !== null}
+                    onClick={() =>
+                      void run('repair', () => repairSkillLink(m.name, skillPath), `${m.name} can read ${skillName} again.`)
+                    }
+                  >
+                    Repair
+                  </Button>
+                )}
+                {m.linked && managed.has(m.name) && (
+                  <Button
+                    variant="quiet"
+                    size="tiny"
+                    disabled={busy !== null}
+                    onClick={() =>
+                      void run('unlink', () => unlinkSkill(m.name, skillPath), `${skillName} is no longer in ${m.name}.`)
+                    }
+                  >
+                    Unlink
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {addable.length > 0 && (
+        <div className="mt-2.5">
+          {needsWrite === 'requested' ? (
+            <span className="text-detail text-ink-faint">Asked the skill's editors for write access.</span>
+          ) : needsWrite === 'ask' ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-detail text-wait">
+                {"You can't change who may read this skill yet."}
+              </span>
+              <Button
+                variant="outline"
+                size="tiny"
+                disabled={busy !== null}
+                onClick={() =>
+                  void (async () => {
+                    setBusy('request');
+                    try {
+                      await requestSkillAccess(skillName);
+                      setNeedsWrite('requested');
+                    } catch (err) {
+                      toast(err instanceof Error ? err.message : "Couldn't request access.", 'danger');
+                    } finally {
+                      setBusy(null);
+                    }
+                  })()
+                }
+              >
+                Request write access
+              </Button>
+            </div>
+          ) : adding ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="text-detail text-ink-muted" htmlFor="add-to-plugin-select">
+                Add to
+              </label>
+              <select
+                id="add-to-plugin-select"
+                className="rounded-md border border-line bg-surface px-2 py-1 text-ui text-ink"
+                defaultValue=""
+                disabled={busy !== null}
+                onChange={(e) => {
+                  const name = e.target.value;
+                  if (!name) return;
+                  void run('link', () => linkSkill(name, skillPath), `${skillName} is now in ${name}.`).then(() =>
+                    setAdding(false),
+                  );
+                }}
+              >
+                <option value="" disabled>
+                  Choose a plugin…
+                </option>
+                {addable.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <Button variant="quiet" size="tiny" onClick={() => setAdding(false)}>
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setAdding(true)}>
+              Add to plugin…
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -36,6 +36,11 @@ import { changeAuthorName, formatWhen } from '../../../change-requests/utils/aut
 import { ownersTextOf } from '../../utils/plugin-summary';
 import { neededToolsFor, toolStatus } from '../../utils/status';
 import { StatusDot } from '../StatusDot';
+import { SharedViaPlugins } from './SharedViaPlugins';
+import { AccessRequestsBanner } from '../AccessRequestsBanner';
+import { useJoinRequests, type JoinRequestsApi } from '../../hooks/useJoinRequests';
+import { listSkillAccessRequests, reconcileSkillAccessRequest } from '../../services/library.api';
+import { ManageAccessDialog } from '../../../access/components/ManageAccessDialog';
 import { ChangeRequestDock } from '../ChangeRequestDock';
 import { ChangeRequestDialog } from '../../../change-requests/components/ChangeRequestDialog';
 import { SkillFileTabs } from './SkillFileTabs';
@@ -135,6 +140,23 @@ export function SkillPage({
   const skill = detail.skill;
   const skillPath = skill?.path ?? '';
   const prefix = `${skillPath}/`;
+
+  /** Every plugin holding this skill, from the catalog's decoration. */
+  const memberships = useMemo(
+    () => data.items.find((i) => i.kind === 'skill' && i.id === name)?.plugins ?? [],
+    [data.items, name],
+  );
+  /**
+   * Write-access requests on this skill, for its editors. The endpoint answers
+   * `[]` to everyone else, so the fetch is unconditional and the banner hides
+   * itself; `owned` only spares a pointless call.
+   */
+  const skillRequestsApi = useMemo<JoinRequestsApi>(
+    () => ({ list: listSkillAccessRequests, reconcile: reconcileSkillAccessRequest }),
+    [],
+  );
+  const accessRequests = useJoinRequests(name, skillPath || null, skillRequestsApi);
+  const [manageOpen, setManageOpen] = useState(false);
 
   /**
    * Who has to say yes. A skill has no owner of its own — it inherits its plugin
@@ -590,7 +612,41 @@ export function SkillPage({
             those rules are decided. Same call the tool page made. */}
       </header>
 
+      {owned && (
+        <AccessRequestsBanner
+          plugin={name}
+          folders={[skillPath]}
+          requests={accessRequests.requests}
+          onManage={() => setManageOpen(true)}
+          onAccept={(r, p) => void accessRequests.accept(r, p)}
+          onDecline={(r) => void accessRequests.decline(r)}
+        />
+      )}
+      {manageOpen && kbDirName && skillPath && (
+        <ManageAccessDialog
+          entry={{ name, relativePath: `${kbDirName}/${skillPath}`, type: 'directory' }}
+          onClose={() => {
+            setManageOpen(false);
+            accessRequests.reload();
+            data.reload();
+          }}
+        />
+      )}
+
       <IntegrationsSection needed={needed} onConnect={() => navigate('/connect')} />
+
+      {skill && (
+        <SharedViaPlugins
+          skillName={name}
+          skillPath={skillPath}
+          memberships={memberships}
+          owned={owned}
+          onChanged={() => {
+            data.reload();
+            data.reloadPlugins();
+          }}
+        />
+      )}
 
       <SkillFileTabs
         files={files}

--- a/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/skill-page/SkillPage.tsx
@@ -624,6 +624,10 @@ export function SkillPage({
       )}
       {manageOpen && kbDirName && skillPath && (
         <ManageAccessDialog
+          // The Library speaks the DEFAULT branch: a skill's rules are edited
+          // where the catalog reads them, whatever branch the ambient
+          // workspace happens to be on.
+          workspaceId={encodeURIComponent(DEFAULT_BRANCH)}
           entry={{ name, relativePath: `${kbDirName}/${skillPath}`, type: 'directory' }}
           onClose={() => {
             setManageOpen(false);

--- a/packages/core-frontend/src/modules/library/hooks/useJoinRequests.ts
+++ b/packages/core-frontend/src/modules/library/hooks/useJoinRequests.ts
@@ -40,14 +40,35 @@ export interface JoinRequestsState {
   reload(): void;
 }
 
-export function useJoinRequests(plugin: string, folder: string | null): JoinRequestsState {
+/**
+ * Where the requests come from. The default is a plugin's join requests; a
+ * skill page passes the skill's write-access endpoints instead — same
+ * proposals, same accept-by-grant, a different folder.
+ */
+export interface JoinRequestsApi {
+  list(name: string): Promise<JoinRequest[]>;
+  reconcile(name: string, number: number): Promise<boolean>;
+}
+
+// Lazy wrappers, not the functions themselves: the plugin API is resolved at
+// call time, so a surface that never lists requests never needs those exports.
+const PLUGIN_JOIN_API: JoinRequestsApi = {
+  list: (name) => listJoinRequests(name),
+  reconcile: (name, number) => reconcileJoinRequest(name, number),
+};
+
+export function useJoinRequests(
+  plugin: string,
+  folder: string | null,
+  api: JoinRequestsApi = PLUGIN_JOIN_API,
+): JoinRequestsState {
   const [requests, setRequests] = useState<JoinRequest[]>([]);
   const [revision, setRevision] = useState(0);
   const toast = useLibraryToast();
 
   useEffect(() => {
     let cancelled = false;
-    listJoinRequests(plugin)
+    api.list(plugin)
       .then((rows) => {
         if (!cancelled) setRequests(rows);
       })
@@ -58,7 +79,7 @@ export function useJoinRequests(plugin: string, folder: string | null): JoinRequ
     return () => {
       cancelled = true;
     };
-  }, [plugin, revision]);
+  }, [plugin, revision, api]);
 
   const reload = useCallback(() => setRevision((r) => r + 1), []);
 
@@ -92,10 +113,10 @@ export function useJoinRequests(plugin: string, folder: string | null): JoinRequ
         ),
       );
       toast(`${proposal.label} now has ${proposal.verb} access.`);
-      await reconcileJoinRequest(plugin, request.number).catch(() => false);
+      await api.reconcile(plugin, request.number).catch(() => false);
       setRevision((r) => r + 1);
     },
-    [folder, plugin, toast],
+    [folder, plugin, toast, api],
   );
 
   const decline = useCallback(

--- a/packages/core-frontend/src/modules/library/routes/library-paths.ts
+++ b/packages/core-frontend/src/modules/library/routes/library-paths.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_BRANCH, PLUGINS_DIR, pluginOfPath, isPersonalPluginFolder } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, PLUGINS_DIR, SKILLS_DIR, pluginOfPath, isPersonalPluginFolder } from '@bevel-software/platform-shared';
 import { matchPath } from 'react-router-dom';
 import { kbFileUrl } from '../../workspace/routing/kb-routes';
 import type { LibraryFilter } from '../utils/status';
@@ -143,8 +143,8 @@ export function isLibraryLocation(pathname: string): boolean {
   return (
     segments[0] === 'workspace' &&
     segments[1] === DEFAULT_BRANCH &&
-    segments[3] === PLUGINS_DIR &&
-    segments.length >= 6 // workspace/<branch>/<kbDir>/Plugins/<plugin>/<item>
+    ((segments[3] === PLUGINS_DIR && segments.length >= 6) || // workspace/<branch>/<kbDir>/Plugins/<plugin>/<item>
+      (segments[3] === SKILLS_DIR && segments.length >= 5)) // workspace/<branch>/<kbDir>/Skills/<skill or scope>/…
   );
 }
 

--- a/packages/core-frontend/src/modules/library/services/library.api.ts
+++ b/packages/core-frontend/src/modules/library/services/library.api.ts
@@ -47,6 +47,10 @@ export interface LibrarySkillSummary {
   path: string;
   /** Every plugin holding this skill. Absent from an older server. */
   plugins?: PluginMembership[];
+  /** The governance owner (`metadata.owner`), when declared. */
+  owner?: string;
+  /** The governance lifecycle (`metadata.lifecycle`), lowercased: `active`, `deprecated`, `retired`. */
+  lifecycle?: string;
 }
 
 /** The open write-access requests on a skill — `[]` to anyone but its editors. */

--- a/packages/core-frontend/src/modules/library/services/library.api.ts
+++ b/packages/core-frontend/src/modules/library/services/library.api.ts
@@ -6,7 +6,7 @@ import { deleteFile, getOrCreateWorkspace, writeFile } from '../../workspace/ser
 import { openChangeRequest } from '../../pr/services/pr-open.api';
 import { postPrComment } from '../../pr/services/pr-comments.api';
 import { branchSegment } from '../../change-requests/services/propose.api';
-import { ensurePersonalPlugin } from './plugins.api';
+import { ensurePersonalPlugin, type JoinRequest } from './plugins.api';
 
 /**
  * Library data access. Skills come from the browser skill routes
@@ -26,6 +26,18 @@ import { ensurePersonalPlugin } from './plugins.api';
  */
 export const defaultWorkspaceId = () => encodeURIComponent(DEFAULT_BRANCH);
 
+/**
+ * One plugin a skill belongs to — inside the plugin folder (`linked: false`)
+ * or linked from the plugin's manifest (`linked: true`). `granted` is the
+ * link's health: whether the skill's own access rules still name the plugin's
+ * `plugin/<Name>/read` principal. Mirrors the backend contract.
+ */
+export interface PluginMembership {
+  name: string;
+  linked: boolean;
+  granted: boolean;
+}
+
 export interface LibrarySkillSummary {
   /** Canonical id = the skill's folder name (e.g. `rfi`). */
   name: string;
@@ -33,6 +45,44 @@ export interface LibrarySkillSummary {
   version?: string;
   /** Repo-root-relative skill folder, e.g. `Plugins/Everyone/rfi`. */
   path: string;
+  /** Every plugin holding this skill. Absent from an older server. */
+  plugins?: PluginMembership[];
+}
+
+/** The open write-access requests on a skill — `[]` to anyone but its editors. */
+export async function listSkillAccessRequests(name: string): Promise<JoinRequest[]> {
+  const data = await handleApiResponse<{ requests: JoinRequest[] }>(
+    await authFetch(`/api/skills/${encodeURIComponent(name)}/access-requests`),
+  );
+  return data.requests;
+}
+
+/** Settle one request if every proposal has landed. Returns whether it closed. */
+export async function reconcileSkillAccessRequest(name: string, number: number): Promise<boolean> {
+  const data = await handleApiResponse<{ closed: boolean }>(
+    await authFetch(`/api/skills/${encodeURIComponent(name)}/access-requests/${number}/reconcile`, {
+      method: 'POST',
+    }),
+  );
+  return data.closed;
+}
+
+/**
+ * Ask the skill's editors for write on it — a change request that proposes
+ * the grant, exactly like asking to join a plugin. Idempotent: a second ask
+ * returns the open request.
+ */
+export async function requestSkillAccess(name: string): Promise<{ number: number }> {
+  const res = await authFetch(`/api/skills/${encodeURIComponent(name)}/access-request`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ verb: 'write' }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? "Couldn't request access.");
+  }
+  return (await res.json()) as { number: number };
 }
 
 export interface LibrarySkill extends LibrarySkillSummary {

--- a/packages/core-frontend/src/modules/library/services/plugins.api.ts
+++ b/packages/core-frontend/src/modules/library/services/plugins.api.ts
@@ -109,6 +109,60 @@ export async function ensurePersonalPlugin(): Promise<{ folder: string; created:
 }
 
 /**
+ * Thrown when linking is refused because the caller may edit the plugin but
+ * not the skill's access rules — the link would share nothing. The UI turns
+ * this into "request write access".
+ */
+export class NeedsSkillWriteError extends Error {
+  readonly root: string;
+  constructor(root: string) {
+    super("You can't change who may read this skill yet.");
+    this.name = 'NeedsSkillWriteError';
+    this.root = root;
+  }
+}
+
+async function linkCall(url: string, init: RequestInit): Promise<Record<string, unknown>> {
+  const res = await authFetch(url, init);
+  const body = (await res.json().catch(() => ({}))) as { error?: string; kind?: string; root?: string };
+  if (!res.ok) {
+    if (body.kind === 'needs-skill-write') throw new NeedsSkillWriteError(body.root ?? '');
+    throw new Error(body.error ?? "Couldn't update the plugin's links.");
+  }
+  return body;
+}
+
+/**
+ * Link a skill (or a folder of skills) into a plugin: the path goes into the
+ * plugin's manifest and the skill's rules grant the plugin's principals. Needs
+ * write on both sides — see `NeedsSkillWriteError`.
+ */
+export async function linkSkill(plugin: string, skillPath: string): Promise<{ root: string; skills: string[] }> {
+  return (await linkCall(`/api/plugins/${encodeURIComponent(plugin)}/links`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ skillPath }),
+  })) as { root: string; skills: string[] };
+}
+
+/** Remove a link. `revoked` says whether the plugin's grant on the skill went with it. */
+export async function unlinkSkill(plugin: string, skillPath: string): Promise<{ root: string; revoked: boolean }> {
+  return (await linkCall(
+    `/api/plugins/${encodeURIComponent(plugin)}/links?skillPath=${encodeURIComponent(skillPath)}`,
+    { method: 'DELETE' },
+  )) as { root: string; revoked: boolean };
+}
+
+/** Re-grant the plugin's principals on a linked skill whose grant was hand-removed. */
+export async function repairSkillLink(plugin: string, skillPath: string): Promise<void> {
+  await linkCall(`/api/plugins/${encodeURIComponent(plugin)}/links/repair`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ skillPath }),
+  });
+}
+
+/**
  * Thrown when a join request is refused because access already landed —
  * between the page load and the click. Not an error to show: the right
  * response is to reload the library and let the plugin appear unlocked.

--- a/packages/core-frontend/src/modules/library/state/library-data.tsx
+++ b/packages/core-frontend/src/modules/library/state/library-data.tsx
@@ -59,6 +59,8 @@ export interface LibraryItem {
   shared?: boolean;
   /** Every plugin holding a skill, inline or linked (skills only). */
   plugins?: PluginMembership[];
+  /** A skill's governance lifecycle (`metadata.lifecycle`), when declared. */
+  lifecycle?: string;
   /** Repo-root-relative path — the skill's folder, or the `.tool` file. */
   path: string;
   /**
@@ -134,6 +136,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       plugin: displayPluginOf(s.path),
       shared: isSharedPath(s.path),
       plugins: s.plugins ?? [],
+      lifecycle: s.lifecycle,
       path: s.path,
       version: s.version,
       status: skillStatus(

--- a/packages/core-frontend/src/modules/library/state/library-data.tsx
+++ b/packages/core-frontend/src/modules/library/state/library-data.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactNode,  } from 'react';
 import { LibraryContext } from './library-context';
-import { pluginOfPath, isPersonalPluginFolder } from '@bevel-software/platform-shared';
+import { pluginOfPath, isPersonalPluginFolder, SKILLS_DIR } from '@bevel-software/platform-shared';
 
 /**
  * The plugin a card files under — with personal folders mapped to `null`, the
@@ -12,6 +12,11 @@ import { pluginOfPath, isPersonalPluginFolder } from '@bevel-software/platform-s
 function displayPluginOf(path: string): string | null {
   const plugin = pluginOfPath(path);
   return plugin !== null && isPersonalPluginFolder(plugin) ? null : plugin;
+}
+
+/** Under the shared `Skills/` root — owned by a scope, not by a person or a plugin folder. */
+function isSharedPath(path: string): boolean {
+  return path === SKILLS_DIR || path.startsWith(`${SKILLS_DIR}/`);
 }
 import { useLibraryData, type LibraryData } from '../hooks/useLibraryData';
 import { listPlugins, type PluginSummary } from '../services/plugins.api';
@@ -48,6 +53,8 @@ export interface LibraryItem {
   status: AttentionStatus;
   /** Folder plugin from the KB path, or null when the item is in none. */
   plugin: string | null;
+  /** Under the shared `Skills/` root — see `LibraryFilterable.shared`. */
+  shared?: boolean;
   /** Repo-root-relative path — the skill's folder, or the `.tool` file. */
   path: string;
   /**
@@ -121,6 +128,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       description: s.description,
       owned: data.ownedSkills.has(s.name),
       plugin: displayPluginOf(s.path),
+      shared: isSharedPath(s.path),
       path: s.path,
       version: s.version,
       status: skillStatus(
@@ -145,6 +153,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       description: s.description,
       owned: false,
       plugin: displayPluginOf(s.path),
+      shared: isSharedPath(s.path),
       path: s.path,
       version: s.version,
       status: { state: 'ok', text: 'In review' },

--- a/packages/core-frontend/src/modules/library/state/library-data.tsx
+++ b/packages/core-frontend/src/modules/library/state/library-data.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactNode,  } from 'react';
 import { LibraryContext } from './library-context';
 import { pluginOfPath, isPersonalPluginFolder, SKILLS_DIR } from '@bevel-software/platform-shared';
+import type { PluginMembership } from '../services/library.api';
 
 /**
  * The plugin a card files under — with personal folders mapped to `null`, the
@@ -21,6 +22,7 @@ function isSharedPath(path: string): boolean {
 import { useLibraryData, type LibraryData } from '../hooks/useLibraryData';
 import { listPlugins, type PluginSummary } from '../services/plugins.api';
 import {
+  isInPlugin,
   neededToolsFor,
   skillStatus,
   toolStatus,
@@ -55,6 +57,8 @@ export interface LibraryItem {
   plugin: string | null;
   /** Under the shared `Skills/` root — see `LibraryFilterable.shared`. */
   shared?: boolean;
+  /** Every plugin holding a skill, inline or linked (skills only). */
+  plugins?: PluginMembership[];
   /** Repo-root-relative path — the skill's folder, or the `.tool` file. */
   path: string;
   /**
@@ -129,6 +133,7 @@ export function LibraryProvider({ children }: { children: ReactNode }) {
       owned: data.ownedSkills.has(s.name),
       plugin: displayPluginOf(s.path),
       shared: isSharedPath(s.path),
+      plugins: s.plugins ?? [],
       path: s.path,
       version: s.version,
       status: skillStatus(
@@ -248,6 +253,6 @@ export function workspaceHasNoPlugins(lib: LibraryContextValue): boolean {
  */
 export function attentionOf(items: LibraryItem[], plugin: string): number {
   return items.filter(
-    (i) => i.plugin === plugin && i.kind === 'integration' && i.status.state !== 'ok',
+    (i) => isInPlugin(i, plugin) && i.kind === 'integration' && i.status.state !== 'ok',
   ).length;
 }

--- a/packages/core-frontend/src/modules/library/utils/status.ts
+++ b/packages/core-frontend/src/modules/library/utils/status.ts
@@ -248,11 +248,54 @@ export interface LibraryFilterable {
    * ungrouped view leaves it out and only the catalog-wide view lists it.
    */
   shared?: boolean;
+  /**
+   * Every plugin the item belongs to, inline or by link. `plugin` above is the
+   * FOLDER plugin only (routing, "yours alone"); this is what the plugin
+   * page and the sidebar counts go by.
+   */
+  plugins?: { name: string }[];
 }
 
 /** "Yours alone": in no plugin folder AND not a shared skill. */
 export function isUngrouped(item: Pick<LibraryFilterable, 'plugin' | 'shared'>): boolean {
   return item.plugin === null && !item.shared;
+}
+
+/** Whether an item belongs to `plugin` — by folder, or by a link from the plugin's manifest. */
+export function isInPlugin(item: Pick<LibraryFilterable, 'plugin' | 'plugins'>, plugin: string): boolean {
+  return item.plugin === plugin || (item.plugins?.some((m) => m.name === plugin) ?? false);
+}
+
+/**
+ * The item as the plugin page should show it: a LINK whose grant is missing
+ * gets the amber note in the tools' grammar — "Needs setup", and "yours to set
+ * up" for someone who can edit the skill's rules — because until the grant is
+ * back, the plugin's members cannot read it. Healthy links are untouched.
+ */
+export function withLinkHealth<T extends LibraryFilterable & { status: AttentionStatus }>(
+  item: T,
+  plugin: string,
+): T {
+  const membership = (item.plugins as { name: string; linked?: boolean; granted?: boolean }[] | undefined)?.find(
+    (m) => m.name === plugin,
+  );
+  if (!membership?.linked || membership.granted !== false) return item;
+  return {
+    ...item,
+    status: {
+      state: 'warn',
+      text: item.owned ? 'Needs setup: share with plugin members' : 'Needs setup',
+      hint: `The skill's access rules no longer name ${plugin}'s members. Repair the link from the skill page.`,
+    },
+  };
+}
+
+/** The distinct plugin names an item belongs to. */
+export function pluginsOfItem(item: Pick<LibraryFilterable, 'plugin' | 'plugins'>): string[] {
+  const names = new Set<string>();
+  if (item.plugin !== null) names.add(item.plugin);
+  for (const m of item.plugins ?? []) names.add(m.name);
+  return [...names];
 }
 
 /** Sidebar selection narrows; the query matches name/description within it. */
@@ -272,7 +315,7 @@ export function filterLibraryItems<T extends LibraryFilterable>(
       case 'owned':
         return item.owned;
       case 'group':
-        return item.plugin === filter.plugin;
+        return isInPlugin(item, filter.plugin);
       case 'ungrouped':
         return isUngrouped(item);
     }
@@ -291,8 +334,9 @@ export function pluginCounts<T extends LibraryFilterable>(
 ): { plugin: string; count: number }[] {
   const counts = new Map<string, number>();
   for (const item of items) {
-    if (item.plugin === null) continue;
-    counts.set(item.plugin, (counts.get(item.plugin) ?? 0) + 1);
+    // A linked skill counts for every plugin that links it, like the plugin
+    // index's own totals.
+    for (const name of pluginsOfItem(item)) counts.set(name, (counts.get(name) ?? 0) + 1);
   }
   return [...counts.entries()]
     .map(([plugin, count]) => ({ plugin, count }))

--- a/packages/core-frontend/src/modules/library/utils/status.ts
+++ b/packages/core-frontend/src/modules/library/utils/status.ts
@@ -241,6 +241,18 @@ export interface LibraryFilterable {
   owned: boolean;
   /** Folder plugin from the item's KB path, or null when it sits in none. */
   plugin: string | null;
+  /**
+   * Lives under the shared `Skills/` root rather than in a plugin folder.
+   * Such an item has no folder plugin, but it is not "yours alone" either —
+   * it is owned by a scope and shared into plugins by link — so the
+   * ungrouped view leaves it out and only the catalog-wide view lists it.
+   */
+  shared?: boolean;
+}
+
+/** "Yours alone": in no plugin folder AND not a shared skill. */
+export function isUngrouped(item: Pick<LibraryFilterable, 'plugin' | 'shared'>): boolean {
+  return item.plugin === null && !item.shared;
 }
 
 /** Sidebar selection narrows; the query matches name/description within it. */
@@ -262,7 +274,7 @@ export function filterLibraryItems<T extends LibraryFilterable>(
       case 'group':
         return item.plugin === filter.plugin;
       case 'ungrouped':
-        return item.plugin === null;
+        return isUngrouped(item);
     }
   });
 }

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -40,6 +40,24 @@ const FIELDS: Record<
     placeholder: 'knowledge-base',
     advanced: true,
   },
+  knowledgeBaseDir: {
+    label: 'Knowledge folder',
+    help: 'The top-level folder in the repository that holds the knowledge. Change it only to read a repository laid out by someone else.',
+    placeholder: 'KnowledgeBase',
+    advanced: true,
+  },
+  skillsDir: {
+    label: 'Skills folder',
+    help: 'The top-level folder that holds shared skills. The three folder names must differ.',
+    placeholder: 'Skills',
+    advanced: true,
+  },
+  pluginsDir: {
+    label: 'Plugins folder',
+    help: 'The top-level folder that holds plugins. The three folder names must differ.',
+    placeholder: 'Plugins',
+    advanced: true,
+  },
   defaultBranch: {
     label: 'Main branch',
     help: 'The version everyone sees. Filled in from your repository when you test the connection.',

--- a/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
+++ b/packages/core-frontend/src/modules/setup/components/SetupScreen.tsx
@@ -58,6 +58,18 @@ const FIELDS: Record<
     placeholder: 'Plugins',
     advanced: true,
   },
+  pluginDialect: {
+    label: 'Plugin format',
+    help: '"native" reads plugin.json manifests (the default). "bundle" reads plugin.bundle.json files and an MCP registry, for a repository laid out that way.',
+    placeholder: 'native',
+    advanced: true,
+  },
+  mcpRegistryPath: {
+    label: 'MCP registry file',
+    help: 'Only for the bundle format: where the MCP server registry lives in the repository.',
+    placeholder: 'configs/mcp/registry.json',
+    advanced: true,
+  },
   defaultBranch: {
     label: 'Main branch',
     help: 'The version everyone sees. Filled in from your repository when you test the connection.',

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -610,7 +610,7 @@ export function ExternalAgentAccessPage() {
                 <div className="text-xs font-medium text-ink mb-1">
                   Skills as native plugins — the marketplace
                 </div>
-                <p className="text-[11px] text-ink-muted mb-1 leading-snug">
+                <p className="text-meta text-ink-muted mb-1 leading-snug">
                   Every skill you may read, compiled into a plugin marketplace served as a git
                   remote. One install brings all of it; a later update fetches what changed.
                   The key stays in the URL because Claude Code refreshes marketplaces without
@@ -621,10 +621,10 @@ export function ExternalAgentAccessPage() {
                   aria-label="Claude Code marketplace command"
                   value={marketplaceCommands(reveal.plaintext).claude}
                   rows={2}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
                   onFocus={(e) => e.currentTarget.select()}
                 />
-                <p className="text-[11px] text-ink-muted mt-2 mb-1 leading-snug">
+                <p className="text-meta text-ink-muted mt-2 mb-1 leading-snug">
                   Codex installs every plugin on add:
                 </p>
                 <textarea
@@ -632,10 +632,10 @@ export function ExternalAgentAccessPage() {
                   aria-label="Codex marketplace command"
                   value={marketplaceCommands(reveal.plaintext).codex}
                   rows={2}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
                   onFocus={(e) => e.currentTarget.select()}
                 />
-                <p className="text-[11px] text-ink-muted mt-2 mb-1 leading-snug">
+                <p className="text-meta text-ink-muted mt-2 mb-1 leading-snug">
                   Any other agent, through the skills CLI:
                 </p>
                 <textarea
@@ -643,7 +643,7 @@ export function ExternalAgentAccessPage() {
                   aria-label="skills CLI command"
                   value={marketplaceCommands(reveal.plaintext).skills}
                   rows={2}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
                   onFocus={(e) => e.currentTarget.select()}
                 />
               </div>

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -17,6 +17,7 @@ import {
   useCopyFeedback,
   workspaceBaseUrl,
 } from '../../../shared/mcp';
+import { marketplaceCommands, marketplaceGitUrl } from '../../../shared/marketplace-url';
 import {
   type ExternalApiKeySummary,
   type MintedExternalApiKey,
@@ -277,6 +278,47 @@ export function ExternalAgentAccessPage() {
                   <ExternalLink size={11} className="opacity-60" aria-hidden="true" />
                 </Link>
                 <ConnectionInstructions mcpUrl={mcpUrl} />
+              </div>
+            </details>
+
+            <details className="border border-line rounded" data-testid="marketplace-section">
+              <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-ink">
+                Skills as native plugins (marketplace)
+              </summary>
+              <div className="px-3 pb-3 space-y-3">
+                <p className="text-meta text-ink-muted leading-snug">
+                  Instead of reading skills through the MCP server, an agent can install them
+                  as native plugins. Every skill you may read is compiled into a plugin
+                  marketplace at the git remote below; it needs an external API key from the{' '}
+                  <button
+                    type="button"
+                    onClick={() => setTab('autonomous')}
+                    className="underline text-ink-muted hover:text-ink"
+                  >
+                    Autonomous agents
+                  </button>{' '}
+                  tab, which the key dialog shows filled in.
+                </p>
+                <CopyBlock label="Marketplace git remote" value={marketplaceGitUrl()} rows={2} />
+                <CopyBlock
+                  label="Claude Code (one install, everything you may read)"
+                  value={marketplaceCommands('<external-api-key>').claude}
+                  rows={2}
+                />
+                <CopyBlock
+                  label="Codex"
+                  value={marketplaceCommands('<external-api-key>').codex}
+                  rows={2}
+                />
+                <CopyBlock
+                  label="Any other agent, via the skills CLI"
+                  value={marketplaceCommands('<external-api-key>').skills}
+                  rows={2}
+                />
+                <p className="text-meta text-ink-muted leading-snug">
+                  The key stays in the URL: Claude Code refreshes marketplaces in the background
+                  without credential helpers. Revoke the key here to cut the agent off.
+                </p>
               </div>
             </details>
 
@@ -560,6 +602,47 @@ export function ExternalAgentAccessPage() {
                   readOnly
                   value={jsonConfigSnippet(mcpUrl, reveal.plaintext)}
                   rows={11}
+                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+              </div>
+              <div>
+                <div className="text-xs font-medium text-ink mb-1">
+                  Skills as native plugins — the marketplace
+                </div>
+                <p className="text-[11px] text-ink-muted mb-1 leading-snug">
+                  Every skill you may read, compiled into a plugin marketplace served as a git
+                  remote. One install brings all of it; a later update fetches what changed.
+                  The key stays in the URL because Claude Code refreshes marketplaces without
+                  credential helpers.
+                </p>
+                <textarea
+                  readOnly
+                  aria-label="Claude Code marketplace command"
+                  value={marketplaceCommands(reveal.plaintext).claude}
+                  rows={2}
+                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <p className="text-[11px] text-ink-muted mt-2 mb-1 leading-snug">
+                  Codex installs every plugin on add:
+                </p>
+                <textarea
+                  readOnly
+                  aria-label="Codex marketplace command"
+                  value={marketplaceCommands(reveal.plaintext).codex}
+                  rows={2}
+                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <p className="text-[11px] text-ink-muted mt-2 mb-1 leading-snug">
+                  Any other agent, through the skills CLI:
+                </p>
+                <textarea
+                  readOnly
+                  aria-label="skills CLI command"
+                  value={marketplaceCommands(reveal.plaintext).skills}
+                  rows={2}
                   className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
                   onFocus={(e) => e.currentTarget.select()}
                 />

--- a/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { ExternalAgentAccessPage } from '../ExternalAgentAccessPage';
 import { configureMcpUrl } from '../../../../shared/mcp';
+import { configureMarketplaceGitUrl } from '../../../../shared/marketplace-url';
 
 /**
  * The Connect page's contract, and the reason this file exists at all: every
@@ -56,6 +57,8 @@ beforeEach(() => {
 
 function mount(mcpUrl: string) {
   configureMcpUrl(mcpUrl);
+  // The marketplace remote is served from the same deployment address.
+  configureMarketplaceGitUrl(`${new URL(mcpUrl).origin}/git/marketplace.git`);
   return render(
     <MemoryRouter>
       <ExternalAgentAccessPage />
@@ -137,7 +140,12 @@ describe('the interactive tab: local first, hosted second, each with its own add
   it('keeps each family on its own address', () => {
     mount(PUBLIC_URL);
     for (const value of snippets()) {
-      if (value.includes('hexis')) {
+      if (value.includes('marketplace.git')) {
+        // The marketplace remote is the deployment's own address (with the
+        // key in the userinfo, so the HOST is what survives), never the browser's.
+        expect(value).toContain(new URL(PUBLIC_URL).host);
+        expect(value).not.toContain(window.location.host);
+      } else if (value.includes('hexis')) {
         expect(value).toContain(window.location.origin);
         expect(value).not.toContain(PUBLIC_URL);
       } else {
@@ -231,9 +239,9 @@ describe('the key-bearing snippets quote the deployment too', () => {
     expect(snippets().some((v) => v.includes(KEY))).toBe(false);
     await revealAKey(user);
     expect(snippets().filter((v) => v.includes(KEY))).toHaveLength(
-      // the reveal textarea itself, the three keyed hosted snippets, and the
-      // two local-server (hexis-mcp) snippets
-      6,
+      // the reveal textarea itself, the three keyed hosted snippets, the two
+      // local-server (hexis-mcp) snippets, and the three marketplace commands
+      9,
     );
   });
 });

--- a/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
@@ -22,6 +22,7 @@ import {
   KNOWLEDGE_BASE_DIR,
   DATA_DIR,
   PLUGINS_DIR,
+  SKILLS_DIR,
   AGENTS_DIR,
   PIPELINES_DIR,
 } from '@bevel-software/platform-shared';
@@ -1098,7 +1099,9 @@ export function FileExplorer() {
     // without it a KB whose only root is Plugins would fail this check, fall
     // back to the flat tree, and show the folder that way instead.
     const plugins = findDir(PLUGINS_DIR);
-    if (!knowledgeBase && !data && !agents && !pipelines && !plugins) return null;
+    // Same for Skills: the Library surface renders it, not this explorer.
+    const skills = findDir(SKILLS_DIR);
+    if (!knowledgeBase && !data && !agents && !pipelines && !plugins && !skills) return null;
     // Any other top-level content folder (e.g. a stray `Legal/`) folds into Knowledge.
     const otherDirs = kids.filter(
       (c) => c.type === 'directory' && !KB_ROOT_DIRS.has(c.name),

--- a/packages/core-frontend/src/modules/workspace/utils/fileTree.ts
+++ b/packages/core-frontend/src/modules/workspace/utils/fileTree.ts
@@ -1,25 +1,21 @@
 import {
-  AGENTS_DIR,
-  DATA_DIR,
   KNOWLEDGE_BASE_DIR,
-  PIPELINES_DIR,
   PLUGINS_DIR,
+  SKILLS_DIR,
+  reservedRootDirNames,
   type FileTreeEntry,
 } from '@bevel-software/platform-shared';
 import type { PendingEntry } from '../state/workspace.context';
 
 // RESERVED is not the same as CREATED (see kb-layout.ts): core only seeds
-// KnowledgeBase/ and Plugins/, but every reserved name renders as its own root
-// when present — a distribution that owns the execution layer seeds Data/,
-// Agents/ and Pipelines/, and a KB that has them must not see them folded
-// into Knowledge as stray content.
-export const KB_ROOT_DIRS = new Set([
-  KNOWLEDGE_BASE_DIR,
-  DATA_DIR,
-  AGENTS_DIR,
-  PIPELINES_DIR,
-  PLUGINS_DIR,
-]);
+// KnowledgeBase/, Skills/ and Plugins/, but every reserved name renders as its
+// own root when present — a distribution that owns the execution layer seeds
+// Data/, Agents/ and Pipelines/, and a KB that has them must not see them
+// folded into Knowledge as stray content. A function, not a module-scope set:
+// three of the names are configurable and arrive after this module loads.
+export const KB_ROOT_DIRS = {
+  has: (name: string): boolean => reservedRootDirNames().has(name),
+};
 
 /**
  * Descend past the workspace / KB-clone wrapper levels to the node that holds
@@ -93,7 +89,7 @@ export function suggestedPages(tree: FileTreeEntry | null, limit: number): FileT
       if (entry.name.startsWith('.')) continue;
       if (entry.type === 'file') {
         if (READABLE_PAGE.test(entry.name) && !isAccessRulesFile(entry)) pages.push(entry);
-      } else if (entry.name !== PLUGINS_DIR) {
+      } else if (entry.name !== PLUGINS_DIR && entry.name !== SKILLS_DIR) {
         next.push(...(entry.children ?? []));
       }
     }

--- a/packages/core-frontend/src/shared/__tests__/marketplace-url.test.ts
+++ b/packages/core-frontend/src/shared/__tests__/marketplace-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  configureMarketplaceGitUrl,
+  marketplaceCommands,
+  marketplaceGitUrl,
+  resetMarketplaceGitUrlForTests,
+  withConnectionKey,
+} from '../marketplace-url';
+
+afterEach(() => resetMarketplaceGitUrlForTests());
+
+describe('marketplace git url', () => {
+  it('uses the server\'s address, with any credential stripped', () => {
+    configureMarketplaceGitUrl('https://user:hunter2@kb.acme.com/git/marketplace.git');
+    expect(marketplaceGitUrl()).toBe('https://kb.acme.com/git/marketplace.git');
+  });
+
+  it('falls back to the origin when the server sends nothing usable', () => {
+    configureMarketplaceGitUrl(undefined);
+    expect(marketplaceGitUrl()).toBe(`${window.location.origin}/git/marketplace.git`);
+    configureMarketplaceGitUrl('javascript:alert(1)');
+    expect(marketplaceGitUrl()).toBe(`${window.location.origin}/git/marketplace.git`);
+  });
+
+  it('puts the connection key in the URL the way git sends it', () => {
+    configureMarketplaceGitUrl('https://kb.acme.com/git/marketplace.git');
+    expect(withConnectionKey('bevel_abc')).toBe('https://key:bevel_abc@kb.acme.com/git/marketplace.git');
+    const cmds = marketplaceCommands('bevel_abc');
+    expect(cmds.claude).toBe(
+      'claude plugin marketplace add https://key:bevel_abc@kb.acme.com/git/marketplace.git && claude plugin install hexis-all@hexis',
+    );
+    expect(cmds.codex).toBe('codex plugin marketplace add https://key:bevel_abc@kb.acme.com/git/marketplace.git');
+    expect(cmds.skills).toBe('npx skills add https://key:bevel_abc@kb.acme.com/git/marketplace.git --all -y');
+  });
+});

--- a/packages/core-frontend/src/shared/marketplace-url.ts
+++ b/packages/core-frontend/src/shared/marketplace-url.ts
@@ -1,0 +1,76 @@
+/**
+ * The per-user marketplace git remote, as `/api/config` names it — the same
+ * "configured at boot, read through a function" shape as `mcpEndpointUrl`
+ * (see `shared/mcp/connect-snippets.ts` for why a module-scope constant would
+ * snapshot the wrong value).
+ *
+ * The URL never carries a credential: the person adds their own connection
+ * key when they paste the command, and `withConnectionKey` is how the
+ * settings card composes that.
+ */
+
+const GIT_PATH = '/git/marketplace.git';
+
+let configured: string | null = null;
+
+/** Record what the server said; absent or unusable falls back to the origin. */
+export function configureMarketplaceGitUrl(url: unknown): void {
+  if (typeof url !== 'string' || url.trim() === '') {
+    configured = null;
+    return;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      configured = null;
+      return;
+    }
+    parsed.username = '';
+    parsed.password = '';
+    configured = parsed.toString();
+  } catch {
+    configured = null;
+  }
+}
+
+/** The remote to show people, without any credential. */
+export function marketplaceGitUrl(): string {
+  return configured ?? `${window.location.origin}${GIT_PATH}`;
+}
+
+/**
+ * The remote with a connection key in the userinfo — what git sends as HTTP
+ * Basic, and what Claude Code's background refresh needs because it disables
+ * credential helpers. `key` is the placeholder when the person has not
+ * minted one yet.
+ */
+export function withConnectionKey(key: string): string {
+  const parsed = new URL(marketplaceGitUrl());
+  parsed.username = 'key';
+  parsed.password = key;
+  return parsed.toString();
+}
+
+/** The marketplace's registered name — what `plugin@<name>` refers to in Claude Code. */
+export const MARKETPLACE_NAME = 'hexis';
+/** The one-install bundle plugin every compiled marketplace carries. */
+export const BUNDLE_PLUGIN = 'hexis-all';
+
+/**
+ * The three one-liners the settings page shows, with the key in the URL —
+ * Claude Code's background refresh disables credential helpers, so the key
+ * has nowhere else to live. `key` may be a placeholder.
+ */
+export function marketplaceCommands(key: string): { claude: string; codex: string; skills: string } {
+  const url = withConnectionKey(key);
+  return {
+    claude: `claude plugin marketplace add ${url} && claude plugin install ${BUNDLE_PLUGIN}@${MARKETPLACE_NAME}`,
+    codex: `codex plugin marketplace add ${url}`,
+    skills: `npx skills add ${url} --all -y`,
+  };
+}
+
+/** For tests — module-global state must not leak between them. */
+export function resetMarketplaceGitUrlForTests(): void {
+  configured = null;
+}

--- a/packages/shared/src/workspace/kb-layout.ts
+++ b/packages/shared/src/workspace/kb-layout.ts
@@ -156,6 +156,11 @@ export function validateKbLayout(layout: KbLayout): string | null {
   if (new Set(names).size !== names.length) {
     return 'The knowledge base, skills and plugins folders must have three different names.';
   }
+  // The fixed reserved roots are taken too: naming the skills folder `Data`
+  // would give one directory two reserved roles.
+  const fixed = [DATA_DIR, AGENTS_DIR, PIPELINES_DIR].map((n) => n.toLowerCase());
+  const clash = names.find((n) => fixed.includes(n));
+  if (clash) return `"${clash}" is a reserved folder name (${[DATA_DIR, AGENTS_DIR, PIPELINES_DIR].join(', ')}).`;
   return null;
 }
 
@@ -186,10 +191,12 @@ export function currentKbLayout(): KbLayout {
  * passes through unchanged.
  */
 export function renderKbLayoutPlaceholders(text: string, layout: KbLayout = currentKbLayout()): string {
+  // Replacer FUNCTIONS: a string replacement would interpret `$&`, `$$` and
+  // friends inside a folder name, and `$` is a legal character in one.
   return text
-    .replaceAll('{{knowledgeBaseDir}}', layout.knowledgeBaseDir)
-    .replaceAll('{{skillsDir}}', layout.skillsDir)
-    .replaceAll('{{pluginsDir}}', layout.pluginsDir);
+    .replaceAll('{{knowledgeBaseDir}}', () => layout.knowledgeBaseDir)
+    .replaceAll('{{skillsDir}}', () => layout.skillsDir)
+    .replaceAll('{{pluginsDir}}', () => layout.pluginsDir);
 }
 
 /**

--- a/packages/shared/src/workspace/kb-layout.ts
+++ b/packages/shared/src/workspace/kb-layout.ts
@@ -206,6 +206,96 @@ export const HEXIS_EXTENSION_NS = 'software.bevel.hexis';
 export const HEXIS_TOOLS_DIR = `${HEXIS_EXTENSION_NS}/tools`;
 
 /**
+ * The manifest key under which a plugin LINKS shared skills:
+ *
+ *   plugin.json → extensions["software.bevel.hexis"].skills: [
+ *     "Skills/Engineering/deploy",   ← one skill folder
+ *     "Skills/Sales"                 ← a folder of skills: every skill beneath
+ *   ]
+ *
+ * Entries are repo-root-relative folder paths. A plugin's effective skill set
+ * is its inline `skills/` folder PLUS everything these roots resolve to. The
+ * spec reserves `extensions` for exactly this kind of client-specific data, so
+ * a conformant client that ignores it still gets a valid manifest; the
+ * compiled distribution copies the linked skills in for it.
+ *
+ * Linking is a reference, not a grant: a member of the plugin can read a
+ * linked skill only because the skill's own access rules name the plugin's
+ * principal (`plugin/<Name>/read`). The link service writes both together.
+ */
+export const HEXIS_LINKED_SKILLS_KEY = 'skills';
+
+/**
+ * Normalise a linked-skill root, or null when it cannot be one: a
+ * repo-root-relative POSIX folder path with no `..`, no leading slash, no
+ * backslashes and no empty segments. Trailing slashes are dropped.
+ */
+export function normalizeSkillRoot(raw: string): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.includes('\\') || trimmed.startsWith('/')) return null;
+  const segments = trimmed.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+  if (segments.some((s) => s === '.' || s === '..')) return null;
+  return segments.join('/');
+}
+
+/**
+ * The linked-skill roots a parsed manifest declares — invalid entries are
+ * dropped, duplicates collapsed, order kept. A manifest with no extension
+ * block links nothing.
+ */
+export function linkedSkillRoots(manifest: unknown): string[] {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) return [];
+  const ext = (manifest as Record<string, unknown>).extensions;
+  if (typeof ext !== 'object' || ext === null) return [];
+  const ns = (ext as Record<string, unknown>)[HEXIS_EXTENSION_NS];
+  if (typeof ns !== 'object' || ns === null) return [];
+  const raw = (ns as Record<string, unknown>)[HEXIS_LINKED_SKILLS_KEY];
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    const root = normalizeSkillRoot(typeof entry === 'string' ? entry : '');
+    if (root !== null && !out.includes(root)) out.push(root);
+  }
+  return out;
+}
+
+/**
+ * The manifest with its linked-skill roots REPLACED by `roots`, every other
+ * byte of the object preserved (the MCP extension block beside it, the
+ * portable fields above it). An empty list removes the key rather than
+ * leaving `skills: []` behind.
+ */
+export function withLinkedSkillRoots(
+  manifest: Record<string, unknown>,
+  roots: readonly string[],
+): Record<string, unknown> {
+  const extensions =
+    typeof manifest.extensions === 'object' && manifest.extensions !== null && !Array.isArray(manifest.extensions)
+      ? { ...(manifest.extensions as Record<string, unknown>) }
+      : {};
+  const current = extensions[HEXIS_EXTENSION_NS];
+  const ns: Record<string, unknown> =
+    typeof current === 'object' && current !== null && !Array.isArray(current)
+      ? { ...(current as Record<string, unknown>) }
+      : {};
+  if (roots.length > 0) ns[HEXIS_LINKED_SKILLS_KEY] = [...roots];
+  else delete ns[HEXIS_LINKED_SKILLS_KEY];
+  if (Object.keys(ns).length > 0) extensions[HEXIS_EXTENSION_NS] = ns;
+  else delete extensions[HEXIS_EXTENSION_NS];
+  const out: Record<string, unknown> = { ...manifest };
+  if (Object.keys(extensions).length > 0) out.extensions = extensions;
+  else delete out.extensions;
+  return out;
+}
+
+/** Whether `skillPath` (a skill folder) falls under `root` (a skill folder or a folder of skills). */
+export function skillUnderRoot(skillPath: string, root: string): boolean {
+  return skillPath === root || skillPath.startsWith(`${root}/`);
+}
+
+/**
  * The manifest `name` for a plugin folder: lowercased, anything outside
  * `[a-z0-9.-]` folded to `-`, runs collapsed, ends trimmed to alphanumerics.
  *

--- a/packages/shared/src/workspace/kb-layout.ts
+++ b/packages/shared/src/workspace/kb-layout.ts
@@ -8,7 +8,8 @@ import { branchSegment } from '../git/branchAuthor.js';
  *
  *   <kbDirName>/
  *   ├── KnowledgeBase/   ← all team ontologies live here (the knowledge graph)
- *   ├── Plugins/         ← one folder per plugin; each holds BOTH skills and tools
+ *   ├── Skills/          ← shared skills, organised by ownership; plugins LINK to them
+ *   ├── Plugins/         ← one folder per plugin: manifest, MCP servers, tools, links
  *   ├── Data/            ← agent-produced records; parsed like KnowledgeBase/
  *   ├── Agents/          ← .agent files — agent role configurations (not the graph)
  *   ├── Pipelines/       ← .pipeline files — execution-layer processes (not the graph)
@@ -24,23 +25,47 @@ import { branchSegment } from '../git/branchAuthor.js';
  *
  * These names are the single source of truth for both sides of the app:
  *  - Backend: the graph parser discovers ontologies under the
- *    {@link ONTOLOGY_ROOTS} (`KnowledgeBase/` and `Data/`); `Plugins/`,
+ *    {@link ontologyRoots} (`KnowledgeBase/` and `Data/`); `Plugins/`,
  *    `Agents/`, `Pipelines/` (and anything else at the root) are ignored by
  *    parsing, validation, and the diagram.
  *  - Frontend: the file tree renders these root folders as distinct
  *    top-level sections.
  *
  * Don't hard-code these strings elsewhere — import them from here.
+ *
+ * CONFIGURABLE, WITH DEFAULTS. The three roots a deployment may rename
+ * (`KnowledgeBase/`, `Skills/`, `Plugins/`) are `let` bindings applied by
+ * {@link configureKbLayout} — the backend from its deployment settings, the
+ * browser from `GET /api/config` — the same live-binding pattern as the branch
+ * model in `git/protected.ts`. Unlike the branch model they carry defaults, so
+ * nothing has to wait for configuration; but the same rule applies: read them
+ * inside a function body, never capture one at module scope.
  */
 
 /** Folder under the repo root that contains all team ontologies. */
-export const KNOWLEDGE_BASE_DIR = 'KnowledgeBase';
+export let KNOWLEDGE_BASE_DIR = 'KnowledgeBase';
+
+/**
+ * Folder under the repo root that holds SHARED skills, organised by ownership:
+ *
+ *   Skills/<scope>/…/<skill>/SKILL.md     a skill, at any depth
+ *   Skills/<scope>/access.md              who owns / may read the scope
+ *
+ * A skill's readability comes from ITS OWN path walk — the scope folders'
+ * `access.md` files — never from the plugins that link it. Plugins point at
+ * skills here by path (see `HEXIS_LINKED_SKILLS_KEY`), so one definition can
+ * ship in several plugins, and a skill in no plugin at all is a normal state.
+ * Inline skills under `Plugins/<Plugin>/skills/` remain supported (personal
+ * folders, legacy layouts); the catalog is the union of both trees.
+ */
+export let SKILLS_DIR = 'Skills';
 
 /**
  * Folder under the repo root that holds the plugins.
  *
- *   Plugins/<Plugin>/plugin.json                  the Agent Plugins manifest
- *   Plugins/<Plugin>/skills/<skill>/SKILL.md      a skill
+ *   Plugins/<Plugin>/plugin.json                  the Agent Plugins manifest; its
+ *                                                 hexis extension lists LINKED skills
+ *   Plugins/<Plugin>/skills/<skill>/SKILL.md      an inline skill
  *   Plugins/<Plugin>/mcp.json                     MCP servers
  *   Plugins/<Plugin>/software.bevel.hexis/tools/  http + inline `.tool` manuals
  *   Plugins/<Plugin>/access.md                    who can read/write the plugin
@@ -59,10 +84,11 @@ export const KNOWLEDGE_BASE_DIR = 'KnowledgeBase';
  *    `inline` types the spec has no slot for. `mcp`-type manuals are emitted as
  *    real `mcp.json` entries instead, so the portable half stays portable.
  *
- * Skills and tools live TOGETHER in one plugin because they share a single
- * access boundary: a tool a plugin cannot read is a skill that plugin cannot
- * run, so splitting them across two roots meant maintaining the same permission
- * twice and letting them drift.
+ * A plugin's own `access.md` governs what the plugin FOLDER holds: the
+ * manifest, the MCP servers, the tools, and any inline skills. Shared skills
+ * under `Skills/` are governed by their own scope and are made visible to a
+ * plugin's members by granting the plugin's principal (`plugin/<Name>/read`)
+ * on the skill — ownership decides, the plugin is a view.
  *
  * A plugin is not a registry of unique names — it is a folder. The same
  * integration may exist in several plugins as separate files (`Everyone/…/
@@ -74,7 +100,82 @@ export const KNOWLEDGE_BASE_DIR = 'KnowledgeBase';
  * display casing. The lowercase slug the spec does constrain lives in the
  * manifest's `name` field.
  */
-export const PLUGINS_DIR = 'Plugins';
+export let PLUGINS_DIR = 'Plugins';
+
+/** The three renameable roots, as a deployment declares them and `/api/config` serves them. */
+export interface KbLayout {
+  knowledgeBaseDir: string;
+  skillsDir: string;
+  pluginsDir: string;
+}
+
+/** The layout a deployment gets when it names nothing. */
+export const DEFAULT_KB_LAYOUT: Readonly<KbLayout> = Object.freeze({
+  knowledgeBaseDir: 'KnowledgeBase',
+  skillsDir: 'Skills',
+  pluginsDir: 'Plugins',
+});
+
+/**
+ * What is wrong with one root name, or null. A root is joined onto the repo
+ * root and onto `<dir>/.gitkeep`, so a separator or `..` would write outside
+ * the repository; a dot-prefixed name would be skipped by every scanner that
+ * treats dot-entries as bookkeeping; `.git` in any case would corrupt the clone.
+ */
+export function validateKbRootName(name: string): string | null {
+  const v = name.trim();
+  if (!v) return 'A folder name is required.';
+  if (v === '.' || v === '..' || v.includes('/') || v.includes('\\')) {
+    return 'Use a single folder name — no slashes.';
+  }
+  if (v.startsWith('.')) return 'The name can\'t start with a dot.';
+  // eslint-disable-next-line no-control-regex -- control chars cannot be a path segment
+  if (/[\u0000-\u001f\u007f]/.test(v)) return 'The name can\'t contain control characters.';
+  return null;
+}
+
+/**
+ * What is wrong with a layout, or null — the same rule {@link configureKbLayout}
+ * enforces, without applying anything. Separate so the setup screen can judge a
+ * proposed layout before it is saved. The three names must differ, compared
+ * case-insensitively: the workspaces live on case-insensitive filesystems too,
+ * where `Skills` and `skills` are one folder.
+ */
+export function validateKbLayout(layout: KbLayout): string | null {
+  for (const [label, value] of [
+    ['knowledge base', layout.knowledgeBaseDir],
+    ['skills', layout.skillsDir],
+    ['plugins', layout.pluginsDir],
+  ] as const) {
+    const problem = validateKbRootName(value ?? '');
+    if (problem) return `The ${label} folder: ${problem}`;
+  }
+  const names = [layout.knowledgeBaseDir, layout.skillsDir, layout.pluginsDir].map((n) =>
+    n.trim().toLowerCase(),
+  );
+  if (new Set(names).size !== names.length) {
+    return 'The knowledge base, skills and plugins folders must have three different names.';
+  }
+  return null;
+}
+
+/**
+ * Apply the layout. Called once during boot on each side; throws on an invalid
+ * one so a bad deployment setting fails beside the rest of the wiring rather
+ * than scattering a half-renamed tree. Applying the defaults is a no-op.
+ */
+export function configureKbLayout(layout: KbLayout): void {
+  const problem = validateKbLayout(layout);
+  if (problem) throw new Error(problem);
+  KNOWLEDGE_BASE_DIR = layout.knowledgeBaseDir.trim();
+  SKILLS_DIR = layout.skillsDir.trim();
+  PLUGINS_DIR = layout.pluginsDir.trim();
+}
+
+/** The layout currently in effect. */
+export function currentKbLayout(): KbLayout {
+  return { knowledgeBaseDir: KNOWLEDGE_BASE_DIR, skillsDir: SKILLS_DIR, pluginsDir: PLUGINS_DIR };
+}
 
 /**
  * The pre-rename name of {@link PLUGINS_DIR}. Referenced ONLY by the migration
@@ -222,8 +323,20 @@ export const PIPELINES_DIR = 'Pipelines';
 /**
  * The roots whose subfolders are discovered as ontologies by the graph parser
  * (each subfolder with both `NodeTypes/` and `Knowledge/` is an ontology).
+ * A function, not a constant: `KNOWLEDGE_BASE_DIR` is configurable, and a
+ * module-scope array would snapshot the default before configuration.
  */
-export const ONTOLOGY_ROOTS: readonly string[] = [KNOWLEDGE_BASE_DIR, DATA_DIR];
+export function ontologyRoots(): readonly string[] {
+  return [KNOWLEDGE_BASE_DIR, DATA_DIR];
+}
+
+/**
+ * Every reserved root name, as currently configured — the set the file tree
+ * renders as its own sections rather than folding into Knowledge.
+ */
+export function reservedRootDirNames(): ReadonlySet<string> {
+  return new Set([KNOWLEDGE_BASE_DIR, SKILLS_DIR, PLUGINS_DIR, DATA_DIR, AGENTS_DIR, PIPELINES_DIR]);
+}
 
 /** The `Knowledge/` marker subfolder of an ontology (holds the graph nodes). */
 export const KNOWLEDGE_DIR = 'Knowledge';

--- a/packages/shared/src/workspace/kb-layout.ts
+++ b/packages/shared/src/workspace/kb-layout.ts
@@ -178,6 +178,21 @@ export function currentKbLayout(): KbLayout {
 }
 
 /**
+ * Render the layout placeholders a managed template carries —
+ * `{{knowledgeBaseDir}}`, `{{skillsDir}}`, `{{pluginsDir}}` — with the
+ * names in effect. The packaged `AGENTS.md` and `.bevelignore` are written
+ * this way so a deployment that renamed its roots hands the agent a guide
+ * that names the folders it will actually find. Text without placeholders
+ * passes through unchanged.
+ */
+export function renderKbLayoutPlaceholders(text: string, layout: KbLayout = currentKbLayout()): string {
+  return text
+    .replaceAll('{{knowledgeBaseDir}}', layout.knowledgeBaseDir)
+    .replaceAll('{{skillsDir}}', layout.skillsDir)
+    .replaceAll('{{pluginsDir}}', layout.pluginsDir);
+}
+
+/**
  * The pre-rename name of {@link PLUGINS_DIR}. Referenced ONLY by the migration
  * that renames it — every other consumer should be reading the new name, and a
  * second live spelling is exactly how two layouts start being supported by


### PR DESCRIPTION
## Summary

Skills get their own home, plugins link to them, and a compiled marketplace ships them to agents.

**Where things live**
- New reserved root `Skills/`: shared skills organised by ownership, any depth. Skills inside plugin folders keep working.
- A plugin is a folder with a manifest, at any depth: `plugin.json` (hexis) or `plugin.bundle.json` (a customer's read-only format, in `modules/plugins/discovery/bundle-dialect/`, deletable as a unit). Nothing else is a plugin; a new `plugin-manifests` boot step writes the manifest into every legacy folder once.
- A plugin lists the shared skills it uses in `extensions["software.bevel.hexis"].skills`. One skill, many plugins.
- The `KnowledgeBase` / `Skills` / `Plugins` folder names are deployment settings (default unchanged), served by `/api/config`.

**Who may see what**
- Ownership governs: a skill's readability comes from its own access rules, never from the plugin listing it. Unreadable linked skills are omitted, fail closed.
- Plugins are grantable principals: `plugin/<Name>/read|write|owner` in any `access.md` means everyone currently holding that verb on the plugin, derived live from the plugin's own rules. No copying, no sync.

**User flows**
- Add an existing skill to a plugin (manifest entry + grant of the plugin's readers/writers on the skill, one operation; needs write on both sides).
- Request write access to a skill (a change request proposing the grant, the join-request machinery pointed at a skill folder).
- Unlink, and Repair for a link whose grant was hand-removed (the only case the amber "needs setup" dot appears).
- "In plugins" section on the skill page; hidden-skill count on the plugin page; plugins as grantees in the Manage-access dialog.

**Distribution**
- Per-user git remote `/git/marketplace.git`: one bare repo, one git namespace per user, served by `git http-backend`, external API keys as Basic/Bearer, fast-forward pulls, pushes refused.
- The compiled tree: Claude/Codex/spec manifests per plugin with skills copied in; a `skills-and-knowledge` plugin holding every readable skill no other plugin ships plus the knowledge base's MCP endpoint (URL only, OAuth signs in); a `hexis-all` bundle for one-command install; Codex `INSTALLED_BY_DEFAULT`; a flat `skills/` folder for `npx skills add --all`.
- Retired skills (`metadata.lifecycle`) never compile; Deprecated/Retired badges in the library; `metadata.owner` is read.

**Upgrade path**
- First boot: `Skills/` created and hidden from the knowledge tree, manifests written into legacy plugin folders, on every branch, idempotent. No DB migration, no env changes, no image changes (git and its http-backend are already in the image).
- Enterprise repin notes: `ResolvedPrincipal.kind` gained `plugin`; `kbPrincipals` returns a `plugins` list; frontend `KB_ROOT_DIRS` is now an object with `has` rather than a `Set`. Constructor signatures only gained optional trailing parameters.

**Deferred**
- "Used by plugins" note in the change-request review panel; pushing a compiled tree to a GitHub mirror for the ChatGPT workspace import; marketplace name/owner are hardcoded in the composition root.

## Test plan

- Backend: 174 files / 2084 tests pass. New coverage: layout configuration, both-root scanning with `.bevelignore`, plugin-principal resolution over a real access tree (working tree and at-ref), linking end to end with the real resolver, the compiled tree shape, real `git clone` / `git pull` against the endpoint including namespace isolation and push refusal, the bundle dialect with an `extends` chain and a cycle, a customer-shaped repository end to end, the boot migrations.
- Frontend: 128 files / 1589 tests pass. New coverage: link membership filters, the link panel including the request-access path, the access page commands, bootstrap layout handling.
- Not done here: the manual end-to-end against a running server with real Claude Code / Codex installs (steps are in the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skills get a shared `Skills/` root, plugins link to skills instead of copying them, and the knowledge base now compiles into a per-user marketplace that agents clone as a git remote.

**Layout and permissions**
- A reserved `Skills/` root holds shared skills at any depth; the `KnowledgeBase` / `Skills` / `Plugins` names are deployment settings served by `/api/config`, and may not take the fixed reserved names.
- Managed `AGENTS.md` and `.bevelignore` templates render with the deployment's root names through placeholders, so a renamed root causes no drift.
- A plugin is a folder with a manifest, at any depth: `plugin.json` natively or read-only `plugin.bundle.json` (the customer dialect). A boot step writes manifests into legacy folders once, on every branch, idempotently. A manifest without `access.md` is a ghost: omitted from the index, neither linkable nor grantable.
- Plugin members become grantable principals (`plugin/<Name>/read|write|owner`), derived live from the plugin's own access rules; the `plugin/` prefix is refused for roles and groups, and a token with more than one separator is an error, so a synthesised principal can never be overwritten.
- Linking a skill writes the manifest entry and the skill's grant in one ordered operation; a failure between the two leaves the visible half-state (amber dot and Repair), never a silent one. Retired skills cannot be linked, and a root that holds a retired skill anywhere beneath it cannot be linked or repaired either.
- Requesting write access to a skill reuses the join-request machinery; a skill's readability always comes from its own access rules, and unreadable linked skills are omitted, fail closed. `/api/skills` names only plugins the caller may discover, and names none when it has links but no gate to judge discoverability by.
- No DB migration or env changes; the only breaking changes are `ResolvedPrincipal.kind` gaining `plugin`, `kbPrincipals` returning a `plugins` list, and frontend `KB_ROOT_DIRS` becoming an object with `has` instead of a `Set`.

**Distribution**
- Each user's compiled tree is served at `/git/marketplace.git` with per-user git namespaces; pulls are fast-forward only, pushes refused, and the server refuses to serve when it cannot name the source commit the tree was compiled from — a commit it re-reads after compiling, so a tree is never stamped with one it wasn't built from.
- Compiled plugin slugs come from the sanitised manifest slug; duplicate or reserved names are skipped, a bundle that folds to a real plugin's slug is refused rather than overwriting it, and the sink refuses paths escaping its scratch directory. A failed first-use initialisation is retried on the next request.
- The tree ships per-plugin vendor manifests with skills copied in, a `skills-and-knowledge` plugin with the hosted MCP endpoint, a `hexis-all` bundle, and a flat `skills/` folder for `npx skills add --all`.
- The bundle dialect reads a customer's `plugin.bundle.json` and MCP registry layout as plugins, read-only, deletable as a unit; the registry validates transports and refuses duplicate ids and blank URLs.
- Retired skills never compile, and deprecated or retired skills wear badges in the library.

<sup>Written for commit 2ff3b5dc6694b7ab66397ed238782ff4e3c1cd9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

