### PR TITLE
Skills file tree in the Library sidebar

### DIFF
--- a/.changeset/skills-sidebar-tree.md
+++ b/.changeset/skills-sidebar-tree.md
@@ -1,0 +1,8 @@
+---
+'@bevel-software/platform-core-backend': minor
+'@bevel-software/platform-core-frontend': minor
+---
+
+The Skills & Tools sidebar shows the shared `Skills/` root as a file tree, above the plugins. It is the same tree as the Knowledge app's — upload by drag and drop, create files and folders, rename, move, delete and manage access from the right-click menu — and clicking a skill file opens it on its skill page. The plugin list below it is now headed "Plugins".
+
+Because the sidebar reads that tree from the workspace, the `Skills/` root is no longer hidden by `.bevelignore`: the packaged template drops the rule, and the maintenance step on the first start removes the line an earlier release appended to existing knowledge bases (only that line and its comment; every other rule stays). The Knowledge explorer never rendered the root and still does not.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,8 +23,9 @@ after an upgrade can take a little longer.
 
 The maintenance phase commits to the knowledge base on every branch when a
 release needs it. The current steps: rename a legacy `Groups/` root to
-`Plugins/`; create the `Skills/` root and hide it from the Knowledge tree
-like `Plugins/`; write a `plugin.json` into every plugin folder that predates
+`Plugins/`; create the `Skills/` root (and take back the `.bevelignore` rule an
+earlier release added for it — the Skills & Tools sidebar shows that root as
+a file tree now); write a `plugin.json` into every plugin folder that predates
 the manifest. Each is idempotent, so a second start writes nothing.
 
 **Downgrading is not supported** once a version's migrations have run: an

--- a/packages/core-backend/kb-template/.bevelignore
+++ b/packages/core-backend/kb-template/.bevelignore
@@ -23,5 +23,3 @@ CLAUDE.md
 roles.yaml
 
 {{pluginsDir}}/
