### PR TITLE
Key dialog drawers and an unencoded marketplace placeholder

### DIFF
--- a/.changeset/marketplace-key-dialog.md
+++ b/.changeset/marketplace-key-dialog.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+The external API key dialog now folds its setup snippets into the same three closed sections as the Your agent tab (desktop agents, web agents and pipelines, skills as native plugins), with the key itself above them. The marketplace commands on the Your agent tab show the key placeholder as written instead of percent-encoding it.

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -523,130 +523,139 @@ export function ExternalAgentAccessPage() {
                   {copied ? <Check size={14} /> : <Copy size={14} />}
                 </button>
               </div>
-              <div>
-                <div className="text-xs font-medium text-ink mb-1">
+              {/* The SAME three drawers as the interactive tab — local server,
+                  hosted endpoint, marketplace — in the same order and CLOSED,
+                  with the key filled in. The key is the news here; which
+                  config the reader needs is their call, and five config walls
+                  in a row buried the one thing the dialog exists to hand over.
+                  Same summaries as the tab too, so a person who read the tab
+                  first finds the drawer they already picked. */}
+              <details className="border border-line rounded">
+                <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-ink">
                   Desktop agents — the local server (recommended)
+                </summary>
+                <div className="px-3 pb-3 space-y-2">
+                  <p className="text-meta text-ink-muted leading-snug">
+                    For agents that run on your machine: Claude Code, Claude Desktop, Cursor,
+                    Windsurf, Cline and similar. Runs this workspace as a local MCP server (needs
+                    Node): the agent gets everything the hosted endpoint serves, plus your
+                    plugins' local-only tools. In Claude Code:
+                  </p>
+                  <textarea
+                    readOnly
+                    value={hexisMcpClaudeCommand(workspaceUrl, reveal.plaintext)}
+                    rows={3}
+                    className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <p className="text-meta text-ink-muted leading-snug">
+                    On Windows, prefer the JSON config below — this one-liner assumes a POSIX
+                    shell (macOS, Linux, WSL or Git Bash).
+                  </p>
+                  <p className="text-meta text-ink-muted leading-snug">
+                    Or as a JSON config, for Claude Desktop, Cursor, Windsurf, Cline and
+                    similar:
+                  </p>
+                  <textarea
+                    readOnly
+                    value={hexisMcpJsonSnippet(workspaceUrl, reveal.plaintext)}
+                    rows={13}
+                    className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
                 </div>
-                <p className="text-meta text-ink-muted mb-1 leading-snug">
-                  For agents that run on your machine: Claude Code, Claude Desktop, Cursor,
-                  Windsurf, Cline and similar. Runs this workspace as a local MCP server (needs
-                  Node): the agent gets everything the hosted endpoint serves, plus your
-                  plugins' local-only tools. In Claude Code:
-                </p>
-                <textarea
-                  readOnly
-                  value={hexisMcpClaudeCommand(workspaceUrl, reveal.plaintext)}
-                  rows={3}
-                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-                <p className="text-meta text-ink-muted mt-1 leading-snug">
-                  On Windows, prefer the JSON config below — this one-liner assumes a POSIX
-                  shell (macOS, Linux, WSL or Git Bash).
-                </p>
-                <p className="text-meta text-ink-muted mt-2 mb-1 leading-snug">
-                  Or as a JSON config, for Claude Desktop, Cursor, Windsurf, Cline and
-                  similar:
-                </p>
-                <textarea
-                  readOnly
-                  value={hexisMcpJsonSnippet(workspaceUrl, reveal.plaintext)}
-                  rows={13}
-                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-              </div>
-              <div>
-                <div className="text-xs font-medium text-ink mb-1">
+              </details>
+
+              <details className="border border-line rounded">
+                <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-ink">
                   Web agents and pipelines — the hosted endpoint
+                </summary>
+                <div className="px-3 pb-3 space-y-3">
+                  <div>
+                    <p className="text-meta text-ink-muted mb-1 leading-snug">
+                      For agents that can't run a process on your machine, and for CI where
+                      installing Node is unwanted. Claude Code, via the hosted endpoint:
+                    </p>
+                    <textarea
+                      readOnly
+                      value={claudeCodeCommand(mcpUrl, reveal.plaintext)}
+                      rows={3}
+                      className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                    />
+                  </div>
+                  <div>
+                    <div className="text-xs font-medium text-ink mb-1">Connect Langdock</div>
+                    <ol className="text-meta text-ink-muted mb-1 leading-snug list-decimal pl-4 space-y-0.5">
+                      <li>In Langdock, open your workspace settings and go to MCP servers → Add server.</li>
+                      <li>Choose <span className="font-medium">HTTP</span> (Streamable HTTP) as the transport.</li>
+                      <li>Give it a name (e.g. <span className="font-medium">Bevel</span>), paste the URL below into the server URL field, and add the Authorization header under custom headers.</li>
+                      <li>Save, then enable the server in any assistant you want it available in.</li>
+                    </ol>
+                    <textarea
+                      readOnly
+                      value={langdockSnippet(mcpUrl, reveal.plaintext)}
+                      rows={3}
+                      className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                    />
+                  </div>
+                  <div>
+                    <div className="text-xs font-medium text-ink mb-1">Other agents (JSON config)</div>
+                    <p className="text-meta text-ink-muted mb-1 leading-snug">
+                      The hosted endpoint for most clients that load servers from a JSON config —
+                      when the local server above isn't wanted.
+                    </p>
+                    <textarea
+                      readOnly
+                      value={jsonConfigSnippet(mcpUrl, reveal.plaintext)}
+                      rows={11}
+                      className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                    />
+                  </div>
                 </div>
-                <p className="text-meta text-ink-muted mb-1 leading-snug">
-                  For agents that can't run a process on your machine, and for CI where
-                  installing Node is unwanted. Claude Code, via the hosted endpoint:
-                </p>
-                <textarea
-                  readOnly
-                  value={claudeCodeCommand(mcpUrl, reveal.plaintext)}
-                  rows={3}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-              </div>
-              <div>
-                <div className="text-xs font-medium text-ink mb-1">
-                  Connect Langdock
-                </div>
-                <ol className="text-[11px] text-ink-muted mb-1 leading-snug list-decimal pl-4 space-y-0.5">
-                  <li>In Langdock, open your workspace settings and go to MCP servers → Add server.</li>
-                  <li>Choose <span className="font-medium">HTTP</span> (Streamable HTTP) as the transport.</li>
-                  <li>Give it a name (e.g. <span className="font-medium">Bevel</span>), paste the URL below into the server URL field, and add the Authorization header under custom headers.</li>
-                  <li>Save, then enable the server in any assistant you want it available in.</li>
-                </ol>
-                <textarea
-                  readOnly
-                  value={langdockSnippet(mcpUrl, reveal.plaintext)}
-                  rows={3}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-              </div>
-              <div>
-                <div className="text-xs font-medium text-ink mb-1">
-                  Other agents (JSON config)
-                </div>
-                <p className="text-[11px] text-ink-muted mb-1 leading-snug">
-                  The hosted endpoint for most clients that load servers from a JSON config —
-                  when the local server above isn't wanted.
-                </p>
-                <textarea
-                  readOnly
-                  value={jsonConfigSnippet(mcpUrl, reveal.plaintext)}
-                  rows={11}
-                  className="w-full font-mono text-[11px] bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-              </div>
-              <div>
-                <div className="text-xs font-medium text-ink mb-1">
+              </details>
+
+              <details className="border border-line rounded">
+                <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-ink">
                   Skills as native plugins — the marketplace
+                </summary>
+                <div className="px-3 pb-3 space-y-2">
+                  <p className="text-meta text-ink-muted leading-snug">
+                    Every skill you may read, compiled into a plugin marketplace served as a git
+                    remote. One install brings all of it; a later update fetches what changed.
+                    The key stays in the URL because Claude Code refreshes marketplaces without
+                    credential helpers.
+                  </p>
+                  <textarea
+                    readOnly
+                    aria-label="Claude Code marketplace command"
+                    value={marketplaceCommands(reveal.plaintext).claude}
+                    rows={2}
+                    className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <p className="text-meta text-ink-muted leading-snug">Codex installs every plugin on add:</p>
+                  <textarea
+                    readOnly
+                    aria-label="Codex marketplace command"
+                    value={marketplaceCommands(reveal.plaintext).codex}
+                    rows={2}
+                    className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
+                  <p className="text-meta text-ink-muted leading-snug">Any other agent, through the skills CLI:</p>
+                  <textarea
+                    readOnly
+                    aria-label="skills CLI command"
+                    value={marketplaceCommands(reveal.plaintext).skills}
+                    rows={2}
+                    className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
+                    onFocus={(e) => e.currentTarget.select()}
+                  />
                 </div>
-                <p className="text-meta text-ink-muted mb-1 leading-snug">
-                  Every skill you may read, compiled into a plugin marketplace served as a git
-                  remote. One install brings all of it; a later update fetches what changed.
-                  The key stays in the URL because Claude Code refreshes marketplaces without
-                  credential helpers.
-                </p>
-                <textarea
-                  readOnly
-                  aria-label="Claude Code marketplace command"
-                  value={marketplaceCommands(reveal.plaintext).claude}
-                  rows={2}
-                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-                <p className="text-meta text-ink-muted mt-2 mb-1 leading-snug">
-                  Codex installs every plugin on add:
-                </p>
-                <textarea
-                  readOnly
-                  aria-label="Codex marketplace command"
-                  value={marketplaceCommands(reveal.plaintext).codex}
-                  rows={2}
-                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-                <p className="text-meta text-ink-muted mt-2 mb-1 leading-snug">
-                  Any other agent, through the skills CLI:
-                </p>
-                <textarea
-                  readOnly
-                  aria-label="skills CLI command"
-                  value={marketplaceCommands(reveal.plaintext).skills}
-                  rows={2}
-                  className="w-full font-mono text-meta bg-sunken border border-line rounded px-2 py-1.5 resize-none"
-                  onFocus={(e) => e.currentTarget.select()}
-                />
-              </div>
+              </details>
             </div>
             <div className="flex justify-end px-4 py-3 border-t border-line">
               <button

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -319,6 +319,11 @@ export function ExternalAgentAccessPage() {
                   The key stays in the URL: Claude Code refreshes marketplaces in the background
                   without credential helpers. Revoke the key here to cut the agent off.
                 </p>
+                <p className="text-meta text-ink-muted leading-snug">
+                  Run the command in the Claude Code CLI. The plugin screens in Claude Desktop
+                  and claude.ai accept only GitHub, GitLab and Bitbucket remotes and refuse
+                  this one as an unsupported host.
+                </p>
               </div>
             </details>
 
@@ -626,7 +631,9 @@ export function ExternalAgentAccessPage() {
                     Every skill you may read, compiled into a plugin marketplace served as a git
                     remote. One install brings all of it; a later update fetches what changed.
                     The key stays in the URL because Claude Code refreshes marketplaces without
-                    credential helpers.
+                    credential helpers. Run the command in the Claude Code CLI: the plugin
+                    screens in Claude Desktop and claude.ai accept only GitHub, GitLab and
+                    Bitbucket remotes.
                   </p>
                   <textarea
                     readOnly

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -320,9 +320,10 @@ export function ExternalAgentAccessPage() {
                   without credential helpers. Revoke the key here to cut the agent off.
                 </p>
                 <p className="text-meta text-ink-muted leading-snug">
-                  Run the command in the Claude Code CLI. The plugin screens in Claude Desktop
-                  and claude.ai accept only GitHub, GitLab and Bitbucket remotes and refuse
-                  this one as an unsupported host.
+                  Add it through Claude Code: the CLI, or the Claude Code section of the
+                  Desktop app's Customize screen. The Chat and Cowork plugin screens accept
+                  only GitHub, GitLab and Bitbucket remotes and refuse this one as an
+                  unsupported host.
                 </p>
               </div>
             </details>
@@ -631,9 +632,9 @@ export function ExternalAgentAccessPage() {
                     Every skill you may read, compiled into a plugin marketplace served as a git
                     remote. One install brings all of it; a later update fetches what changed.
                     The key stays in the URL because Claude Code refreshes marketplaces without
-                    credential helpers. Run the command in the Claude Code CLI: the plugin
-                    screens in Claude Desktop and claude.ai accept only GitHub, GitLab and
-                    Bitbucket remotes.
+                    credential helpers. Add it through Claude Code (the CLI, or the Claude
+                    Code section of the Desktop app's Customize screen): the Chat and Cowork
+                    plugin screens accept only GitHub, GitLab and Bitbucket remotes.
                   </p>
                   <textarea
                     readOnly

--- a/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/__tests__/ExternalAgentAccessPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { ExternalAgentAccessPage } from '../ExternalAgentAccessPage';
@@ -226,6 +226,43 @@ describe('the key-bearing snippets quote the deployment too', () => {
     expect(parsed.env.HEXIS_URL).toBe(window.location.origin);
     expect(parsed.env.HEXIS_CONNECTION_KEY).toBe(KEY);
     expect(json).not.toContain(PUBLIC_URL);
+  });
+
+  /**
+   * The modal holds the SAME three drawers as the interactive tab, in the
+   * same order, and every one of them arrives closed: the key is what the
+   * dialog hands over, and the configs wait until the reader picks a side.
+   */
+  it('folds the configs into the tab\'s three drawers, all closed', async () => {
+    const user = userEvent.setup();
+    mount(PUBLIC_URL);
+    await revealAKey(user);
+    const dialog = screen.getByRole('alertdialog');
+    const summaries = [
+      'Desktop agents — the local server (recommended)',
+      'Web agents and pipelines — the hosted endpoint',
+      'Skills as native plugins — the marketplace',
+    ].map((text) => within(dialog).getByText(text));
+    for (const summary of summaries) {
+      expect(summary.tagName).toBe('SUMMARY');
+      expect((summary.closest('details') as HTMLDetailsElement).open).toBe(false);
+    }
+    expect(summaries[0].compareDocumentPosition(summaries[1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(summaries[1].compareDocumentPosition(summaries[2]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The key itself is not behind a drawer.
+    expect(within(dialog).getByRole('button', { name: 'Copy external API key' }).closest('details')).toBeNull();
+  });
+
+  /**
+   * The placeholder on the keyless tab is a placeholder, not a percent-encoded
+   * one: `%3Cexternal-api-key%3E` looked like a secret to paste.
+   */
+  it('shows the marketplace placeholder verbatim on the keyless tab', () => {
+    mount(PUBLIC_URL);
+    const marketplace = snippets().filter((v) => v.includes('marketplace.git'));
+    expect(marketplace.length).toBeGreaterThan(0);
+    for (const v of marketplace) expect(v).not.toContain('%3C');
+    expect(marketplace.some((v) => v.includes('key:<external-api-key>@'))).toBe(true);
   });
 
   /**

--- a/packages/core-frontend/src/shared/__tests__/marketplace-url.test.ts
+++ b/packages/core-frontend/src/shared/__tests__/marketplace-url.test.ts
@@ -32,4 +32,23 @@ describe('marketplace git url', () => {
     expect(cmds.codex).toBe('codex plugin marketplace add https://key:bevel_abc@kb.acme.com/git/marketplace.git');
     expect(cmds.skills).toBe('npx skills add https://key:bevel_abc@kb.acme.com/git/marketplace.git --all -y');
   });
+
+  it('shows a placeholder verbatim — never percent-encoded into something that looks like a key', () => {
+    configureMarketplaceGitUrl('https://kb.acme.com/git/marketplace.git');
+    expect(withConnectionKey('<external-api-key>')).toBe(
+      'https://key:<external-api-key>@kb.acme.com/git/marketplace.git',
+    );
+    expect(marketplaceCommands('<external-api-key>').claude).not.toContain('%3C');
+  });
+
+  it('keeps a real key byte for byte — tenant prefix plus base64url, with its dashes and underscores', () => {
+    configureMarketplaceGitUrl('https://kb.acme.com/git/marketplace.git');
+    const key = 'corestaging_Ab-9_x2C9-Nmm_ic';
+    expect(withConnectionKey(key)).toBe(`https://key:${key}@kb.acme.com/git/marketplace.git`);
+  });
+
+  it('keeps a non-default port in the remote', () => {
+    configureMarketplaceGitUrl('http://localhost:3000/git/marketplace.git');
+    expect(withConnectionKey('bevel_abc')).toBe('http://key:bevel_abc@localhost:3000/git/marketplace.git');
+  });
 });

--- a/packages/core-frontend/src/shared/marketplace-url.ts
+++ b/packages/core-frontend/src/shared/marketplace-url.ts
@@ -43,12 +43,16 @@ export function marketplaceGitUrl(): string {
  * Basic, and what Claude Code's background refresh needs because it disables
  * credential helpers. `key` is the placeholder when the person has not
  * minted one yet.
+ *
+ * Spliced as TEXT, not set through `URL.password`: the URL parser
+ * percent-encodes what it is given, and the placeholder `<external-api-key>`
+ * came out as `%3Cexternal-api-key%3E` — a thing to paste that looks like a
+ * secret. A real key never needs encoding: it is a tenant prefix plus base64url,
+ * all of it URL-safe by construction.
  */
 export function withConnectionKey(key: string): string {
-  const parsed = new URL(marketplaceGitUrl());
-  parsed.username = 'key';
-  parsed.password = key;
-  return parsed.toString();
+  const { protocol, host, pathname } = new URL(marketplaceGitUrl());
+  return `${protocol}//key:${key}@${host}${pathname}`;
 }
 
 /** The marketplace's registered name — what `plugin@<name>` refers to in Claude Code. */


### PR DESCRIPTION
## What

- The external API key dialog now folds its setup snippets into the **same three closed drawers as the Your agent tab** — desktop agents (local server), web agents and pipelines (hosted endpoint), skills as native plugins (marketplace) — in the same order and with the same summaries. The key itself stays above them, not behind a drawer.
- The marketplace commands on the keyless tab showed the placeholder as `%3Cexternal-api-key%3E`: the key was set through `URL.password`, which percent-encodes. The key is now spliced in as text — a real key is tenant prefix + base64url and never needs encoding, and a placeholder reads as one.

## Verified

- The staging marketplace remote answers `git ls-remote` with the key and 401 without; on Claude Code 2.1.252 `claude plugin marketplace add <url-with-key>` followed by `claude plugin install hexis-all@hexis` installed the bundle with its five dependencies.
- Tests: 26 across `marketplace-url.test.ts` (placeholder verbatim, real key byte for byte, non-default port) and `ExternalAgentAccessPage.test.tsx` (three closed drawers in order, key outside them, placeholder not encoded). Typecheck clean; `pnpm ds:check` drops five off-scale font sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds the external API key dialog's setup snippets into the same three closed drawers as the Your agent tab, and fixes the marketplace placeholder showing as `%3Cexternal-api-key%3E` instead of `<external-api-key>`.

- The key sits above the drawers, not buried under five configuration blocks.
- Marketplace URL building now splices the key in as text instead of using `URL.password`, which percent-encodes its input.
- Both places showing the marketplace command now name where it works: the Claude Code CLI or the Claude Code section of the Desktop app's Customize screen — the Chat and Cowork plugin screens reject self-hosted remotes as unsupported hosts.
- Adds tests covering the drawer order, placeholder verbatim, real keys kept byte for byte, and the CLI note.

<sup>Written for commit 78ccb8b0a0ae05b08b88ece9c6daaa59aa295b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

