### PR TITLE
Review harness: rule-outputs gate must match multiline blocks

### DIFF
--- a/.github/workflows/kb-architecture-review.yml
+++ b/.github/workflows/kb-architecture-review.yml
@@ -478,15 +478,24 @@ jobs:
                   # The question is asked of the section's CONTENT, not of
                   # the page's shape: capture each rule-outputs block's
                   # interior (lazy, up to its closing tag) and pass when ANY
-                  # interior holds a non-whitespace character. One semantic,
-                  # so the traps of composing page-level patterns cannot
-                  # recur: content may open with markup, and an empty block
-                  # beside a substantive one is fine. A block with no closing
-                  # tag captures nothing and is treated as absent — that page
-                  # is malformed, and erroring it is correct.
-                  ro_pattern="<pre[[:space:]][^>]*class=[\"']rule-outputs[\"'][^>]*>(.*?)</pre>"
+                  # interior holds a non-space character. One semantic, so
+                  # the traps of composing page-level patterns cannot recur:
+                  # content may open with markup, and an empty block beside a
+                  # substantive one is fine. A block with no closing tag
+                  # captures nothing and is treated as absent — that page is
+                  # malformed, and erroring it is correct.
+                  #
+                  # ALL whitespace is collapsed to single spaces BEFORE the
+                  # match, so the pattern never needs a newline-crossing
+                  # mode and carries only the boring `i` flag. That is
+                  # load-bearing: jq's regex flags are Oniguruma, not PCRE —
+                  # `s` is single-line ANCHORS and `m` is the dotall — and a
+                  # PCRE-shaped flag here silently matched nothing across
+                  # lines, erroring a valid review. Verified against jq
+                  # itself, not an approximation of it.
+                  ro_pattern="<pre [^>]*class=[\"']rule-outputs[\"'][^>]*>(.*?)</pre>"
                   if ! jq -e --arg pat "$ro_pattern" \
-                       '[(.content? // "") | tostring | scan($pat; "is")] | flatten | map(tostring) | any(test("[^[:space:]]"))' \
+                       '(.content? // "") | tostring | gsub("[[:space:]]+"; " ") | [scan($pat; "i")] | flatten | map(tostring) | any(test("[^ ]"))' \
                        page.json >/dev/null 2>&1; then
                     echo "::warning::The one-pager at $branch:$path has no non-empty Rule outputs section — the review's rule blocks are its evidence; marking the check errored."
                     ruleoutputs_ok=0


### PR DESCRIPTION
The gate from #138 false-errored the first genuinely valid one-pager (PR #136's latest run — real Stated contracts / Test interfaces / Git serialization blocks, published as "review incomplete"). Root cause: jq regex flags are Oniguruma, not PCRE — `s` = single-line anchors, `m` = dotall — so the `is`-flagged lazy capture never crossed a newline.

Fixed by removing the failure class rather than swapping the flag: all whitespace is collapsed to single spaces before the match, so the pattern needs no newline-crossing mode and carries only `i`. Every case is verified against jq 1.7.1 itself (the prior round's mistake was verifying against a node approximation of jq): multiline real page, newline inside the open tag, markup-first content, empty block, empty-beside-substantive, missing section, unclosed block.

After merge, re-trigger `/bevel-review` on #136 — its current errored status is this false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rule-outputs gate so it correctly matches multiline blocks instead of false-erroring valid reviews. The gate now collapses all whitespace to single spaces before matching, avoiding the previous Oniguruma flag confusion. After merge, re-trigger `/bevel-review` on #136.

<sup>Written for commit 963e992ba38b2e5db3db704102287e2440e5dd6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