-# The shared-skills root is rendered by the Skills & Tools app, like {{pluginsDir}}/.
-{{skillsDir}}/

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -171,7 +171,8 @@ describe('TemplateFilesStep', () => {
     expect(agents).not.toContain('KnowledgeBase/');
     const ignore = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8')).split('\n').map((l) => l.trim());
     expect(ignore).toContain('plugins/');
-    expect(ignore).toContain('skills/');
+    // The skills root stays VISIBLE: the Skills & Tools sidebar reads it from the workspace tree.
+    expect(ignore).not.toContain('skills/');
     expect(ignore).not.toContain('Plugins/');
     expect(await exists(dir, 'docs/.gitkeep')).toBe(true);
 
@@ -215,41 +216,66 @@ describe('TemplateFilesStep', () => {
     const lines = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8')).split('\n').map((l) => l.trim());
     expect(lines).toContain('MyStuff/'); // the operator's rules survive
     expect(lines).toContain('AGENTS.md'); // the platform's rule was appended
-    expect(lines).toContain('Skills/'); // and the shared-skills root's
+    expect(lines).not.toContain('Skills/'); // never the skills root — the Library's tree needs it
   });
 
-  it('hides the Skills/ root on an existing KB whose ignore file predates it, keeping every other rule', async () => {
-    // A knowledge base seeded before `Skills/` existed: its ignore file names
-    // `Plugins/` and knows nothing of the new root. The top-up appends the
-    // one line, so the root stays the Library's and out of the agent view.
+  it('drops the Skills/ rule an earlier release appended, and its comment, keeping every other rule', async () => {
+    // A knowledge base whose ignore file was topped up by the release that
+    // hid the skills root: the platform's comment + line sit at the end. The
+    // Skills & Tools sidebar reads that root from the workspace tree now, so
+    // the rule comes out exactly as it went in — nothing of the operator's moves.
     const scaffold = await fullScaffold();
-    scaffold['.bevelignore'] = '# mine\n.git/\nAGENTS.md\nPlugins/\n';
+    scaffold['.bevelignore'] =
+      '# mine\n.git/\nAGENTS.md\nPlugins/\n\n# Added by the platform: the conventions doc is not node content.\nSkills/\n';
     await seedUpstream(scaffold);
 
     await makeRunner([new TemplateFilesStep()]).runAll();
 
     const dir = await checkout(DEFAULT_BRANCH);
     const text = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'));
-    expect(text.startsWith('# mine\n.git/\nAGENTS.md\nPlugins/\n')).toBe(true);
-    expect(text.split('\n').map((l) => l.trim())).toContain('Skills/');
-    // Idempotent: a second boot has nothing to add.
+    expect(text).toBe('# mine\n.git/\nAGENTS.md\nPlugins/\n');
+    // Idempotent: a second boot has nothing to change.
     await makeRunner([new TemplateFilesStep()]).runAll();
     const again = await checkout(DEFAULT_BRANCH);
     expect(norm(await fs.readFile(path.join(again, '.bevelignore'), 'utf8'))).toBe(text);
+  });
+
+  it("drops the template's own Skills/ rule from a KB seeded by that release, comment included", async () => {
+    // The previous template listed the rule under its own explanatory line.
+    const scaffold = await fullScaffold();
+    scaffold['.bevelignore'] =
+      'AGENTS.md\nPlugins/\n# The shared-skills root is rendered by the Skills & Tools app, like Plugins/.\nSkills/\n';
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n');
+  });
+
+  it("leaves an operator's !Skills/ negation alone — there is nothing of the platform's to remove", async () => {
+    const scaffold = await fullScaffold();
+    scaffold['.bevelignore'] = 'AGENTS.md\nPlugins/\n!Skills/\n';
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n!Skills/\n');
   });
 
   it('respects an explicit !AGENTS.md negation — hiding the doc is a default, not a mandate', async () => {
     // Appending the positive rule after the negation would WIN under ordered
     // matching and silently defeat the operator's stated choice to show it.
     const scaffold = await fullScaffold();
-    scaffold['.bevelignore'] = '# operator wants the doc visible\n!AGENTS.md\nSkills/\n';
+    scaffold['.bevelignore'] = '# operator wants the doc visible\n!AGENTS.md\nPlugins/\n';
     await seedUpstream(scaffold);
 
     await makeRunner([new TemplateFilesStep()]).runAll();
 
     const dir = await checkout(DEFAULT_BRANCH);
     expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe(
-      '# operator wants the doc visible\n!AGENTS.md\nSkills/\n',
+      '# operator wants the doc visible\n!AGENTS.md\nPlugins/\n',
     );
   });
 

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -240,17 +240,58 @@ describe('TemplateFilesStep', () => {
     expect(norm(await fs.readFile(path.join(again, '.bevelignore'), 'utf8'))).toBe(text);
   });
 
-  it("drops the template's own Skills/ rule from a KB seeded by that release, comment included", async () => {
-    // The previous template listed the rule under its own explanatory line.
+  it("drops the template's own Skills/ rule from a KB seeded by that release, comment included — whatever root the comment named", async () => {
+    // The previous template listed the rule under its own explanatory line,
+    // ending with the plugins root's name of the day; a deployment may have
+    // renamed that root since, so the line is known by its opening.
     const scaffold = await fullScaffold();
     scaffold['.bevelignore'] =
-      'AGENTS.md\nPlugins/\n# The shared-skills root is rendered by the Skills & Tools app, like Plugins/.\nSkills/\n';
+      'AGENTS.md\nPlugins/\n# The shared-skills root is rendered by the Skills & Tools app, like Groups/.\nSkills/\n';
     await seedUpstream(scaffold);
 
     await makeRunner([new TemplateFilesStep()]).runAll();
 
     const dir = await checkout(DEFAULT_BRANCH);
     expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n');
+  });
+
+  it("keeps a Skills/ rule the operator wrote themselves — provenance is the platform's comment", async () => {
+    const scaffold = await fullScaffold();
+    scaffold['.bevelignore'] = 'AGENTS.md\nPlugins/\n# I hide skills on purpose\nSkills/\n';
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe(
+      'AGENTS.md\nPlugins/\n# I hide skills on purpose\nSkills/\n',
+    );
+  });
+
+  it("declares a custom template's ignore file without the stale Skills/ rule it still ships", async () => {
+    // A KB with NO ignore file gets the template's copy — and a distribution's
+    // template may still carry the rule the previous release had. The on-disk
+    // reconciliation never runs on an absent file, so the declared content
+    // must arrive already reconciled.
+    const customTemplate = path.join(root, 'custom-template-stale');
+    await fs.mkdir(customTemplate, { recursive: true });
+    await fs.writeFile(path.join(customTemplate, 'AGENTS.md'), await template('AGENTS.md'), 'utf8');
+    await fs.writeFile(
+      path.join(customTemplate, '.bevelignore'),
+      '# custom\nMyStuff/\n# The shared-skills root is rendered by the Skills & Tools app, like {{pluginsDir}}/.\n{{skillsDir}}/\n',
+      'utf8',
+    );
+    const scaffold = await fullScaffold();
+    delete scaffold['.bevelignore'];
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()], customTemplate).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    const text = norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'));
+    expect(text).toContain('MyStuff/');
+    expect(text.split('\n').map((l) => l.trim())).not.toContain('Skills/');
+    expect(text).not.toContain('shared-skills root');
   });
 
   it("leaves an operator's !Skills/ negation alone — there is nothing of the platform's to remove", async () => {

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -255,6 +255,21 @@ describe('TemplateFilesStep', () => {
     expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n');
   });
 
+  it('recognises the legacy comment for a renamed plugins root with a space in its name', async () => {
+    // The name between the fixed opening and closing is judged by the one
+    // root-name rule the platform has, so every name it could have rendered
+    // there is recognised — and nothing a root cannot be called is.
+    const scaffold = await fullScaffold();
+    scaffold['.bevelignore'] =
+      'AGENTS.md\nPlugins/\n# The shared-skills root is rendered by the Skills & Tools app, like My Plugins/.\nSkills/\n';
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n');
+  });
+
   it("keeps an operator's Skills/ rule whose own comment merely opens like the platform's", async () => {
     // Provenance is the platform's EXACT comment. A comment that begins the
     // same way and goes on differently was never written by the platform.

--- a/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/__tests__/steps.test.ts
@@ -255,6 +255,21 @@ describe('TemplateFilesStep', () => {
     expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe('AGENTS.md\nPlugins/\n');
   });
 
+  it("keeps an operator's Skills/ rule whose own comment merely opens like the platform's", async () => {
+    // Provenance is the platform's EXACT comment. A comment that begins the
+    // same way and goes on differently was never written by the platform.
+    const scaffold = await fullScaffold();
+    const text =
+      'AGENTS.md\nPlugins/\n# The shared-skills root is rendered by the Skills & Tools app, and I hide it anyway\nSkills/\n';
+    scaffold['.bevelignore'] = text;
+    await seedUpstream(scaffold);
+
+    await makeRunner([new TemplateFilesStep()]).runAll();
+
+    const dir = await checkout(DEFAULT_BRANCH);
+    expect(norm(await fs.readFile(path.join(dir, '.bevelignore'), 'utf8'))).toBe(text);
+  });
+
   it("keeps a Skills/ rule the operator wrote themselves — provenance is the platform's comment", async () => {
     const scaffold = await fullScaffold();
     scaffold['.bevelignore'] = 'AGENTS.md\nPlugins/\n# I hide skills on purpose\nSkills/\n';

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -217,7 +217,7 @@ export class TemplateFilesStep implements OnServerStart {
       // custom one. Make it true here, so the managed conventions doc is
       // hidden from the file tree from the first boot either way.
       if (rel === IGNORE_FILENAME) {
-        content = withIgnorePattern(withIgnorePattern(content, 'AGENTS.md'), `${SKILLS_DIR}/`);
+        content = withIgnorePattern(content, 'AGENTS.md');
       }
       branch.write(rel, content);
       added.push(rel);
@@ -235,13 +235,16 @@ export class TemplateFilesStep implements OnServerStart {
     // the operator explicitly choosing to SHOW the file, and hiding it is a
     // default this step provides, not a mandate it re-imposes every boot.
     //
-    // The shared-skills root rides the same merge: it is the Library's, like
-    // `Plugins/`, and a KB whose ignore file predates it would show `Skills/`
-    // in the Knowledge tree and the agent view. Spelled with the CONFIGURED
-    // root name, since a deployment may have renamed it. ONE read-modify-
-    // write for both patterns: two merges would each read the on-disk file
-    // and the second declared write would drop the first's line.
-    added.push(...(await mergeIgnorePatterns(repoDir, branch, ['AGENTS.md', `${SKILLS_DIR}/`])));
+    // The shared-skills root goes the OTHER way. An earlier release hid it
+    // like `Plugins/`; the Skills & Tools sidebar now renders it as a file
+    // tree read from the workspace tree, which the ignore file filters — so a
+    // KB still carrying that rule would show an empty Skills section. The
+    // line that release appended (and its comment) comes out; the Knowledge
+    // explorer never rendered the root and still does not. Spelled with the
+    // CONFIGURED root name, since a deployment may have renamed it. ONE
+    // read-modify-write for both rules: two passes would each read the
+    // on-disk file and the second declared write would lose the first's.
+    added.push(...(await reconcileIgnoreRules(repoDir, branch, { add: ['AGENTS.md'], drop: [`${SKILLS_DIR}/`] })));
 
     // AGENTS.md is MANAGED, not merely seeded: the platform owns its content,
     // and a stale copy is replaced with the packaged template's every startup
@@ -338,33 +341,72 @@ async function templateDiffers(templateDir: string, repoDir: string, relPath: st
 }
 
 /**
- * Ensure `.bevelignore` carries every `pattern`, declaring the appended content when
- * absent. Returns the paths changed, for the note.
+ * Reconcile the platform's OWN rules in `.bevelignore`: every `add` pattern
+ * guaranteed present as a line, every `drop` pattern taken out. Returns the
+ * paths changed, for the note.
  *
- * APPENDS — never rewrites. The file is the operator's, and every rule
- * already in it is theirs to keep; this adds one line under a comment saying
- * where it came from. Absent file, or a file that already lists the pattern,
- * is a no-op — an absent file means the template's copy (declared in the same
- * step) arrives with the pattern in it.
+ * Never rewrites the rest. The file is the operator's, and every rule already
+ * in it is theirs to keep: adding puts one line under a comment saying where
+ * it came from, and dropping removes exactly the line (and the comment) an
+ * earlier release put there. Absent file is a no-op — it means the template's
+ * copy (declared in the same step) arrives with the right rules in it.
  *
  * Matched line-wise rather than by substring: a rule for `Plugins/AGENTS.md`
  * is not a rule for the root `AGENTS.md`, and treating it as one would leave
  * the mismatch this exists to close.
  */
-async function mergeIgnorePatterns(repoDir: string, branch: KbBranch, patterns: string[]): Promise<string[]> {
+async function reconcileIgnoreRules(
+  repoDir: string,
+  branch: KbBranch,
+  rules: { add: string[]; drop: string[] },
+): Promise<string[]> {
   let current: string;
   try {
     current = await fs.readFile(path.join(repoDir, IGNORE_FILENAME), 'utf8');
   } catch {
     // No ignore file — the copy declared from the template arrives with the
-    // patterns in it (guaranteed at declaration time, see the required-files
-    // loop above).
+    // right rules in it (guaranteed at declaration time, see the
+    // required-files loop above).
     return [];
   }
-  const merged = patterns.reduce((text, pattern) => withIgnorePattern(text, pattern), current);
+  const added = rules.add.reduce((text, pattern) => withIgnorePattern(text, pattern), current);
+  const merged = rules.drop.reduce((text, pattern) => withoutIgnorePattern(text, pattern), added);
   if (merged === current) return [];
   branch.write(IGNORE_FILENAME, merged);
   return [IGNORE_FILENAME];
+}
+
+/** The comment `withIgnorePattern` writes above a line it appends. */
+const PLATFORM_RULE_COMMENT = '# Added by the platform: the conventions doc is not node content.';
+
+/** The template line an earlier release shipped above the shared-skills rule. */
+function legacySkillsRuleComment(): string {
+  return `# The shared-skills root is rendered by the Skills & Tools app, like ${PLUGINS_DIR}/.`;
+}
+
+/**
+ * `text` without any line equal to `pattern` — and without the platform's
+ * own comment directly above such a line (the one `withIgnorePattern` writes,
+ * or the template line an earlier release shipped), plus the blank line that
+ * opened the appended block. The rule leaves the way it came in; nothing else
+ * moves. A `!pattern` negation is the operator's and stays.
+ */
+function withoutIgnorePattern(text: string, pattern: string): string {
+  const lines = text.split('\n');
+  if (!lines.some((l) => l.trim() === pattern)) return text;
+  const kept: string[] = [];
+  for (const line of lines) {
+    if (line.trim() !== pattern) {
+      kept.push(line);
+      continue;
+    }
+    const above = kept[kept.length - 1]?.trim();
+    if (above === PLATFORM_RULE_COMMENT || above === legacySkillsRuleComment()) {
+      kept.pop();
+      if (above === PLATFORM_RULE_COMMENT && kept.length > 1 && kept[kept.length - 1]?.trim() === '') kept.pop();
+    }
+  }
+  return kept.join('\n');
 }
 
 /**

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -5,6 +5,7 @@ import {
   PLUGINS_DIR,
   SKILLS_DIR,
   renderKbLayoutPlaceholders,
+  validateKbRootName,
 } from '@bevel-software/platform-shared';
 import { IGNORE_FILENAME } from '../../bevel-ignore.js';
 import type { KbBranch, OnServerStart, ServerStartContext, StepResult } from '../on-server-start.js';
@@ -388,19 +389,38 @@ async function reconcileIgnoreRules(
 const PLATFORM_RULE_COMMENT = '# Added by the platform: the conventions doc is not node content.';
 
 /**
- * The template line an earlier release shipped above the shared-skills rule —
- * the WHOLE line, anchored at both ends. Its one variable is the plugins
- * root's name (a single path segment, which a deployment may have renamed
- * since); everything else is fixed. A looser match (an opening, a substring)
- * would accept lines the platform never wrote, and a line the platform never
- * wrote is the operator's.
+ * The template line an earlier release shipped above the shared-skills rule,
+ * split around its one variable: the plugins root's name, which a deployment
+ * may have renamed since. Everything else is fixed.
  */
-const LEGACY_SKILLS_RULE_COMMENT = /^# The shared-skills root is rendered by the Skills & Tools app, like [^/\s]+\/\.$/;
+const LEGACY_SKILLS_RULE_COMMENT_OPENING = '# The shared-skills root is rendered by the Skills & Tools app, like ';
+const LEGACY_SKILLS_RULE_COMMENT_CLOSING = '/.';
 
-/** Whether a line is EXACTLY a comment the platform wrote above a rule it added. */
+/**
+ * Whether a line is EXACTLY a comment the platform wrote above a rule it
+ * added. For the legacy template line that means the fixed opening, the
+ * fixed closing, and between them a name the platform could have rendered
+ * there — judged by the ONE rule that decides what a root may be called
+ * (`validateKbRootName`), not by a second grammar written here: a hand-made
+ * character class either admits names the validator refuses, or refuses
+ * names it admits (a space, say), and either way a line the platform did
+ * write would be left standing. A looser match (an opening, a substring)
+ * errs the other way and takes a line the operator wrote.
+ */
 function isPlatformRuleComment(line: string): boolean {
   const trimmed = line.trim();
-  return trimmed === PLATFORM_RULE_COMMENT || LEGACY_SKILLS_RULE_COMMENT.test(trimmed);
+  if (trimmed === PLATFORM_RULE_COMMENT) return true;
+  if (
+    !trimmed.startsWith(LEGACY_SKILLS_RULE_COMMENT_OPENING) ||
+    !trimmed.endsWith(LEGACY_SKILLS_RULE_COMMENT_CLOSING)
+  ) {
+    return false;
+  }
+  const name = trimmed.slice(
+    LEGACY_SKILLS_RULE_COMMENT_OPENING.length,
+    trimmed.length - LEGACY_SKILLS_RULE_COMMENT_CLOSING.length,
+  );
+  return name === name.trim() && validateKbRootName(name) === null;
 }
 
 /**

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -216,8 +216,12 @@ export class TemplateFilesStep implements OnServerStart {
       // true of the packaged template, not necessarily of a distribution's
       // custom one. Make it true here, so the managed conventions doc is
       // hidden from the file tree from the first boot either way.
+      // …and a template still shipping the skills rule an earlier release
+      // had (a distribution's copy, a stale packaged one) must not declare
+      // it: the on-disk reconciliation below never sees a file that was
+      // absent, so the declared content is reconciled here instead.
       if (rel === IGNORE_FILENAME) {
-        content = withIgnorePattern(content, 'AGENTS.md');
+        content = withoutPlatformIgnorePattern(withIgnorePattern(content, 'AGENTS.md'), `${SKILLS_DIR}/`);
       }
       branch.write(rel, content);
       added.push(rel);
@@ -239,11 +243,14 @@ export class TemplateFilesStep implements OnServerStart {
     // like `Plugins/`; the Skills & Tools sidebar now renders it as a file
     // tree read from the workspace tree, which the ignore file filters — so a
     // KB still carrying that rule would show an empty Skills section. The
-    // line that release appended (and its comment) comes out; the Knowledge
-    // explorer never rendered the root and still does not. Spelled with the
-    // CONFIGURED root name, since a deployment may have renamed it. ONE
-    // read-modify-write for both rules: two passes would each read the
-    // on-disk file and the second declared write would lose the first's.
+    // line that release wrote comes out, recognised by the PLATFORM'S OWN
+    // COMMENT above it — an operator who wrote the same rule by hand keeps
+    // it, for the same reason the negation above is kept: the file is
+    // theirs. The Knowledge explorer never rendered the root and still does
+    // not. Spelled with the CONFIGURED root name, since a deployment may
+    // have renamed it. ONE read-modify-write for both rules: two passes
+    // would each read the on-disk file and the second declared write would
+    // lose the first's.
     added.push(...(await reconcileIgnoreRules(repoDir, branch, { add: ['AGENTS.md'], drop: [`${SKILLS_DIR}/`] })));
 
     // AGENTS.md is MANAGED, not merely seeded: the platform owns its content,
@@ -348,8 +355,9 @@ async function templateDiffers(templateDir: string, repoDir: string, relPath: st
  * Never rewrites the rest. The file is the operator's, and every rule already
  * in it is theirs to keep: adding puts one line under a comment saying where
  * it came from, and dropping removes exactly the line (and the comment) an
- * earlier release put there. Absent file is a no-op — it means the template's
- * copy (declared in the same step) arrives with the right rules in it.
+ * earlier release put there — never a line the operator wrote. Absent file is
+ * a no-op — it means the template's copy (declared in the same step, and
+ * reconciled the same way at declaration) arrives with the right rules in it.
  *
  * Matched line-wise rather than by substring: a rule for `Plugins/AGENTS.md`
  * is not a rule for the root `AGENTS.md`, and treating it as one would leave
@@ -370,7 +378,7 @@ async function reconcileIgnoreRules(
     return [];
   }
   const added = rules.add.reduce((text, pattern) => withIgnorePattern(text, pattern), current);
-  const merged = rules.drop.reduce((text, pattern) => withoutIgnorePattern(text, pattern), added);
+  const merged = rules.drop.reduce((text, pattern) => withoutPlatformIgnorePattern(text, pattern), added);
   if (merged === current) return [];
   branch.write(IGNORE_FILENAME, merged);
   return [IGNORE_FILENAME];
@@ -379,32 +387,38 @@ async function reconcileIgnoreRules(
 /** The comment `withIgnorePattern` writes above a line it appends. */
 const PLATFORM_RULE_COMMENT = '# Added by the platform: the conventions doc is not node content.';
 
-/** The template line an earlier release shipped above the shared-skills rule. */
-function legacySkillsRuleComment(): string {
-  return `# The shared-skills root is rendered by the Skills & Tools app, like ${PLUGINS_DIR}/.`;
+/**
+ * The template line an earlier release shipped above the shared-skills rule,
+ * by its stable opening — the line ended by naming the plugins root, which a
+ * deployment may have renamed since.
+ */
+const LEGACY_SKILLS_RULE_COMMENT_PREFIX = '# The shared-skills root is rendered by the Skills & Tools app';
+
+/** Whether a line is a comment the platform wrote above a rule it added. */
+function isPlatformRuleComment(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed === PLATFORM_RULE_COMMENT || trimmed.startsWith(LEGACY_SKILLS_RULE_COMMENT_PREFIX);
 }
 
 /**
- * `text` without any line equal to `pattern` — and without the platform's
- * own comment directly above such a line (the one `withIgnorePattern` writes,
- * or the template line an earlier release shipped), plus the blank line that
- * opened the appended block. The rule leaves the way it came in; nothing else
- * moves. A `!pattern` negation is the operator's and stays.
+ * `text` without the `pattern` lines THE PLATFORM WROTE — the ones sitting
+ * directly under its own comment (the one `withIgnorePattern` writes, or the
+ * template line an earlier release shipped) — and without that comment, plus
+ * the blank line that opened an appended block. Provenance is the comment:
+ * an identical line with no platform comment above it is the operator's and
+ * stays, as does a `!pattern` negation. Nothing else moves.
  */
-function withoutIgnorePattern(text: string, pattern: string): string {
+function withoutPlatformIgnorePattern(text: string, pattern: string): string {
   const lines = text.split('\n');
-  if (!lines.some((l) => l.trim() === pattern)) return text;
   const kept: string[] = [];
   for (const line of lines) {
-    if (line.trim() !== pattern) {
+    const above = kept[kept.length - 1];
+    if (line.trim() !== pattern || above === undefined || !isPlatformRuleComment(above)) {
       kept.push(line);
       continue;
     }
-    const above = kept[kept.length - 1]?.trim();
-    if (above === PLATFORM_RULE_COMMENT || above === legacySkillsRuleComment()) {
-      kept.pop();
-      if (above === PLATFORM_RULE_COMMENT && kept.length > 1 && kept[kept.length - 1]?.trim() === '') kept.pop();
-    }
+    kept.pop();
+    if (above.trim() === PLATFORM_RULE_COMMENT && kept.length > 1 && kept[kept.length - 1]?.trim() === '') kept.pop();
   }
   return kept.join('\n');
 }

--- a/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
+++ b/packages/core-backend/src/modules/workspace/startup/steps/template-files.step.ts
@@ -388,16 +388,19 @@ async function reconcileIgnoreRules(
 const PLATFORM_RULE_COMMENT = '# Added by the platform: the conventions doc is not node content.';
 
 /**
- * The template line an earlier release shipped above the shared-skills rule,
- * by its stable opening — the line ended by naming the plugins root, which a
- * deployment may have renamed since.
+ * The template line an earlier release shipped above the shared-skills rule —
+ * the WHOLE line, anchored at both ends. Its one variable is the plugins
+ * root's name (a single path segment, which a deployment may have renamed
+ * since); everything else is fixed. A looser match (an opening, a substring)
+ * would accept lines the platform never wrote, and a line the platform never
+ * wrote is the operator's.
  */
-const LEGACY_SKILLS_RULE_COMMENT_PREFIX = '# The shared-skills root is rendered by the Skills & Tools app';
+const LEGACY_SKILLS_RULE_COMMENT = /^# The shared-skills root is rendered by the Skills & Tools app, like [^/\s]+\/\.$/;
 
-/** Whether a line is a comment the platform wrote above a rule it added. */
+/** Whether a line is EXACTLY a comment the platform wrote above a rule it added. */
 function isPlatformRuleComment(line: string): boolean {
   const trimmed = line.trim();
-  return trimmed === PLATFORM_RULE_COMMENT || trimmed.startsWith(LEGACY_SKILLS_RULE_COMMENT_PREFIX);
+  return trimmed === PLATFORM_RULE_COMMENT || LEGACY_SKILLS_RULE_COMMENT.test(trimmed);
 }
 
 /**

--- a/packages/core-frontend/src/modules/layout/components/SidebarFrame.tsx
+++ b/packages/core-frontend/src/modules/layout/components/SidebarFrame.tsx
@@ -57,7 +57,7 @@ export function SidebarFrame({
   header,
 }: {
   children: ReactNode;
-  /** Names the region and its resize handle, e.g. `Library plugins`. */
+  /** Names the region and its resize handle, e.g. `Library navigation`. */
   label: string;
   /**
    * Pinned above `children`, outside whatever list the surface is holding.

--- a/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
@@ -259,7 +259,7 @@ describe('LibraryRoutes', () => {
       },
     ]);
     renderAt('/skills-and-tools');
-    const nav = await screen.findByRole('navigation', { name: 'Library plugins' });
+    const nav = await screen.findByRole('navigation', { name: 'Library navigation' });
     // In the member half, with a zero count — never below the gap as locked.
     expect(await within(nav).findByRole('button', { name: /^Fresh/ })).toBeInTheDocument();
     expect(within(nav).queryByRole('button', { name: 'Fresh (locked)' })).toBeNull();

--- a/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
@@ -142,7 +142,7 @@ function renderLibrary(path = '/skills-and-tools') {
   );
 }
 
-const nav = () => screen.getByRole('navigation', { name: 'Library plugins' });
+const nav = () => screen.getByRole('navigation', { name: 'Library navigation' });
 const menuItems = () =>
   within(screen.getByRole('menu'))
     .getAllByRole('menuitem')

--- a/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.contextmenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.contextmenu.test.tsx
@@ -42,7 +42,7 @@ function renderSidebar(over: Partial<PluginsSidebarProps> = {}) {
   return { onContextMenu, onSelect };
 }
 
-const nav = () => screen.getByRole('navigation', { name: 'Library plugins' });
+const nav = () => screen.getByRole('navigation', { name: 'Library navigation' });
 const rightClick = (el: Element, at = { clientX: 120, clientY: 240 }) =>
   fireEvent.contextMenu(el, at);
 

--- a/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.locked.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.locked.test.tsx
@@ -40,7 +40,7 @@ function renderSidebar(over: Partial<PluginsSidebarProps> = {}) {
   return { onSelect };
 }
 
-const nav = () => screen.getByRole('navigation', { name: 'Library plugins' });
+const nav = () => screen.getByRole('navigation', { name: 'Library navigation' });
 
 describe('PluginsSidebar: locked plugins', () => {
   it('names a locked row by its state, with no count in it', () => {

--- a/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.test.tsx
@@ -67,9 +67,20 @@ describe('PluginsSidebar', () => {
     expect(row(/^All plugins/)).toHaveAttribute('aria-current', 'false');
   });
 
-  it('heads the plugin rows with what the list is: the set in your MCP', () => {
+  it('heads the plugin rows with what they are: plugins', () => {
     renderSidebar();
-    expect(screen.getByText('Included in your MCP')).toBeInTheDocument();
+    expect(screen.getByText('Plugins')).toBeInTheDocument();
+    expect(screen.queryByText('Included in your MCP')).not.toBeInTheDocument();
+  });
+
+  it('renders the Skills section it is handed between the lenses and the plugins', () => {
+    renderSidebar({ skillsTree: <div data-testid="skills-tree">tree</div> });
+    const tree = screen.getByTestId('skills-tree');
+    const owned = screen.getByRole('button', { name: /^Owned by me/ });
+    const plugins = screen.getByText('Plugins');
+    // Document order: Owned by me → the tree → the Plugins heading.
+    expect(owned.compareDocumentPosition(tree) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(tree.compareDocumentPosition(plugins) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("leads the plugins with the caller's own space", () => {

--- a/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { DEFAULT_BRANCH, type FileTreeEntry } from '@bevel-software/platform-shared';
+import { WorkspaceContext, type WorkspaceContextValue } from '../../workspace/state/workspace.context';
+import { makeWorkspaceFixture } from '../../workspace/__tests__/testFixtures';
+import { SkillsTree } from '../components/SkillsTree';
+
+/**
+ * The Skills section of the Library nav: the shared root as Knowledge's tree
+ * rows, headed by a label instead of a root row, with the two things that
+ * differ from Knowledge — where a click goes (the skill page, on the default
+ * branch) and which row is current (the file the URL names).
+ */
+
+const KB = 'knowledge-base';
+
+const file = (rel: string): FileTreeEntry => ({ name: rel.split('/').pop()!, relativePath: rel, type: 'file' });
+const dir = (rel: string, children: FileTreeEntry[]): FileTreeEntry => ({
+  name: rel.split('/').pop()!,
+  relativePath: rel,
+  type: 'directory',
+  children,
+});
+
+const TREE: FileTreeEntry = dir('.', [
+  dir(KB, [
+    dir(`${KB}/KnowledgeBase`, [file(`${KB}/KnowledgeBase/Handbook.md`)]),
+    dir(`${KB}/Skills`, [
+      dir(`${KB}/Skills/Engineering`, [
+        dir(`${KB}/Skills/Engineering/deploy`, [file(`${KB}/Skills/Engineering/deploy/SKILL.md`)]),
+      ]),
+      dir(`${KB}/Skills/Sales`, [
+        dir(`${KB}/Skills/Sales/discovery-call`, [
+          file(`${KB}/Skills/Sales/discovery-call/SKILL.md`),
+          file(`${KB}/Skills/Sales/discovery-call/checklist.md`),
+        ]),
+      ]),
+    ]),
+  ]),
+]);
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div aria-label="pathname">{location.pathname}</div>;
+}
+
+function renderTree(url: string, over: Partial<WorkspaceContextValue> = {}) {
+  const workspace = makeWorkspaceFixture({ fileTree: TREE, kbDirName: KB, ...over });
+  const view = render(
+    <MemoryRouter initialEntries={[url]}>
+      <WorkspaceContext.Provider value={workspace}>
+        <SkillsTree />
+        <LocationProbe />
+      </WorkspaceContext.Provider>
+    </MemoryRouter>,
+  );
+  return { workspace, ...view };
+}
+
+const row = (name: string) => screen.getByRole('button', { name });
+
+describe('SkillsTree', () => {
+  it('heads the scopes with a Skills label and draws no root row', () => {
+    renderTree('/skills-and-tools');
+    expect(screen.getByText('Skills')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Skills' })).not.toBeInTheDocument();
+    // The scopes are the top level, collapsed until opened.
+    expect(row('Engineering')).toBeInTheDocument();
+    expect(row('Sales')).toBeInTheDocument();
+    expect(screen.queryByText('deploy')).not.toBeInTheDocument();
+    expect(screen.queryByText('discovery-call')).not.toBeInTheDocument();
+  });
+
+  it('reveals and marks the file the URL names — the Library never sets an open tab', () => {
+    renderTree(`/workspace/${DEFAULT_BRANCH}/${KB}/Skills/Sales/discovery-call/checklist.md`, {
+      openFilePath: null,
+    });
+    expect(row('checklist.md')).toHaveAttribute('aria-current', 'true');
+    expect(row('SKILL.md')).toHaveAttribute('aria-current', 'false');
+    // The other scope stays shut: only the named file's folders open.
+    expect(screen.queryByText('deploy')).not.toBeInTheDocument();
+  });
+
+  it('opens a clicked file on its skill page, on the default branch, whatever is checked out', () => {
+    renderTree('/skills-and-tools');
+    fireEvent.click(row('Sales'));
+    fireEvent.click(row('discovery-call'));
+    fireEvent.click(row('SKILL.md'));
+    expect(screen.getByLabelText('pathname')).toHaveTextContent(
+      `/workspace/${DEFAULT_BRANCH}/${KB}/Skills/Sales/discovery-call/SKILL.md`,
+    );
+  });
+
+  it('renders nothing when the tree has no Skills root — no heading over nothing', () => {
+    const noSkills = dir('.', [dir(KB, [dir(`${KB}/KnowledgeBase`, [])])]);
+    renderTree('/skills-and-tools', { fileTree: noSkills });
+    expect(screen.queryByText('Skills')).not.toBeInTheDocument();
+  });
+
+  it("the label's New folder button creates a scope directly under the root", () => {
+    const createDirectory = vi.fn().mockResolvedValue(undefined);
+    renderTree('/skills-and-tools', { createDirectory });
+    fireEvent.click(screen.getByRole('button', { name: 'New folder in Skills' }));
+    const input = screen.getByPlaceholderText('folder name');
+    fireEvent.change(input, { target: { value: 'Marketing' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(createDirectory).toHaveBeenCalledWith(`${KB}/Skills/Marketing`);
+  });
+});

--- a/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { DEFAULT_BRANCH, type FileTreeEntry } from '@bevel-software/platform-shared';
 import { WorkspaceContext, type WorkspaceContextValue } from '../../workspace/state/workspace.context';
@@ -98,7 +98,45 @@ describe('SkillsTree', () => {
     expect(screen.queryByText('Skills')).not.toBeInTheDocument();
   });
 
-  it("the label's New folder button creates a scope directly under the root", () => {
+  it('takes a drop on its heading — the heading is the root row, so it uploads into Skills/', () => {
+    const dispatchUpload = vi.fn().mockResolvedValue(undefined);
+    renderTree('/skills-and-tools', { dispatchUpload });
+    const dropped = new File(['x'], 'notes.md');
+    fireEvent.drop(screen.getByText('Skills'), {
+      dataTransfer: { getData: () => '', items: undefined, files: [dropped] },
+    });
+    expect(dispatchUpload).toHaveBeenCalledWith({ kind: 'files', files: [dropped] }, `${KB}/Skills`);
+  });
+
+  it("opens the folder's menu on the heading, minus what a reserved root must not do", () => {
+    renderTree('/skills-and-tools');
+    fireEvent.contextMenu(screen.getByText('Skills'));
+    const menu = screen.getByRole('menu', { name: 'Actions for Skills' });
+    expect(within(menu).getByRole('menuitem', { name: /New folder/ })).toBeInTheDocument();
+    expect(within(menu).getByRole('menuitem', { name: /Manage access/ })).toBeInTheDocument();
+    expect(within(menu).queryByRole('menuitem', { name: /Rename/ })).not.toBeInTheDocument();
+    expect(within(menu).queryByRole('menuitem', { name: /Delete/ })).not.toBeInTheDocument();
+    expect(within(menu).queryByRole('menuitem', { name: /Pin/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps a right-click anywhere in the section from reaching the nav behind it', () => {
+    const onNav = vi.fn();
+    const workspace = makeWorkspaceFixture({ fileTree: TREE, kbDirName: KB });
+    render(
+      <MemoryRouter initialEntries={['/skills-and-tools']}>
+        <WorkspaceContext.Provider value={workspace}>
+          <div onContextMenu={onNav}>
+            <SkillsTree />
+          </div>
+        </WorkspaceContext.Provider>
+      </MemoryRouter>,
+    );
+    fireEvent.contextMenu(screen.getByText('Skills'));
+    fireEvent.contextMenu(screen.getByTestId('skills-tree'));
+    expect(onNav).not.toHaveBeenCalled();
+  });
+
+  it("the heading's New folder button creates a scope directly under the root", () => {
     const createDirectory = vi.fn().mockResolvedValue(undefined);
     renderTree('/skills-and-tools', { createDirectory });
     fireEvent.click(screen.getByRole('button', { name: 'New folder in Skills' }));

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -92,7 +92,13 @@ function wrap(children: ReactNode) {
 
 function LocationProbe() {
   const location = useLocation();
-  return <div aria-label="pathname">{location.pathname}</div>;
+  const rawFile = (location.state as { rawFile?: boolean } | null)?.rawFile === true;
+  return (
+    <>
+      <div aria-label="pathname">{location.pathname}</div>
+      <div aria-label="raw-file">{String(rawFile)}</div>
+    </>
+  );
 }
 
 function renderAt(url: string) {
@@ -474,6 +480,66 @@ describe('WorkspaceItemRoute', () => {
     expect(await screen.findByLabelText('skill-page')).toHaveTextContent(
       'create-sales-deck::notes.md',
     );
+  });
+
+  /**
+   * The shared-skills root: skills and the scope folders that own them, no
+   * plugin around them. The same evidence rules as under `Plugins/`, with
+   * the two plugin destinations replaced — a scope has no page, and a file
+   * filed directly in a scope opens as the plain file it is.
+   */
+  describe('a skill under the shared Skills/ root', () => {
+    const SHARED: LibraryData = {
+      ...CATALOG,
+      skills: [
+        ...CATALOG.skills,
+        { name: 'discovery-call', description: '', path: 'Skills/Sales/discovery-call' },
+      ],
+    };
+
+    beforeEach(() => {
+      dataMock.useLibraryData.mockReturnValue(SHARED);
+    });
+
+    it("renders a shared skill file on that file's tab, inside the library nav", async () => {
+      renderAt(itemUrl('Skills/Sales/discovery-call/checklist.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent('discovery-call::checklist.md');
+      expect(screen.getByRole('button', { name: /^All plugins/ })).toBeInTheDocument();
+    });
+
+    it('opens a bare shared skill folder on SKILL.md', async () => {
+      renderAt(itemUrl('Skills/Sales/discovery-call'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent('discovery-call::SKILL.md');
+    });
+
+    it('resolves a just-created shared skill from its SKILL.md alone', async () => {
+      dataMock.useLibraryData.mockReturnValue({ ...CATALOG, loading: true, skills: [], tools: [] });
+      renderAt(itemUrl('Skills/Sales/brand-new/SKILL.md'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent('brand-new::SKILL.md');
+    });
+
+    it('sends a SCOPE folder home — the sidebar tree is where scopes are browsed', async () => {
+      renderAt(itemUrl('Skills/Sales'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent(/^\/skills-and-tools$/),
+      );
+    });
+
+    it("opens a scope's own file as a plain file, in the pane workspace", async () => {
+      renderAt(itemUrl('Skills/Sales/access.md'));
+      await waitFor(() => expect(screen.getByLabelText('raw-file')).toHaveTextContent('true'));
+      // Same URL — the raw view is router state, never a different address.
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Skills/Sales/access.md'));
+      expect(screen.queryByLabelText('skill-page')).not.toBeInTheDocument();
+    });
+
+    it('waits for the catalog rather than guessing a scope is a skill', async () => {
+      dataMock.useLibraryData.mockReturnValue({ ...CATALOG, loading: true, skills: [], tools: [] });
+      renderAt(itemUrl('Skills/Sales'));
+      await waitFor(() => expect(screen.getByRole('button', { name: /^All plugins/ })).toBeInTheDocument());
+      expect(screen.queryByLabelText('skill-page')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Skills/Sales'));
+    });
   });
 
   it('a non-default branch never renders an item page', async () => {

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -96,6 +96,7 @@ function LocationProbe() {
   return (
     <>
       <div aria-label="pathname">{location.pathname}</div>
+      <div aria-label="hash">{location.hash}</div>
       <div aria-label="raw-file">{String(rawFile)}</div>
     </>
   );
@@ -531,6 +532,12 @@ describe('WorkspaceItemRoute', () => {
       // Same URL — the raw view is router state, never a different address.
       expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Skills/Sales/access.md'));
       expect(screen.queryByLabelText('skill-page')).not.toBeInTheDocument();
+    });
+
+    it("carries a scope file's #fragment into the raw view — a heading deep link still lands", async () => {
+      renderAt(`${itemUrl('Skills/Sales/README.md')}#goal`);
+      await waitFor(() => expect(screen.getByLabelText('raw-file')).toHaveTextContent('true'));
+      expect(screen.getByLabelText('hash')).toHaveTextContent('#goal');
     });
 
     it('waits for the catalog rather than guessing a scope is a skill', async () => {

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -22,6 +22,7 @@ import { useWorkspace } from '../../workspace/state/workspace.context';
 import { ManageAccessDialog } from '../../access/components/ManageAccessDialog';
 import { ConnectAgentPill } from '../../onboarding/components/ConnectAgentPill';
 import { PluginsSidebar, type SidebarContextTarget } from './PluginsSidebar';
+import { SkillsTree } from './SkillsTree';
 import { PluginsSidebarMenu } from './PluginsSidebarMenu';
 import { AddToPluginDialog } from './AddToPluginDialog';
 import { DeletePluginDialog } from './DeletePluginDialog';
@@ -96,8 +97,8 @@ export function LibraryLayout() {
    * The member rows: every plugin the caller can READ (or manages), whether or
    * not anything is in it yet. Counts come from the catalog, membership does
    * not — a freshly created plugin has no skills or tools, and deriving the
-   * rows from the items alone made it vanish from the very nav that says
-   * "Included in your MCP". Being in a plugin is what puts it in your MCP;
+   * rows from the items alone made it vanish from the very nav that lists
+   * the caller's plugins. Being in a plugin is what puts it in your MCP;
    * having content is not. The catalog still contributes names the summaries
    * miss (a per-file grant can surface one skill from an otherwise unreadable
    * folder), so the two witnesses are merged rather than either winning.
@@ -232,6 +233,7 @@ export function LibraryLayout() {
           pluginsIndexActive={isPluginsIndexPath(location.pathname)}
           onOpenPluginsIndex={() => navigate(pathForPluginsIndex())}
           onContextMenu={openContextMenu}
+          skillsTree={<SkillsTree />}
         />
       </SidebarFrame>
 

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -211,7 +211,7 @@ export function LibraryLayout() {
           place — a person who skipped the welcome page and stayed in
           Knowledge still sees it. It renders nothing once onboarding is
           done. */}
-      <SidebarFrame label="Library plugins" header={<ConnectAgentPill />}>
+      <SidebarFrame label="Library navigation" header={<ConnectAgentPill />}>
         <PluginsSidebar
           filter={filter}
           onSelect={(next) => navigate(pathForLibraryFilter(next))}

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -87,6 +87,15 @@ export interface PluginsSidebarProps {
    * appears — which is the honest default for a view with no actions wired.
    */
   onContextMenu?(target: SidebarContextTarget): void;
+  /**
+   * The Skills section — a file tree of the shared `Skills/` root — rendered
+   * between the lenses and the plugins. A SLOT rather than a component this
+   * nav names: the tree reads the workspace and navigates on its own, and the
+   * sidebar stays what it is, a pure view of names and counts. Omitted, the
+   * nav has no Skills section, which keeps a host rendering the shipped nav
+   * source-compatible.
+   */
+  skillsTree?: ReactNode;
 }
 
 /**
@@ -123,6 +132,7 @@ export function PluginsSidebar({
   pluginsIndexActive,
   onOpenPluginsIndex,
   onContextMenu,
+  skillsTree,
 }: PluginsSidebarProps) {
   const rowClass = (selected: boolean) =>
     cn(
@@ -272,6 +282,9 @@ export function PluginsSidebar({
             ownedAttention > 0 ? ownedAttention : ownedCount,
             ownedAttention > 0 ? 'pending' : 'count',
           )}
+          {/* Skills first, plugins after: a skill is the thing, a plugin is
+              a bundle of them. The tree brings its own label. */}
+          {skillsTree}
           <PluginsLabel onCreate={onCreatePlugin} />
 
           {/* Your own space leads the plugins, as in the prototype (line 2487):
@@ -337,52 +350,73 @@ export function PluginsSidebar({
 }
 
 /**
- * The `INCLUDED IN YOUR MCP` heading, and the one way to make a new plugin —
- * the prototype's `.lbladd` (line 78).
+ * A nav section's name, with an optional row of actions at its right edge.
+ * The first one has no top padding — the sidebar's own `pt-6` already placed
+ * it — so every label is the same component with its spacing decided by where
+ * it sits, not by which one it is.
  *
- * The heading says what this list IS rather than what its rows are called:
- * these folders are the set mounted into the caller's MCP — the agent's
- * working context — not merely a directory of plugins. (The locked rows that
- * trail the list sit below a gap for exactly that reason: they are in the
- * workspace but not in your MCP, and the break is what keeps the heading
- * honest about them.)
- *
- * `All plugins` is NOT a row here. It heads the whole nav instead: it is the
- * Library's home rather than one more entry in the set mounted into your MCP,
- * and inside this list it used to collect the clicks meant for the plugins
- * under it.
- *
- * The `+` is always in the DOM and always reachable by keyboard; only its
- * opacity follows hover, so the nav stays quiet without the control being
- * conditional. `focus-visible:opacity-100` is what keeps that honest for
+ * The actions are always in the DOM and always reachable by keyboard; only
+ * their opacity follows hover, so the nav stays quiet without the controls
+ * being conditional. `focus-within:opacity-100` is what keeps that honest for
  * anyone who never hovers anything.
+ *
+ * Exported for the Skills tree, whose heading is this label with the tree's
+ * own create buttons in the slot — one heading style over every list of
+ * places in this nav.
  */
-/**
- * A nav section's name. The first one has no top padding — the sidebar's own
- * `pt-6` already placed it — so the two labels are the same component with
- * their spacing decided by where they sit, not by which one they are.
- */
-function SectionLabel({ children, spaced = false }: { children: ReactNode; spaced?: boolean }) {
+export function SectionLabel({
+  children,
+  spaced = false,
+  actions,
+}: {
+  children: ReactNode;
+  spaced?: boolean;
+  actions?: ReactNode;
+}) {
   return (
-    <div className={cn('px-2.5 pb-1.5 text-label uppercase text-ink-faint', spaced && 'pt-5')}>
-      {children}
+    <div className={cn('group/label flex items-center gap-1 px-2.5 pb-1.5', spaced && 'pt-5')}>
+      <span className="text-label uppercase text-ink-faint">{children}</span>
+      {actions && (
+        <span className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/label:opacity-100">
+          {actions}
+        </span>
+      )}
     </div>
   );
 }
 
+/**
+ * The `PLUGINS` heading, and the one way to make a new plugin — the
+ * prototype's `.lbladd` (line 78).
+ *
+ * It used to read "Included in your MCP", from when a plugin was the only
+ * way a skill reached an agent. Skills have a root of their own now, listed
+ * as a tree above this section, so the heading says what these rows ARE:
+ * plugins — the bundles the caller is in. (The locked rows that trail the
+ * list sit below a gap for the same reason: they are in the workspace but
+ * not the caller's, and the break is what keeps the heading honest.)
+ *
+ * `All plugins` is NOT a row here. It heads the whole nav instead: it is the
+ * Library's home rather than one more entry in the caller's set, and inside
+ * this list it used to collect the clicks meant for the plugins under it.
+ */
 function PluginsLabel({ onCreate }: { onCreate(): void }) {
   return (
-    <div className="group/label flex items-center gap-1 px-2.5 pb-1.5 pt-5">
-      <span className="text-label uppercase text-ink-faint">Included in your MCP</span>
-      <button
-        type="button"
-        onClick={onCreate}
-        title="New plugin"
-        aria-label="New plugin"
-        className="ml-auto flex size-4.5 items-center justify-center rounded-xs text-ui leading-none text-ink-faint opacity-0 transition-opacity hover:bg-hover hover:text-ink focus-visible:opacity-100 group-hover/label:opacity-100"
-      >
-        +
-      </button>
-    </div>
+    <SectionLabel
+      spaced
+      actions={
+        <button
+          type="button"
+          onClick={onCreate}
+          title="New plugin"
+          aria-label="New plugin"
+          className="flex size-4.5 items-center justify-center rounded-xs text-ui leading-none text-ink-faint hover:bg-hover hover:text-ink"
+        >
+          +
+        </button>
+      }
+    >
+      Plugins
+    </SectionLabel>
   );
 }

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -235,7 +235,7 @@ export function PluginsSidebar({
   return (
     <>
         <nav
-          aria-label="Library plugins"
+          aria-label="Library navigation"
           className="flex min-h-0 flex-1 flex-col gap-px overflow-y-auto"
           // The nav's empty space is a target too — Knowledge's tree gives its
           // ROOT row a menu holding the create verbs, and this is where the

--- a/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
+++ b/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
@@ -1,0 +1,132 @@
+import { useMemo, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { FilePlus, FolderPlus } from 'lucide-react';
+import { DEFAULT_BRANCH, SKILLS_DIR } from '@bevel-software/platform-shared';
+import { IconButton } from '../../../shared/components';
+import { useWorkspace } from '../../workspace/state/workspace.context';
+import { findKbRoot } from '../../workspace/utils/fileTree';
+import { KB_ROUTE_PREFIX, kbFileUrl } from '../../workspace/routing/kb-routes';
+import { useMergedWorkspaceTree } from '../../workspace/hooks/useMergedWorkspaceTree';
+import {
+  FileTreeNode,
+  TreeChrome,
+  UploadNotices,
+  type FileTreeNodeControls,
+  type TreeNav,
+} from '../../workspace/components/FileExplorer';
+import { SectionLabel } from './PluginsSidebar';
+
+/**
+ * The Skills section of the Library's nav: the shared `Skills/` root as a
+ * file tree, made of the SAME rows as Knowledge's explorer — right-click menu
+ * (new file, new folder, rename, delete, manage access, download), drag to
+ * move, drop to upload, the caller's proposed files shown in accent. One tree
+ * component in the app, holding a different root.
+ *
+ * Two things differ from Knowledge, and both are the surroundings' (see
+ * `TreeChrome`), not the rows':
+ *
+ *  - A click opens the file on its SKILL PAGE, here in Skills & Tools — at
+ *    the item's canonical default-branch URL, whatever branch is checked
+ *    out. The Library speaks the default branch everywhere; this is no
+ *    exception.
+ *  - The current row is the file the URL names, not the pane workspace's
+ *    open tab, which the Library never sets.
+ *
+ * The root's own row is not drawn: the section label is its heading, and the
+ * scopes sit directly under it, at the nav's own indent. The label carries
+ * the create buttons that row would have had.
+ *
+ * Renders nothing while the tree is loading or when the caller can read no
+ * part of the root — an empty "SKILLS" heading over nothing would be a
+ * question, not a section.
+ */
+export function SkillsTree() {
+  const { kbDirName } = useWorkspace();
+  const { tree, suggestionOnlyPaths } = useMergedWorkspaceTree();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const root = useMemo(() => {
+    const kids = findKbRoot(tree)?.children;
+    return kids?.find((c) => c.type === 'directory' && c.name === SKILLS_DIR) ?? null;
+  }, [tree]);
+
+  const nav = useMemo<TreeNav>(
+    () => ({
+      activePath: activeWorkspacePath(location.pathname, kbDirName),
+      open: (path) => navigate(kbFileUrl(DEFAULT_BRANCH, path)),
+    }),
+    [location.pathname, kbDirName, navigate],
+  );
+
+  // The root's row is not drawn, so its create verbs live on the label and
+  // reach the node through its handle.
+  const controls = useRef<FileTreeNodeControls>(null);
+
+  if (!root) return null;
+
+  return (
+    <TreeChrome nav={nav} suggestionOnlyPaths={suggestionOnlyPaths}>
+      <SectionLabel
+        spaced
+        actions={
+          <>
+            <IconButton
+              size={18}
+              title="New file"
+              aria-label={`New file in ${SKILLS_DIR}`}
+              onClick={() => controls.current?.create('file')}
+            >
+              <FilePlus size={13} />
+            </IconButton>
+            <IconButton
+              size={18}
+              title="New folder"
+              aria-label={`New folder in ${SKILLS_DIR}`}
+              onClick={() => controls.current?.create('directory')}
+            >
+              <FolderPlus size={13} />
+            </IconButton>
+          </>
+        }
+      >
+        Skills
+      </SectionLabel>
+      <UploadNotices />
+      <div data-testid="skills-tree">
+        <FileTreeNode
+          entry={root}
+          depth={0}
+          hideRow
+          collapseChildren
+          controls={controls}
+        />
+      </div>
+    </TreeChrome>
+  );
+}
+
+/**
+ * The workspace-relative path a Library URL names, or null. Library item
+ * pages live at `/workspace/<default>/<kbDir>/...` — the inverse of
+ * `kbFileUrl`, segment by segment. Any other URL (the index, a lens, a
+ * plugin page) names no file, so no row is current.
+ */
+function activeWorkspacePath(pathname: string, kbDirName: string | null): string | null {
+  const prefix = `${KB_ROUTE_PREFIX}/`;
+  if (!pathname.startsWith(prefix)) return null;
+  const [branch, ...rest] = pathname.slice(prefix.length).split('/').map(safeDecode);
+  if (branch !== DEFAULT_BRANCH || rest.length < 2) return null;
+  if (kbDirName !== null && rest[0] !== kbDirName) return null;
+  return rest.join('/');
+}
+
+/** A malformed escape is a bad link, not a crash — fall back to the raw segment. */
+function safeDecode(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
+++ b/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
@@ -1,20 +1,16 @@
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { FilePlus, FolderPlus } from 'lucide-react';
 import { DEFAULT_BRANCH, SKILLS_DIR } from '@bevel-software/platform-shared';
-import { IconButton } from '../../../shared/components';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 import { findKbRoot } from '../../workspace/utils/fileTree';
-import { KB_ROUTE_PREFIX, kbFileUrl } from '../../workspace/routing/kb-routes';
+import { KB_ROUTE_PREFIX, kbFileUrl, safeDecode } from '../../workspace/routing/kb-routes';
 import { useMergedWorkspaceTree } from '../../workspace/hooks/useMergedWorkspaceTree';
 import {
   FileTreeNode,
   TreeChrome,
   UploadNotices,
-  type FileTreeNodeControls,
   type TreeNav,
 } from '../../workspace/components/FileExplorer';
-import { SectionLabel } from './PluginsSidebar';
 
 /**
  * The Skills section of the Library's nav: the shared `Skills/` root as a
@@ -22,6 +18,11 @@ import { SectionLabel } from './PluginsSidebar';
  * (new file, new folder, rename, delete, manage access, download), drag to
  * move, drop to upload, the caller's proposed files shown in accent. One tree
  * component in the app, holding a different root.
+ *
+ * The root's row is drawn as the section's HEADING (`FileTreeNode.heading`),
+ * so the heading is a real row: drop files on it to upload into `Skills/`,
+ * hover it for the create buttons and the pickers, right-click it for the
+ * folder's menu. Its scopes sit directly under it at the nav's own indent.
  *
  * Two things differ from Knowledge, and both are the surroundings' (see
  * `TreeChrome`), not the rows':
@@ -32,10 +33,6 @@ import { SectionLabel } from './PluginsSidebar';
  *    exception.
  *  - The current row is the file the URL names, not the pane workspace's
  *    open tab, which the Library never sets.
- *
- * The root's own row is not drawn: the section label is its heading, and the
- * scopes sit directly under it, at the nav's own indent. The label carries
- * the create buttons that row would have had.
  *
  * Renders nothing while the tree is loading or when the caller can read no
  * part of the root — an empty "SKILLS" heading over nothing would be a
@@ -60,48 +57,17 @@ export function SkillsTree() {
     [location.pathname, kbDirName, navigate],
   );
 
-  // The root's row is not drawn, so its create verbs live on the label and
-  // reach the node through its handle.
-  const controls = useRef<FileTreeNodeControls>(null);
-
   if (!root) return null;
 
   return (
     <TreeChrome nav={nav} suggestionOnlyPaths={suggestionOnlyPaths}>
-      <SectionLabel
-        spaced
-        actions={
-          <>
-            <IconButton
-              size={18}
-              title="New file"
-              aria-label={`New file in ${SKILLS_DIR}`}
-              onClick={() => controls.current?.create('file')}
-            >
-              <FilePlus size={13} />
-            </IconButton>
-            <IconButton
-              size={18}
-              title="New folder"
-              aria-label={`New folder in ${SKILLS_DIR}`}
-              onClick={() => controls.current?.create('directory')}
-            >
-              <FolderPlus size={13} />
-            </IconButton>
-          </>
-        }
-      >
-        Skills
-      </SectionLabel>
-      <UploadNotices />
-      <div data-testid="skills-tree">
-        <FileTreeNode
-          entry={root}
-          depth={0}
-          hideRow
-          collapseChildren
-          controls={controls}
-        />
+      {/* A right-click that lands between the tree's rows is the tree's, not
+          the plugin nav's behind it: with nothing wired for the gap the
+          browser's own menu is the honest answer, as in Knowledge. The rows
+          and the heading stop their own events before reaching here. */}
+      <div data-testid="skills-tree" onContextMenu={(e) => e.stopPropagation()}>
+        <UploadNotices />
+        <FileTreeNode entry={root} depth={0} heading="Skills" collapseChildren />
       </div>
     </TreeChrome>
   );
@@ -120,13 +86,4 @@ function activeWorkspacePath(pathname: string, kbDirName: string | null): string
   if (branch !== DEFAULT_BRANCH || rest.length < 2) return null;
   if (kbDirName !== null && rest[0] !== kbDirName) return null;
   return rest.join('/');
-}
-
-/** A malformed escape is a bad link, not a crash — fall back to the raw segment. */
-function safeDecode(raw: string): string {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
 }

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -1,5 +1,5 @@
-import { Navigate, useParams, useSearchParams } from 'react-router-dom';
-import { DEFAULT_BRANCH, PLUGINS_DIR } from '@bevel-software/platform-shared';
+import { Navigate, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { DEFAULT_BRANCH, PLUGINS_DIR, SKILLS_DIR } from '@bevel-software/platform-shared';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 import { useLibrary } from '../state/library-data';
 import { SkillPage } from '../components/skill-page/SkillPage';
@@ -8,9 +8,10 @@ import { LIBRARY_ROOT, pathForPlugin } from './library-paths';
 
 /**
  * The library page behind a canonical workspace URL —
- * `/workspace/<default>/<kbDir>/Plugins/<plugin>/<...>` — rendered INSIDE the
- * same `LibraryLayout` route tree as every other library page, so the sidebar
- * is the one the reader already had and nothing remounts on the way in.
+ * `/workspace/<default>/<kbDir>/Plugins/<plugin>/<...>` or
+ * `/workspace/<default>/<kbDir>/Skills/<...>` — rendered INSIDE the same
+ * `LibraryLayout` route tree as every other library page, so the sidebar is
+ * the one the reader already had and nothing remounts on the way in.
  *
  * Resolution is STRUCTURAL, not a catalog lookup: under `Plugins/<plugin>/`, a
  * `*.tool` file is a tool page, the plugin's `mcp.json` is a tool page too
@@ -30,6 +31,7 @@ import { LIBRARY_ROOT, pathForPlugin } from './library-paths';
 export function WorkspaceItemRoute() {
   const params = useParams<{ branch: string; '*': string }>();
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const splat = params['*'] ?? '';
   const branch = safeDecode(params.branch ?? '');
   const { kbDirName } = useWorkspace();
@@ -38,19 +40,13 @@ export function WorkspaceItemRoute() {
   // Shape re-validation: the route pattern (`:branch/*`) is broader than the
   // shape the shell dispatches here, and a stray URL must not read as a page.
   const segments = splat.split('/').filter(Boolean).map(safeDecode);
-  if (branch !== DEFAULT_BRANCH || segments[1] !== PLUGINS_DIR || segments.length < 3) {
+  const kbRoot = segments[1];
+  if (branch !== DEFAULT_BRANCH || (kbRoot !== PLUGINS_DIR && kbRoot !== SKILLS_DIR) || segments.length < 3) {
     return <Navigate to={LIBRARY_ROOT} replace />;
   }
   if (kbDirName !== null && segments[0] !== kbDirName) {
     return <Navigate to={LIBRARY_ROOT} replace />;
   }
-
-  const [, , plugin, ...tail] = segments;
-  const last = tail[tail.length - 1];
-  if (!plugin || !last) {
-    return <Navigate to={LIBRARY_ROOT} replace />;
-  }
-  const repoRel = `${PLUGINS_DIR}/${plugin}/${tail.join('/')}`;
 
   /**
    * `key={name}` is load-bearing. A provisional name gets CORRECTED once the
@@ -62,6 +58,51 @@ export function WorkspaceItemRoute() {
   const skillPage = (name: string, activeFile: string, provisional: boolean) => (
     <SkillPage key={name} name={name} activeFile={activeFile} provisional={provisional} />
   );
+
+  // The shared-skills root holds skills and the scope folders that own them,
+  // nothing else with a page: no plugin, no tools. The same evidence rules as
+  // below, with the two plugin destinations replaced — a SCOPE folder has no
+  // page of its own (the sidebar's tree is where it is browsed), and a file
+  // filed directly in a scope (its access.md, a stray note) opens as the plain
+  // file it is, in the pane workspace.
+  if (kbRoot === SKILLS_DIR) {
+    const rest = segments.slice(2);
+    const last = rest[rest.length - 1]!;
+    const repoRel = `${SKILLS_DIR}/${rest.join('/')}`;
+    const owner = deepestSkillOwning(data.items, repoRel);
+    if (owner) {
+      const file = repoRel.slice(owner.path.length + 1);
+      return skillPage(owner.id, file || 'SKILL.md', false);
+    }
+    if (last === 'SKILL.md' && rest.length >= 2) {
+      return skillPage(rest[rest.length - 2]!, 'SKILL.md', true);
+    }
+    if (!hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
+      return <Navigate to={LIBRARY_ROOT} replace />;
+    }
+    const parentRel = repoRel.slice(0, repoRel.length - last.length - 1);
+    if (hasExtension(last) && (rest.length === 1 || containsCatalogSkill(data.items, parentRel))) {
+      // Router STATE, not a different URL: the shell reads `rawFile` to step
+      // past the shape rule into the pane workspace, and a shared link can
+      // never carry state — so nobody lands on the raw view by accident.
+      // Once asked, hold still: the shell is swapping surfaces on that state,
+      // and asking again from here would be a navigation loop.
+      const rawRequested = (location.state as { rawFile?: boolean } | null)?.rawFile === true;
+      if (rawRequested) return null;
+      return <Navigate to={`${location.pathname}${location.search}`} state={{ rawFile: true }} replace />;
+    }
+    if (data.loading) return null;
+    return hasExtension(last)
+      ? skillPage(rest[rest.length - 2]!, last, true)
+      : skillPage(last, 'SKILL.md', true);
+  }
+
+  const [, , plugin, ...tail] = segments;
+  const last = tail[tail.length - 1];
+  if (!plugin || !last) {
+    return <Navigate to={LIBRARY_ROOT} replace />;
+  }
+  const repoRel = `${PLUGINS_DIR}/${plugin}/${tail.join('/')}`;
 
   // A `.tool` is a tool page wherever it sits. The backend finds manuals at
   // ANY depth below `Plugins/` (`walkFiles` over the whole tree), so a manual

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -1,6 +1,7 @@
 import { Navigate, useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { DEFAULT_BRANCH, PLUGINS_DIR, SKILLS_DIR } from '@bevel-software/platform-shared';
 import { useWorkspace } from '../../workspace/state/workspace.context';
+import { safeDecode } from '../../workspace/routing/kb-routes';
 import { useLibrary } from '../state/library-data';
 import { SkillPage } from '../components/skill-page/SkillPage';
 import { ToolPage } from '../components/tool-page/ToolPage';
@@ -16,13 +17,17 @@ import { LIBRARY_ROOT, pathForPlugin } from './library-paths';
  * Resolution is STRUCTURAL, not a catalog lookup: under `Plugins/<plugin>/`, a
  * `*.tool` file is a tool page, the plugin's `mcp.json` is a tool page too
  * (which of its servers is named by `?server=`, or by the catalog when the file
- * declares only one), any other direct FILE (an extension, no segments below
- * it — `access.md`) belongs to the plugin page, and everything else is a skill
- * FOLDER whose name is the skill's id — the same identity the old name-based
- * route used. That is what makes a skill created a moment ago
- * open instantly: its URL says everything the page needs, and `SkillPage`
- * fetches the skill by name itself. Waiting on the catalog here raced every
- * reload and lost (the just-created skill bounced to its plugin's page).
+ * declares only one), and everything else — under either root — is a skill
+ * FOLDER whose name is the skill's id, resolved by {@link resolveSkillPath}.
+ * That is what makes a skill created a moment ago open instantly: its URL
+ * says everything the page needs, and `SkillPage` fetches the skill by name
+ * itself. Waiting on the catalog here raced every reload and lost (the
+ * just-created skill bounced to its plugin's page).
+ *
+ * The two roots differ only in where a path that is NO skill goes: a
+ * container folder or a loose file belongs to its plugin page under
+ * `Plugins/`; under `Skills/` a scope folder has no page (home) and a loose
+ * file opens as the plain file it is.
  *
  * The catalog is consulted only to REFINE a tool's slug (a `.tool` may
  * declare an explicit id different from its filename); the filename is the
@@ -59,42 +64,36 @@ export function WorkspaceItemRoute() {
     <SkillPage key={name} name={name} activeFile={activeFile} provisional={provisional} />
   );
 
-  // The shared-skills root holds skills and the scope folders that own them,
-  // nothing else with a page: no plugin, no tools. The same evidence rules as
-  // below, with the two plugin destinations replaced — a SCOPE folder has no
-  // page of its own (the sidebar's tree is where it is browsed), and a file
-  // filed directly in a scope (its access.md, a stray note) opens as the plain
-  // file it is, in the pane workspace.
   if (kbRoot === SKILLS_DIR) {
     const rest = segments.slice(2);
-    const last = rest[rest.length - 1]!;
-    const repoRel = `${SKILLS_DIR}/${rest.join('/')}`;
-    const owner = deepestSkillOwning(data.items, repoRel);
-    if (owner) {
-      const file = repoRel.slice(owner.path.length + 1);
-      return skillPage(owner.id, file || 'SKILL.md', false);
+    const resolved = resolveSkillPath(data, `${SKILLS_DIR}/${rest.join('/')}`, rest, null);
+    switch (resolved.kind) {
+      case 'skill':
+        return skillPage(resolved.name, resolved.file, resolved.provisional);
+      case 'wait':
+        return null;
+      case 'container':
+        // A scope has no page of its own — the sidebar's tree is where it is browsed.
+        return <Navigate to={LIBRARY_ROOT} replace />;
+      case 'loose-file': {
+        // A file filed directly in a scope (its access.md, a stray note)
+        // opens as the plain file it is, in the pane workspace. Router STATE,
+        // not a different URL: the shell reads `rawFile` to step past the
+        // shape rule, and a shared link can never carry state — so nobody
+        // lands on the raw view by accident. Once asked, hold still: the
+        // shell is swapping surfaces on that state, and asking again from
+        // here would be a navigation loop.
+        const rawRequested = (location.state as { rawFile?: boolean } | null)?.rawFile === true;
+        if (rawRequested) return null;
+        return (
+          <Navigate
+            to={`${location.pathname}${location.search}${location.hash}`}
+            state={{ rawFile: true }}
+            replace
+          />
+        );
+      }
     }
-    if (last === 'SKILL.md' && rest.length >= 2) {
-      return skillPage(rest[rest.length - 2]!, 'SKILL.md', true);
-    }
-    if (!hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
-      return <Navigate to={LIBRARY_ROOT} replace />;
-    }
-    const parentRel = repoRel.slice(0, repoRel.length - last.length - 1);
-    if (hasExtension(last) && (rest.length === 1 || containsCatalogSkill(data.items, parentRel))) {
-      // Router STATE, not a different URL: the shell reads `rawFile` to step
-      // past the shape rule into the pane workspace, and a shared link can
-      // never carry state — so nobody lands on the raw view by accident.
-      // Once asked, hold still: the shell is swapping surfaces on that state,
-      // and asking again from here would be a navigation loop.
-      const rawRequested = (location.state as { rawFile?: boolean } | null)?.rawFile === true;
-      if (rawRequested) return null;
-      return <Navigate to={`${location.pathname}${location.search}`} state={{ rawFile: true }} replace />;
-    }
-    if (data.loading) return null;
-    return hasExtension(last)
-      ? skillPage(rest[rest.length - 2]!, last, true)
-      : skillPage(last, 'SKILL.md', true);
   }
 
   const [, , plugin, ...tail] = segments;
@@ -140,68 +139,98 @@ export function WorkspaceItemRoute() {
     return <Navigate to={pathForPlugin(plugin)} replace />;
   }
 
-  // THE CATALOG IS THE AUTHORITY on which folder is a skill and what its id
-  // is. Plugins may nest (`Plugins/Engineering/coding/create-ticket/SKILL.md`),
-  // and a skill's id is its frontmatter `id`/`name` — only FALLING BACK to the
-  // folder name — so neither the depth nor the id can be read off the URL with
-  // certainty. Take the DEEPEST skill whose folder contains this path: a
-  // category folder is never itself a skill, so the deepest match is the owner,
-  // and a `SKILL.md` bundled inside a skill (`<skill>/examples/SKILL.md`)
-  // stays that skill's file instead of inventing a skill called `examples`.
+  // `Plugins/<plugin>/SKILL.md` makes the plugin folder itself the skill,
+  // which is what the backend's walk would report for it.
+  const resolved = resolveSkillPath(data, repoRel, tail, plugin);
+  switch (resolved.kind) {
+    case 'skill':
+      return skillPage(resolved.name, resolved.file, resolved.provisional);
+    case 'wait':
+      return null;
+    case 'container':
+    case 'loose-file':
+      // A category has no page of its own; its plugin does. A file that can
+      // be no skill's — `access.md` at either level, a stray upload — is the
+      // plugin's business too.
+      return <Navigate to={pathForPlugin(plugin)} replace />;
+  }
+}
+
+type SkillPathResolution =
+  | { kind: 'skill'; name: string; file: string; provisional: boolean }
+  /** A folder with catalog skills BELOW it — a category or a scope, never a skill itself. */
+  | { kind: 'container' }
+  /** A file that can be no skill's: directly in the root folder, or in a known container. */
+  | { kind: 'loose-file' }
+  /** Nothing positive settled it and the catalog is still loading. */
+  | { kind: 'wait' };
+
+/**
+ * What a path under a root names, by the ONE set of evidence rules both roots
+ * share. `tail` is the path below the root's own folder (the plugin, or
+ * `Skills/` itself); `selfName` is that folder's name when it can be a skill
+ * (a plugin holding a bare `SKILL.md`), null when it cannot (`Skills/`).
+ *
+ * THE CATALOG IS THE AUTHORITY on which folder is a skill and what its id
+ * is. Folders may nest (`Plugins/Engineering/coding/create-ticket/SKILL.md`),
+ * and a skill's id is its frontmatter `id`/`name` — only FALLING BACK to the
+ * folder name — so neither the depth nor the id can be read off the URL with
+ * certainty. Take the DEEPEST skill whose folder contains this path: a
+ * category folder is never itself a skill, so the deepest match is the owner,
+ * and a `SKILL.md` bundled inside a skill (`<skill>/examples/SKILL.md`)
+ * stays that skill's file instead of inventing a skill called `examples`.
+ *
+ * Not in the catalog: a `SKILL.md` still names its own skill structurally —
+ * the folder holding it — and that is deliberately catalog-FREE, so a skill
+ * created a moment ago opens from its URL alone, before any reload lands.
+ *
+ * Everything below that is decided on POSITIVE evidence only. What the
+ * catalog KNOWS is trustworthy whenever it is there — cached entries survive
+ * a failed refresh — but what it does NOT know proves nothing: it may be
+ * loading, stale (a skill created seconds ago), or have failed outright.
+ * Reading absence as "this is not a page" is what bounced valid deep links
+ * to the plugin, so this never draws that inference. A folder with catalog
+ * skills UNDER it is a container, not a skill — the discriminator between a
+ * category and a just-created skill whose reload hasn't landed: the former
+ * has known descendants, the latter has none. A FILE is loose when it cannot
+ * be a skill's: it sits directly in the root folder (structurally never
+ * inside a skill), or its own folder is a known container. A file under an
+ * UNKNOWN folder is left alone — that folder is most likely a skill the
+ * catalog hasn't caught up with. When nothing positive settled it and the
+ * catalog is still loading, WAIT: the evidence may be one render away, and
+ * guessing flashes a page for a name that is about to change. Only then is
+ * the URL read structurally — a file belongs to the folder holding it, a
+ * bare folder names itself — and provisionally, so `SkillPage` must not turn
+ * a failed lookup into "doesn't exist" until the catalog has answered.
+ */
+function resolveSkillPath(
+  data: { items: readonly { kind: string; id: string; path: string }[]; loading: boolean },
+  repoRel: string,
+  tail: readonly string[],
+  selfName: string | null,
+): SkillPathResolution {
+  const last = tail[tail.length - 1]!;
   const owner = deepestSkillOwning(data.items, repoRel);
   if (owner) {
     const file = repoRel.slice(owner.path.length + 1);
-    return skillPage(owner.id, file || 'SKILL.md', false);
+    return { kind: 'skill', name: owner.id, file: file || 'SKILL.md', provisional: false };
   }
-
-  // Not in the catalog. A `SKILL.md` still names its own skill structurally —
-  // the folder holding it — and that is deliberately catalog-FREE: a skill
-  // created a moment ago opens from its URL alone, before any reload lands.
-  // (`Plugins/<plugin>/SKILL.md` makes the plugin folder itself the skill, which
-  // is what the backend's walk would report for it.)
-  if (last === 'SKILL.md') {
-    return skillPage(tail.length >= 2 ? tail[tail.length - 2]! : plugin, 'SKILL.md', true);
+  const parentName = tail.length >= 2 ? tail[tail.length - 2]! : selfName;
+  if (last === 'SKILL.md' && parentName !== null) {
+    return { kind: 'skill', name: parentName, file: 'SKILL.md', provisional: true };
   }
-
-  // Everything below is decided on POSITIVE evidence only. What the catalog
-  // KNOWS is trustworthy whenever it is there — cached entries survive a
-  // failed refresh — but what it does NOT know proves nothing: it may be
-  // loading, stale (a skill created seconds ago), or have failed outright.
-  // Reading absence as "this is not a page" is what bounced valid deep links
-  // to the plugin, so this no longer draws that inference at all.
-
-  // A folder with catalog skills UNDER it is a category, not a skill. That is
-  // the discriminator between a category folder and a just-created skill whose
-  // reload hasn't landed: the former has known descendants, the latter has
-  // none. A category has no page of its own; its plugin does.
-  if (!hasExtension(last) && containsCatalogSkill(data.items, repoRel)) {
-    return <Navigate to={pathForPlugin(plugin)} replace />;
-  }
-
-  // A FILE is the plugin's business when it cannot be a skill's file: either it
-  // sits directly in the plugin folder (structurally never inside a skill), or
-  // its own folder is a known category. `access.md` at either level, a stray
-  // upload. A file under an UNKNOWN folder is left alone — that folder is most
-  // likely a skill the catalog hasn't caught up with.
+  if (!hasExtension(last) && containsCatalogSkill(data.items, repoRel)) return { kind: 'container' };
   const parentRel = repoRel.slice(0, repoRel.length - last.length - 1);
   if (hasExtension(last) && (tail.length === 1 || containsCatalogSkill(data.items, parentRel))) {
-    return <Navigate to={pathForPlugin(plugin)} replace />;
+    return { kind: 'loose-file' };
   }
-
-  // Nothing positive settled it. While the catalog is still loading, WAIT: the
-  // evidence above may be one render away, and guessing flashes a page for a
-  // name that is about to change. The layout and its sidebar are already on
-  // screen around this.
-  if (data.loading) return null;
-
-  // Read the URL structurally — a file belongs to the folder holding it, a
-  // bare folder names itself, the same rule the backend applies when no
-  // frontmatter declares an id. Provisional: the catalog never confirmed it,
-  // so SkillPage must not turn a failed lookup into "doesn't exist" until the
-  // catalog has actually answered.
-  return hasExtension(last)
-    ? skillPage(tail.length >= 2 ? tail[tail.length - 2]! : plugin, last, true)
-    : skillPage(last, 'SKILL.md', true);
+  if (data.loading) return { kind: 'wait' };
+  if (hasExtension(last)) {
+    return parentName === null
+      ? { kind: 'loose-file' }
+      : { kind: 'skill', name: parentName, file: last, provisional: true };
+  }
+  return { kind: 'skill', name: last, file: 'SKILL.md', provisional: true };
 }
 
 /** Whether a path segment names a file rather than a folder. */
@@ -242,13 +271,4 @@ function deepestSkillOwning(
     if (!best || item.path.length > best.path.length) best = { id: item.id, path: item.path };
   }
   return best;
-}
-
-/** A malformed escape is a bad link, not a crash — fall back to the raw segment. */
-function safeDecode(raw: string): string {
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
 }

--- a/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
@@ -1,4 +1,15 @@
-import { useState, useCallback, useEffect, useMemo, useRef, createContext, useContext } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  createContext,
+  useContext,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import {
   ChevronRight,
   FilePlus,
@@ -26,8 +37,9 @@ import {
   AGENTS_DIR,
   PIPELINES_DIR,
 } from '@bevel-software/platform-shared';
-import { useWorkspace, type PendingEntry } from '../state/workspace.context';
-import { mergePendingIntoTree, pathExistsInTree, findKbRoot, KB_ROOT_DIRS } from '../utils/fileTree';
+import { useWorkspace } from '../state/workspace.context';
+import { findKbRoot, KB_ROOT_DIRS } from '../utils/fileTree';
+import { useMergedWorkspaceTree } from '../hooks/useMergedWorkspaceTree';
 import { ChangeRequestDialog } from '../../change-requests/components/ChangeRequestDialog';
 import { PR_STALE_EVENT } from '../../../core/events';
 import { snapshotEntries } from '../utils/readDroppedEntries';
@@ -95,16 +107,24 @@ function readPinnedPaths(): string[] {
 }
 
 interface PinnedController {
+  /**
+   * Whether this tree offers pinning at all. Only the Knowledge explorer has
+   * a Company Context section to pin INTO; a tree without one hides the item
+   * rather than offering a verb that lands nowhere.
+   */
+  available: boolean;
   isPinned: (path: string) => boolean;
   togglePin: (path: string) => void;
 }
 
 // Default no-op so a ContextMenu rendered outside the provider (e.g. in a unit
 // test) never throws — the real controller is supplied by FileExplorer.
-const PinnedContext = createContext<PinnedController>({
+const NO_PINNING: PinnedController = {
+  available: false,
   isPinned: () => false,
   togglePin: () => {},
-});
+};
+const PinnedContext = createContext<PinnedController>(NO_PINNING);
 const usePinned = () => useContext(PinnedContext);
 
 // Lets the deep right-click menu open the Manage access sheet without prop
@@ -135,6 +155,28 @@ const SuggestionsContext = createContext<SuggestionsController>({
   open: () => {},
 });
 const useSuggestions = () => useContext(SuggestionsContext);
+
+/**
+ * Which row is current, and where a row's click goes.
+ *
+ * Context, for the same reason as the three above — and because the SAME rows
+ * serve two navs. The Knowledge explorer opens a file in the pane workspace
+ * on the checked-out branch; the Library's Skills tree opens a skill on its
+ * own page, on the default branch, whatever is checked out. The rows know
+ * neither: they report the path they hold and read which one is active.
+ */
+export interface TreeNav {
+  /** The workspace-relative path the surface is showing — lights its row, reveals its folders. */
+  activePath: string | null;
+  open(path: string): void;
+}
+const TreeNavContext = createContext<TreeNav>({ activePath: null, open: () => {} });
+const useTreeNav = () => useContext(TreeNavContext);
+
+/** What a headless root's stand-in heading can ask of it — see `FileTreeNode.controls`. */
+export interface FileTreeNodeControls {
+  create(kind: 'file' | 'directory'): void;
+}
 
 /** Depth-first lookup of a tree entry by its exact relativePath. */
 function findEntryByPath(node: FileTreeEntry, path: string): FileTreeEntry | null {
@@ -174,7 +216,7 @@ function ContextMenu({
   returnFocusTo?: React.RefObject<HTMLElement | null>;
 }) {
   const { deleteEntry, unzipHere } = useWorkspace();
-  const { isPinned, togglePin } = usePinned();
+  const { isPinned, togglePin, available: pinning } = usePinned();
   const openManageAccess = useManageAccess();
   const pinned = isPinned(entry.relativePath);
   const [unzipping, setUnzipping] = useState(false);
@@ -298,7 +340,7 @@ function ContextMenu({
           </MenuItem>
         </>
       )}
-      {entry.type === 'directory' && !isRoot && (
+      {entry.type === 'directory' && !isRoot && pinning && (
         <MenuItem role="menuitem" onClick={() => { togglePin(entry.relativePath); onClose(); }}>
           <span className="flex items-center gap-2">
             {pinned ? <PinOff size={14} /> : <Pin size={14} />}
@@ -425,11 +467,14 @@ function RenameInput({
 
 const DRAG_MIME = 'application/x-workspace-path';
 
-function FileTreeNode({
+export function FileTreeNode({
   entry,
   depth,
   initiallyExpanded,
   collapseChildren,
+  hideRow = false,
+  outdent = false,
+  controls,
 }: {
   entry: FileTreeEntry;
   depth: number;
@@ -440,9 +485,29 @@ function FileTreeNode({
   // When set, this node's direct children start collapsed (so opening Knowledge
   // reveals the ontologies without cascading them all open).
   collapseChildren?: boolean;
+  /**
+   * Render the children and nothing of the row itself: no name, no caret, no
+   * menu, always open, children at THIS depth. For a root whose place a
+   * section label has taken — the Library's Skills tree heads its scopes with
+   * "SKILLS", not with a folder row called Skills under it.
+   */
+  hideRow?: boolean;
+  /**
+   * Draw this node's descendants one indent step to the left. Set by a
+   * headless root for its whole subtree: the children keep their LOGICAL
+   * depth (so what starts open and what starts shut is exactly as under a
+   * drawn root), but sit where the missing row's children would have been.
+   */
+  outdent?: boolean;
+  /**
+   * The verbs a hidden row's hover buttons would have offered, for the
+   * section label that stands in for it — `create` opens the same inline
+   * input the row's buttons open.
+   */
+  controls?: Ref<FileTreeNodeControls>;
 }) {
-  const { openFilePath, createFile, createDirectory, dispatchUpload, isUploading, moveEntry, workspaceId, pendingUploads } = useWorkspace();
-  const { openFile } = useFileNav();
+  const { createFile, createDirectory, dispatchUpload, isUploading, moveEntry, workspaceId, pendingUploads } = useWorkspace();
+  const nav = useTreeNav();
   // One shared fetch behind this — see `OpenChangeRequestsProvider`.
   const openChangeRequests = useOpenChangeRequests();
   const suggestions = useSuggestions();
@@ -479,6 +544,16 @@ function FileTreeNode({
   // at which point intent is reset and auto-expand takes over again.
   const [userIntent, setUserIntent] = useState<boolean | null>(null);
   const [creating, setCreating] = useState<'file' | 'directory' | null>(null);
+  useImperativeHandle(
+    controls,
+    () => ({
+      create: (kind) => {
+        setUserIntent(true);
+        setCreating(kind);
+      },
+    }),
+    [],
+  );
   const [renaming, setRenaming] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   // Only the root row uses these refs, but hooks must run unconditionally.
@@ -522,7 +597,7 @@ function FileTreeNode({
   const [dragging, setDragging] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
-  const paddingLeft = indentFor(depth);
+  const paddingLeft = indentFor(depth) - (outdent ? 13 : 0);
   const isRoot = entry.relativePath === '.';
   const isPending = pendingUploads.has(entry.relativePath);
   // A folder with nothing in it doesn't get a caret, because there is nothing
@@ -535,15 +610,15 @@ function FileTreeNode({
   // deep-link URLs reveal the file's row in the tree) or while files
   // dropped under it are still uploading (so the user can watch them
   // fill in).
-  const isOpenFileAncestor = entry.type === 'directory' && !!openFilePath && (
-    isRoot || openFilePath.startsWith(entry.relativePath + '/')
+  const isOpenFileAncestor = entry.type === 'directory' && !!nav.activePath && (
+    isRoot || nav.activePath.startsWith(entry.relativePath + '/')
   );
   const autoExpanded = entry.type === 'directory' && (isPending || isOpenFileAncestor);
 
   // Fingerprint of what currently drives auto-expand. When it transitions
   // (different file opened, upload starts), the user's prior collapse intent
   // is stale — reset so deep-links / new uploads can re-reveal the folder.
-  const autoTrigger = `${isPending ? 'P' : ''}|${isOpenFileAncestor ? openFilePath : ''}`;
+  const autoTrigger = `${isPending ? 'P' : ''}|${isOpenFileAncestor ? nav.activePath : ''}`;
   const prevAutoTriggerRef = useRef(autoTrigger);
   useEffect(() => {
     if (prevAutoTriggerRef.current !== autoTrigger) {
@@ -552,7 +627,7 @@ function FileTreeNode({
     }
   }, [autoTrigger]);
 
-  const isExpanded = userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2));
+  const isExpanded = hideRow || (userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2)));
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -636,6 +711,7 @@ function FileTreeNode({
     const dirPath = isRoot ? '' : entry.relativePath;
     return (
       <div>
+        {!hideRow && (
         <div
           className={cn(
             ROW_CLASS,
@@ -754,13 +830,16 @@ function FileTreeNode({
             </>
           )}
         </div>
+        )}
         {isExpanded && (
           <div>
             {creating && (
               // Line the input up with the child rows it is about to join:
               // one more indent step (13px), plus the caret slot (13px) and
-              // the row gap (6px) the child's name starts after.
-              <div style={{ paddingLeft: paddingLeft + 32 }} className="px-2 py-0.5">
+              // the row gap (6px) the child's name starts after. A headless
+              // root's children are outdented a step, so only the slot and
+              // the gap remain.
+              <div style={{ paddingLeft: paddingLeft + (hideRow ? 19 : 32) }} className="px-2 py-0.5">
                 <InlineInput
                   placeholder={creating === 'file' ? 'filename' : 'folder name'}
                   onSubmit={async (name) => {
@@ -794,6 +873,7 @@ function FileTreeNode({
                 key={child.relativePath}
                 entry={child}
                 depth={depth + 1}
+                outdent={hideRow || outdent}
                 initiallyExpanded={collapseChildren ? false : undefined}
               />
             ))}
@@ -847,7 +927,7 @@ function FileTreeNode({
     );
   }
 
-  const isActive = entry.relativePath === openFilePath;
+  const isActive = entry.relativePath === nav.activePath;
 
   return (
     <>
@@ -865,7 +945,7 @@ function FileTreeNode({
         draggable={!renaming && !isPending}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
-        onClick={() => { if (!renaming && !isPending) openFile(entry.relativePath); }}
+        onClick={() => { if (!renaming && !isPending) nav.open(entry.relativePath); }}
         onContextMenu={handleContextMenu}
         title={isPending ? 'Adding…' : undefined}
       >
@@ -933,83 +1013,26 @@ function FileTreeNode({
 // ── Explorer Root ──
 
 /**
- * Walk down to the node that actually holds the KB content. The file tree roots
- * at the per-branch workspace dir and wraps the KB clone a level or two deep
- * (`<branch>/<kbDir>/{KnowledgeBase,Data,Agents,Pipelines,Skills,Tools,…}`), so
- * the split lives below the visible root. Returns the first node whose children
- * include one of those well-known root directories, or null when there's no
- * such split (legacy clones).
+ * Everything a tree of `FileTreeNode`s needs AROUND it, and nothing about
+ * where it sits: the navigation (which row is current, where a click goes),
+ * the suggestion rows' change-request dialog, the right-click menu's Manage
+ * access sheet, and — for the one tree that has somewhere to pin into — a pin
+ * controller. The Knowledge explorer and the Library's Skills tree both render
+ * inside one of these, which is why their rows cannot drift: the rows are one
+ * component and so are their surroundings.
  */
-// (`findKbRoot` lives in `../utils/fileTree` — shared with registry-
-// contributed explorer items.)
-
-export function FileExplorer() {
-  const {
-    fileTree,
-    kbDirName,
-    dispatchUpload,
-    uploadError,
-    clearUploadError,
-    uploadNotice,
-    clearUploadNotice,
-    pendingUploads,
-  } = useWorkspace();
-  const [dragOver, setDragOver] = useState(false);
-  // Download is now a per-path permission (resolved server-side from the
-  // access tree's `download:` verb), so there's no global preflight gate
-  // here anymore. The menu items always render; if the user clicks on a
-  // file they don't have download permission for, the backend returns 403
-  // and `handleDownload` shows the error.
-  // Optimistic overlay: every dropped/picked file shows up in the tree
-  // within a frame, even before its commit echoes back from the server.
-  const serverTree = useMemo(
-    () => (fileTree ? mergePendingIntoTree(fileTree, pendingUploads) : null),
-    [fileTree, pendingUploads],
-  );
-
-  // The caller's own proposed files that do NOT exist on this branch — they
-  // live only on the personal suggestions branch behind an open change
-  // request. The tree shows them beside the branch's real files (synthesized
-  // below), coloured differently, and clicking one opens the request.
+export function TreeChrome({
+  nav,
+  suggestionOnlyPaths,
+  pinned,
+  children,
+}: {
+  nav: TreeNav;
+  suggestionOnlyPaths: ReadonlyMap<string, number>;
+  pinned?: PinnedController;
+  children: ReactNode;
+}) {
   const openChangeRequests = useOpenChangeRequests();
-  const suggestionOnlyPaths = useMemo(() => {
-    const map = new Map<string, number>();
-    if (!serverTree) return map;
-    /**
-     * "Not in the tree" has TWO causes, and only one earns a row: the file is
-     * new on the suggestions branch — or the server FILTERED it (.bevelignore,
-     * read gates). The client cannot evaluate those rules itself, but it can
-     * read their verdict off the tree: if the path's top-level folder under
-     * the repo root is absent, the whole subtree is hidden (a skill proposal
-     * under a bevelignored `Plugins/` was the observed leak), so the overlay
-     * must not resurrect it. The known cost: a proposal that CREATES a new
-     * top-level root folder shows no row until it merges.
-     */
-    const hiddenRoot = (path: string): boolean => {
-      const prefix = kbDirName && path.startsWith(`${kbDirName}/`) ? `${kbDirName}/` : '';
-      const segments = path.slice(prefix.length).split('/');
-      if (segments.length < 2) return false; // directly under the repo root
-      return !pathExistsInTree(serverTree, `${prefix}${segments[0]}`);
-    };
-    for (const [path, crNumber] of openChangeRequests.minePaths) {
-      if (!pathExistsInTree(serverTree, path) && !hiddenRoot(path)) {
-        map.set(path, crNumber);
-      }
-    }
-    return map;
-  }, [serverTree, openChangeRequests, kbDirName]);
-
-  const mergedTree = useMemo(() => {
-    if (!serverTree || suggestionOnlyPaths.size === 0) return serverTree;
-    // Reuses the pending-upload synthesizer: same parent-directory creation,
-    // same sort order, and a real entry always wins over a synthesized one.
-    const asEntries = new Map<string, PendingEntry>();
-    for (const path of suggestionOnlyPaths.keys()) {
-      asEntries.set(path, { fullPath: path, type: 'file' });
-    }
-    return mergePendingIntoTree(serverTree, asEntries);
-  }, [serverTree, suggestionOnlyPaths]);
-
   // A clicked suggestion row opens the SHARED change-request dialog on the
   // request the path belongs to — the row is a link to the request, and the
   // dialog is the one change-request view the app has.
@@ -1024,6 +1047,122 @@ export function FileExplorer() {
     }),
     [suggestionOnlyPaths, openChangeRequests],
   );
+  // Right-click → Manage access opens this sheet for the chosen entry.
+  const [accessTarget, setAccessTarget] = useState<FileTreeEntry | null>(null);
+
+  return (
+    <>
+      <TreeNavContext.Provider value={nav}>
+      <PinnedContext.Provider value={pinned ?? NO_PINNING}>
+      <ManageAccessContext.Provider value={setAccessTarget}>
+      <SuggestionsContext.Provider value={suggestionsController}>
+        {children}
+      </SuggestionsContext.Provider>
+      </ManageAccessContext.Provider>
+      </PinnedContext.Provider>
+      </TreeNavContext.Provider>
+      {openSuggestionCr && (
+        <ChangeRequestDialog
+          cr={openSuggestionCr}
+          onClose={() => setOpenSuggestionCr(null)}
+          onResolved={() => {
+            setOpenSuggestionCr(null);
+            window.dispatchEvent(new Event(PR_STALE_EVENT));
+          }}
+        />
+      )}
+      {accessTarget && (
+        <ManageAccessDialog
+          key={accessTarget.relativePath}
+          entry={accessTarget}
+          // The dialog is keyed on the path, so pointing it at a parent remounts
+          // it against that folder — the whole retarget is this one setter.
+          onManageAncestor={setAccessTarget}
+          onClose={() => setAccessTarget(null)}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * The upload banners: the last upload's error, or the one non-error notice
+ * (it landed on the suggestions branch). Rendered by every tree that can
+ * upload, because the state is the workspace's and a drop into a tree with no
+ * banner would fail — or succeed elsewhere — in silence.
+ */
+export function UploadNotices() {
+  const { uploadError, clearUploadError, uploadNotice, clearUploadNotice } = useWorkspace();
+  return (
+    <>
+      {uploadError && (
+        <div
+          role="alert"
+          className="flex items-start gap-1 px-2 py-1 text-xs text-danger bg-danger-soft border-b border-danger/30 shrink-0"
+        >
+          <span className="flex-1 truncate" title={uploadError.reason}>
+            Couldn't add {uploadError.filename}: {uploadError.reason}
+          </span>
+          <IconButton
+            size={18}
+            tone="danger"
+            title="Dismiss"
+            aria-label="Dismiss upload error"
+            onClick={clearUploadError}
+          >
+            <X size={12} />
+          </IconButton>
+        </div>
+      )}
+      {/* Not an error: the upload LANDED, on the suggestions branch. Saying
+          so is load-bearing — nothing appears in the tree where the user
+          dropped the files, and silence there reads as a failed upload. */}
+      {uploadNotice && (
+        <div
+          role="status"
+          className="flex items-start gap-1 px-2 py-1 text-xs text-ink bg-wait-soft border-b border-line shrink-0"
+        >
+          <span className="flex-1" title={uploadNotice}>
+            {uploadNotice}
+          </span>
+          <IconButton
+            size={18}
+            title="Dismiss"
+            aria-label="Dismiss upload notice"
+            onClick={clearUploadNotice}
+          >
+            <X size={12} />
+          </IconButton>
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Walk down to the node that actually holds the KB content. The file tree roots
+ * at the per-branch workspace dir and wraps the KB clone a level or two deep
+ * (`<branch>/<kbDir>/{KnowledgeBase,Data,Agents,Pipelines,Skills,Tools,…}`), so
+ * the split lives below the visible root. Returns the first node whose children
+ * include one of those well-known root directories, or null when there's no
+ * such split (legacy clones).
+ */
+// (`findKbRoot` lives in `../utils/fileTree` — shared with registry-
+// contributed explorer items.)
+
+export function FileExplorer() {
+  const { openFilePath, dispatchUpload } = useWorkspace();
+  const { openFile } = useFileNav();
+  const [dragOver, setDragOver] = useState(false);
+  // Download is now a per-path permission (resolved server-side from the
+  // access tree's `download:` verb), so there's no global preflight gate
+  // here anymore. The menu items always render; if the user clicks on a
+  // file they don't have download permission for, the backend returns 403
+  // and `handleDownload` shows the error.
+  const { tree: mergedTree, suggestionOnlyPaths } = useMergedWorkspaceTree();
+  // The pane workspace's own navigation: the open tab is the current row, and
+  // a click opens the file on the checked-out branch.
+  const nav = useMemo<TreeNav>(() => ({ activePath: openFilePath, open: openFile }), [openFilePath, openFile]);
 
   // Pinned folders — a personal, client-side shortcut list surfaced at the top
   // of the explorer. Stored as relativePaths in localStorage; toggled from the
@@ -1041,7 +1180,7 @@ export function FileExplorer() {
     });
   }, []);
   const pinnedController = useMemo<PinnedController>(
-    () => ({ isPinned: (path) => pinnedPaths.includes(path), togglePin }),
+    () => ({ available: true, isPinned: (path) => pinnedPaths.includes(path), togglePin }),
     [pinnedPaths, togglePin],
   );
   // Resolve pinned paths to live tree entries, dropping any that no longer
@@ -1062,9 +1201,6 @@ export function FileExplorer() {
   // ships none of its own.
   const { explorerItems } = useAppRegistry();
 
-  // Right-click → Manage access opens this sheet for the chosen entry.
-  const [accessTarget, setAccessTarget] = useState<FileTreeEntry | null>(null);
-
   // KB content splits into separate top-level folders; surface them as labelled
   // sections rather than a single flat root. The Knowledge section hoists
   // `KnowledgeBase/`'s children and folds in any other top-level content folder
@@ -1079,6 +1215,10 @@ export function FileExplorer() {
   // none of the surrounding affordances, on a folder whose access is managed
   // from the plugin page. Deep links into a plugin file still resolve; the
   // folder just is not a browsing destination in Knowledge.
+  //
+  // `Skills/` neither: the Skills & Tools sidebar renders that root as its
+  // own tree (`SkillsTree`), with these same rows, and a skill file opens on
+  // its skill page there.
   //
   // `Data/`, `Agents/` and `Pipelines/` are rendered when PRESENT but never
   // created by core (see `CORE_REQUIRED_DIRS`) — a deployment that owns the
@@ -1151,7 +1291,7 @@ export function FileExplorer() {
   );
 
   return (
-    <>
+    <TreeChrome nav={nav} suggestionOnlyPaths={suggestionOnlyPaths} pinned={pinnedController}>
     {/* No background, no border, no width: this is the CONTENTS of the app's
         one sidebar, and `SidebarFrame` is the sidebar. It used to be
         `bg-white` against the Library's `bg-sidebar`, which is how two navs in
@@ -1175,49 +1315,7 @@ export function FileExplorer() {
         setDragOver(false);
       }}
     >
-      {uploadError && (
-        <div
-          role="alert"
-          className="flex items-start gap-1 px-2 py-1 text-xs text-danger bg-danger-soft border-b border-danger/30 shrink-0"
-        >
-          <span className="flex-1 truncate" title={uploadError.reason}>
-            Couldn't add {uploadError.filename}: {uploadError.reason}
-          </span>
-          <IconButton
-            size={18}
-            tone="danger"
-            title="Dismiss"
-            aria-label="Dismiss upload error"
-            onClick={clearUploadError}
-          >
-            <X size={12} />
-          </IconButton>
-        </div>
-      )}
-      {/* Not an error: the upload LANDED, on the suggestions branch. Saying
-          so is load-bearing — nothing appears in the tree where the user
-          dropped the files, and silence there reads as a failed upload. */}
-      {uploadNotice && (
-        <div
-          role="status"
-          className="flex items-start gap-1 px-2 py-1 text-xs text-ink bg-wait-soft border-b border-line shrink-0"
-        >
-          <span className="flex-1" title={uploadNotice}>
-            {uploadNotice}
-          </span>
-          <IconButton
-            size={18}
-            title="Dismiss"
-            aria-label="Dismiss upload notice"
-            onClick={clearUploadNotice}
-          >
-            <X size={12} />
-          </IconButton>
-        </div>
-      )}
-      <PinnedContext.Provider value={pinnedController}>
-      <ManageAccessContext.Provider value={setAccessTarget}>
-      <SuggestionsContext.Provider value={suggestionsController}>
+      <UploadNotices />
       <div className="flex-1 overflow-y-auto min-h-0">
         {/* "Company Context", not "Pinned". The mechanism is pinning; the
             SECTION is the handful of places this company actually works out
@@ -1263,31 +1361,8 @@ export function FileExplorer() {
           <FileTreeNode entry={mergedTree} depth={0} />
         )}
       </div>
-      </SuggestionsContext.Provider>
-      </ManageAccessContext.Provider>
-      </PinnedContext.Provider>
       <PullRequestsForMe />
     </div>
-    {openSuggestionCr && (
-      <ChangeRequestDialog
-        cr={openSuggestionCr}
-        onClose={() => setOpenSuggestionCr(null)}
-        onResolved={() => {
-          setOpenSuggestionCr(null);
-          window.dispatchEvent(new Event(PR_STALE_EVENT));
-        }}
-      />
-    )}
-    {accessTarget && (
-      <ManageAccessDialog
-        key={accessTarget.relativePath}
-        entry={accessTarget}
-        // The dialog is keyed on the path, so pointing it at a parent remounts
-        // it against that folder — the whole retarget is this one setter.
-        onManageAncestor={setAccessTarget}
-        onClose={() => setAccessTarget(null)}
-      />
-    )}
-    </>
+    </TreeChrome>
   );
 }

--- a/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
@@ -2,13 +2,11 @@ import {
   useState,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useMemo,
   useRef,
   createContext,
   useContext,
   type ReactNode,
-  type Ref,
 } from 'react';
 import {
   ChevronRight,
@@ -173,11 +171,6 @@ export interface TreeNav {
 const TreeNavContext = createContext<TreeNav>({ activePath: null, open: () => {} });
 const useTreeNav = () => useContext(TreeNavContext);
 
-/** What a headless root's stand-in heading can ask of it — see `FileTreeNode.controls`. */
-export interface FileTreeNodeControls {
-  create(kind: 'file' | 'directory'): void;
-}
-
 /** Depth-first lookup of a tree entry by its exact relativePath. */
 function findEntryByPath(node: FileTreeEntry, path: string): FileTreeEntry | null {
   if (node.relativePath === path) return node;
@@ -202,11 +195,14 @@ function ContextMenu({
   onRename,
   onDownload,
   returnFocusTo,
+  deletable = true,
 }: {
   x: number;
   y: number;
   entry: FileTreeEntry;
   isRoot: boolean;
+  /** False for a folder the platform owns (a reserved root drawn as a heading): no Delete. */
+  deletable?: boolean;
   onClose: () => void;
   onCreateFile?: () => void;
   onCreateFolder?: () => void;
@@ -353,7 +349,7 @@ function ContextMenu({
           <span className="flex items-center gap-2"><Pencil size={14} />Rename</span>
         </MenuItem>
       )}
-      {!isRoot && (
+      {!isRoot && deletable && (
         // Danger tone comes from the primitive, not from a hand-written red.
         <MenuItem role="menuitem" tone="danger" onClick={handleDelete}>
           <span className="flex items-center gap-2"><Trash2 size={14} />Delete</span>
@@ -472,9 +468,8 @@ export function FileTreeNode({
   depth,
   initiallyExpanded,
   collapseChildren,
-  hideRow = false,
+  heading,
   outdent = false,
-  controls,
 }: {
   entry: FileTreeEntry;
   depth: number;
@@ -486,25 +481,26 @@ export function FileTreeNode({
   // reveals the ontologies without cascading them all open).
   collapseChildren?: boolean;
   /**
-   * Render the children and nothing of the row itself: no name, no caret, no
-   * menu, always open, children at THIS depth. For a root whose place a
-   * section label has taken — the Library's Skills tree heads its scopes with
-   * "SKILLS", not with a folder row called Skills under it.
+   * Draw this folder's row as a SECTION HEADING carrying this text, always
+   * open, with its children at the nav's own indent. For a reserved root the
+   * Library heads a section with — "SKILLS" over its scopes, not a folder
+   * row called Skills with the scopes indented under it.
+   *
+   * The heading IS the row, not a label standing in for one: it takes drops,
+   * offers the create buttons and the file/folder pickers, and opens the
+   * folder's menu on right-click — everything the row does, minus what a
+   * reserved root must not do (rename, delete, be dragged, be pinned).
+   * Rendering the label elsewhere and hiding the row here is how a section
+   * ends up without a drop target.
    */
-  hideRow?: boolean;
+  heading?: string;
   /**
    * Draw this node's descendants one indent step to the left. Set by a
-   * headless root for its whole subtree: the children keep their LOGICAL
-   * depth (so what starts open and what starts shut is exactly as under a
-   * drawn root), but sit where the missing row's children would have been.
+   * heading row for its whole subtree: the children keep their LOGICAL depth
+   * (so what starts open and what starts shut is exactly as under a plain
+   * row), but sit where the nav's first level sits.
    */
   outdent?: boolean;
-  /**
-   * The verbs a hidden row's hover buttons would have offered, for the
-   * section label that stands in for it — `create` opens the same inline
-   * input the row's buttons open.
-   */
-  controls?: Ref<FileTreeNodeControls>;
 }) {
   const { createFile, createDirectory, dispatchUpload, isUploading, moveEntry, workspaceId, pendingUploads } = useWorkspace();
   const nav = useTreeNav();
@@ -544,16 +540,6 @@ export function FileTreeNode({
   // at which point intent is reset and auto-expand takes over again.
   const [userIntent, setUserIntent] = useState<boolean | null>(null);
   const [creating, setCreating] = useState<'file' | 'directory' | null>(null);
-  useImperativeHandle(
-    controls,
-    () => ({
-      create: (kind) => {
-        setUserIntent(true);
-        setCreating(kind);
-      },
-    }),
-    [],
-  );
   const [renaming, setRenaming] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   // Only the root row uses these refs, but hooks must run unconditionally.
@@ -572,11 +558,12 @@ export function FileTreeNode({
 
   // Resetting `value` after dispatch lets users re-select the same file and
   // still get an `onChange` event the second time around.
+  const pickTarget = entry.relativePath === '.' ? '' : entry.relativePath;
   const handleRootFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
     e.target.value = '';
-    if (files.length > 0) dispatchUpload({ kind: 'files', files }, '');
-  }, [dispatchUpload]);
+    if (files.length > 0) dispatchUpload({ kind: 'files', files }, pickTarget);
+  }, [dispatchUpload, pickTarget]);
 
   // Folder picker: each File carries a `webkitRelativePath` like
   // "foldername/sub/file.txt" — we feed those straight into the upload
@@ -592,8 +579,8 @@ export function FileTreeNode({
       file,
       relativePath: file.webkitRelativePath || file.name,
     }));
-    dispatchUpload({ kind: 'paths', items }, '');
-  }, [dispatchUpload]);
+    dispatchUpload({ kind: 'paths', items }, pickTarget);
+  }, [dispatchUpload, pickTarget]);
   const [dragging, setDragging] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
@@ -627,7 +614,8 @@ export function FileTreeNode({
     }
   }, [autoTrigger]);
 
-  const isExpanded = hideRow || (userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2)));
+  const isHeading = heading !== undefined;
+  const isExpanded = isHeading || (userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2)));
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -709,9 +697,101 @@ export function FileTreeNode({
 
   if (entry.type === 'directory') {
     const dirPath = isRoot ? '' : entry.relativePath;
+    // The verbs a folder row offers, built once so the plain row and the
+    // heading row cannot offer different ones.
+    const createButtons = (
+      <>
+        <IconButton
+          size={18}
+          title="New file"
+          aria-label={`New file in ${entry.name}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            setUserIntent(true);
+            setCreating('file');
+          }}
+        >
+          <FilePlus size={13} />
+        </IconButton>
+        <IconButton
+          size={18}
+          title="New folder"
+          aria-label={`New folder in ${entry.name}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            setUserIntent(true);
+            setCreating('directory');
+          }}
+        >
+          <FolderPlus size={13} />
+        </IconButton>
+      </>
+    );
+    const pickerButtons = (
+      <>
+        <IconButton
+          size={18}
+          title="Add files"
+          aria-label="Add files"
+          disabled={isUploading}
+          onClick={handleRootUploadClick}
+        >
+          <Upload size={13} />
+        </IconButton>
+        <input
+          ref={rootFileInputRef}
+          type="file"
+          multiple
+          hidden
+          aria-hidden="true"
+          data-testid="file-explorer-file-input"
+          onChange={handleRootFileChange}
+        />
+        <IconButton
+          size={18}
+          title="Add folder"
+          aria-label="Add folder"
+          disabled={isUploading}
+          onClick={handleRootFolderClick}
+        >
+          <FolderUp size={13} />
+        </IconButton>
+        <input
+          ref={rootFolderInputRef}
+          type="file"
+          multiple
+          webkitdirectory=""
+          hidden
+          aria-hidden="true"
+          data-testid="file-explorer-folder-input"
+          onChange={handleRootFolderChange}
+        />
+      </>
+    );
     return (
       <div>
-        {!hideRow && (
+        {isHeading ? (
+          // The same heading as the Library's `SectionLabel` and the
+          // explorer's "Company Context" — a heading over a list of places —
+          // that happens to be this folder's row: it takes drops, opens the
+          // folder's menu, and shows the row's verbs on hover.
+          <div
+            className={cn(
+              'group/label flex items-center gap-1 rounded-sm px-2.5 pb-1.5 pt-5',
+              dragOver && 'bg-hover ring-1 ring-accent/40',
+            )}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onContextMenu={handleContextMenu}
+          >
+            <span className="text-label uppercase text-ink-faint">{heading}</span>
+            <span className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/label:opacity-100">
+              {createButtons}
+              {pickerButtons}
+            </span>
+          </div>
+        ) : (
         <div
           className={cn(
             ROW_CLASS,
@@ -763,72 +843,9 @@ export function FileTreeNode({
             )}
           </button>
           <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex group-focus-within:flex">
-            <IconButton
-              size={18}
-              title="New file"
-              aria-label={`New file in ${entry.name}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                setUserIntent(true);
-                setCreating('file');
-              }}
-            >
-              <FilePlus size={13} />
-            </IconButton>
-            <IconButton
-              size={18}
-              title="New folder"
-              aria-label={`New folder in ${entry.name}`}
-              onClick={(e) => {
-                e.stopPropagation();
-                setUserIntent(true);
-                setCreating('directory');
-              }}
-            >
-              <FolderPlus size={13} />
-            </IconButton>
+            {createButtons}
           </div>
-          {isRoot && (
-            <>
-              <IconButton
-                size={18}
-                title="Add files"
-                aria-label="Add files"
-                disabled={isUploading}
-                onClick={handleRootUploadClick}
-              >
-                <Upload size={13} />
-              </IconButton>
-              <input
-                ref={rootFileInputRef}
-                type="file"
-                multiple
-                hidden
-                aria-hidden="true"
-                data-testid="file-explorer-file-input"
-                onChange={handleRootFileChange}
-              />
-              <IconButton
-                size={18}
-                title="Add folder"
-                aria-label="Add folder"
-                disabled={isUploading}
-                onClick={handleRootFolderClick}
-              >
-                <FolderUp size={13} />
-              </IconButton>
-              <input
-                ref={rootFolderInputRef}
-                type="file"
-                multiple
-                webkitdirectory=""
-                hidden
-                aria-hidden="true"
-                data-testid="file-explorer-folder-input"
-                onChange={handleRootFolderChange}
-              />
-            </>
-          )}
+          {isRoot && pickerButtons}
         </div>
         )}
         {isExpanded && (
@@ -836,10 +853,10 @@ export function FileTreeNode({
             {creating && (
               // Line the input up with the child rows it is about to join:
               // one more indent step (13px), plus the caret slot (13px) and
-              // the row gap (6px) the child's name starts after. A headless
-              // root's children are outdented a step, so only the slot and
-              // the gap remain.
-              <div style={{ paddingLeft: paddingLeft + (hideRow ? 19 : 32) }} className="px-2 py-0.5">
+              // the row gap (6px) the child's name starts after. A heading's
+              // children are outdented a step, so only the slot and the gap
+              // remain.
+              <div style={{ paddingLeft: paddingLeft + (isHeading ? 19 : 32) }} className="px-2 py-0.5">
                 <InlineInput
                   placeholder={creating === 'file' ? 'filename' : 'folder name'}
                   onSubmit={async (name) => {
@@ -873,7 +890,7 @@ export function FileTreeNode({
                 key={child.relativePath}
                 entry={child}
                 depth={depth + 1}
-                outdent={hideRow || outdent}
+                outdent={isHeading || outdent}
                 initiallyExpanded={collapseChildren ? false : undefined}
               />
             ))}
@@ -888,7 +905,9 @@ export function FileTreeNode({
             onClose={() => setContextMenu(null)}
             onCreateFile={() => { setUserIntent(true); setCreating('file'); }}
             onCreateFolder={() => { setUserIntent(true); setCreating('directory'); }}
-            onRename={() => setRenaming(true)}
+            // A reserved root drawn as a heading is the platform's: no rename, no delete.
+            onRename={isHeading ? undefined : () => setRenaming(true)}
+            deletable={!isHeading}
             onDownload={handleDownload}
             returnFocusTo={rowRef}
           />

--- a/packages/core-frontend/src/modules/workspace/hooks/useMergedWorkspaceTree.ts
+++ b/packages/core-frontend/src/modules/workspace/hooks/useMergedWorkspaceTree.ts
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import type { FileTreeEntry } from '@bevel-software/platform-shared';
+import { useWorkspace, type PendingEntry } from '../state/workspace.context';
+import { mergePendingIntoTree, pathExistsInTree } from '../utils/fileTree';
+import { useOpenChangeRequests } from './useOpenChangeRequests';
+
+/**
+ * The branch's tree with two overlays: the caller's pending uploads (a
+ * dropped file shows within a frame, before its commit echoes back) and the
+ * files their own open change requests propose that this branch does not have
+ * yet. ONE hook, because two navs read the same workspace — the Knowledge
+ * explorer and the Library's Skills tree — and an overlay one of them lacked
+ * would be a file that exists in one sidebar and not the other.
+ */
+export function useMergedWorkspaceTree(): {
+  tree: FileTreeEntry | null;
+  /** Paths synthesized from the caller's own requests → the request's number. */
+  suggestionOnlyPaths: ReadonlyMap<string, number>;
+} {
+  const { fileTree, kbDirName, pendingUploads } = useWorkspace();
+  const serverTree = useMemo(
+    () => (fileTree ? mergePendingIntoTree(fileTree, pendingUploads) : null),
+    [fileTree, pendingUploads],
+  );
+
+  // The caller's own proposed files that do NOT exist on this branch — they
+  // live only on the personal suggestions branch behind an open change
+  // request. The tree shows them beside the branch's real files (synthesized
+  // below), coloured differently, and clicking one opens the request.
+  const openChangeRequests = useOpenChangeRequests();
+  const suggestionOnlyPaths = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!serverTree) return map;
+    /**
+     * "Not in the tree" has TWO causes, and only one earns a row: the file is
+     * new on the suggestions branch — or the server FILTERED it (.bevelignore,
+     * read gates). The client cannot evaluate those rules itself, but it can
+     * read their verdict off the tree: if the path's top-level folder under
+     * the repo root is absent, the whole subtree is hidden (a skill proposal
+     * under a bevelignored `Plugins/` was the observed leak), so the overlay
+     * must not resurrect it. The known cost: a proposal that CREATES a new
+     * top-level root folder shows no row until it merges.
+     */
+    const hiddenRoot = (path: string): boolean => {
+      const prefix = kbDirName && path.startsWith(`${kbDirName}/`) ? `${kbDirName}/` : '';
+      const segments = path.slice(prefix.length).split('/');
+      if (segments.length < 2) return false; // directly under the repo root
+      return !pathExistsInTree(serverTree, `${prefix}${segments[0]}`);
+    };
+    for (const [path, crNumber] of openChangeRequests.minePaths) {
+      if (!pathExistsInTree(serverTree, path) && !hiddenRoot(path)) {
+        map.set(path, crNumber);
+      }
+    }
+    return map;
+  }, [serverTree, openChangeRequests, kbDirName]);
+
+  const tree = useMemo(() => {
+    if (!serverTree || suggestionOnlyPaths.size === 0) return serverTree;
+    // Reuses the pending-upload synthesizer: same parent-directory creation,
+    // same sort order, and a real entry always wins over a synthesized one.
+    const asEntries = new Map<string, PendingEntry>();
+    for (const path of suggestionOnlyPaths.keys()) {
+      asEntries.set(path, { fullPath: path, type: 'file' });
+    }
+    return mergePendingIntoTree(serverTree, asEntries);
+  }, [serverTree, suggestionOnlyPaths]);
+
+  return { tree, suggestionOnlyPaths };
+}

--- a/packages/core-frontend/src/modules/workspace/routing/kb-routes.ts
+++ b/packages/core-frontend/src/modules/workspace/routing/kb-routes.ts
@@ -143,7 +143,7 @@ export function useCanonicalFileUrl(workspacePath: string | null): string | null
   return `${window.location.origin}${relative}`;
 }
 
-function safeDecode(s: string): string {
+export function safeDecode(s: string): string {
   try {
     return decodeURIComponent(s);
   } catch {


### PR DESCRIPTION
## What

The Skills & Tools sidebar now shows the shared `Skills/` root as a file tree, above the plugin list, and the plugin list is headed **Plugins** instead of "Included in your MCP".

The tree is the Knowledge explorer's tree, holding a different root: same rows, same right-click menu (new file/folder, rename, delete, manage access, download, copy path), drag to move, drop to upload, proposed-but-unmerged files in accent. Two things differ, both in the surroundings rather than the rows: a click opens the file on its **skill page** at the default-branch URL whatever branch is checked out, and the current row is the file the URL names. The root's own row is not drawn — the section label is the heading and carries the create buttons.

## How

- `FileExplorer` exports its row (`FileTreeNode`, with a headless mode for a root a label stands in for), the surroundings every tree needs (`TreeChrome`: navigation, suggestion dialog, manage-access sheet, optional pinning) and the upload banners; the pending-uploads + suggestions overlay moves to `useMergedWorkspaceTree`. Navigation and the active row come from context, so the rows know nothing about either surface.
- `SkillsTree` (library) composes those on the `Skills/` root of the workspace tree and is passed into `PluginsSidebar` as a slot.
- `WorkspaceItemRoute` accepts `Skills/` URLs with the same evidence rules as `Plugins/`: a skill file opens its page, a scope folder has no page (home), a file filed directly in a scope opens as a plain file via router state.
- **`.bevelignore` no longer hides `Skills/`.** The sidebar reads the root from the workspace tree, which that file filters, so the template drops the rule and the maintenance step removes the line an earlier release appended to existing knowledge bases (only that line and its comment; an operator's `!Skills/` negation and every other rule stay). The Knowledge explorer never rendered the root and still does not.

## Tests

- `SkillsTree.test.tsx`: label without a root row, scopes collapsed, deep link reveals and marks the file, click lands on the default-branch skill URL, nothing without a root, label's New folder creates under `Skills/`.
- `WorkspaceItemRoute.test.tsx`: six `Skills/` cases (file tab, bare folder, just-created skill, scope → home, scope file → raw, waits for the catalog).
- `steps.test.ts`: drops the appended rule + comment, drops the template's own rule + comment, leaves a negation alone, idempotent.
- Full suites: frontend 129 files / 1601 tests, backend 176 files / 2114 tests; typecheck, lint and `pnpm ds:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Skills & Tools sidebar now shows the shared `Skills/` root as a file tree above the plugin list, and the plugin list is headed **Plugins** instead of "Included in your MCP".

**New Features**
- The tree reuses the Knowledge explorer's rows; the section heading is the root row itself — it takes drops, holds the create buttons and pickers, and its right-click menu omits rename, delete, drag, and pin, never reaching the plugin nav.
- Clicking a skill file opens it on its skill page at the default-branch URL; the current row follows the URL, not the workspace's open tab.
- `WorkspaceItemRoute` resolves both roots with one rule set: scope folders go to the Library home, and files filed directly in a scope open as plain files.

**Migration**
- `.bevelignore` no longer hides `Skills/`; the first start after upgrade removes the previously appended rule and its comment only when the platform's exact comment (matched in full) sits above it — an operator's own rule, negation, or lookalike comment stays.
- The Knowledge explorer never rendered the `Skills/` root and still does not.

<sup>Written for commit efc617aa9e8ad70b190075f114803330bd4e27f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

