### PR TITLE
The GitHub Action example runs on branch pushes

### DIFF
--- a/docs/git-sync.md
+++ b/docs/git-sync.md
@@ -89,8 +89,11 @@ A `curl --fail` therefore fails exactly when Hexis is not in sync.
 name: Sync Hexis
 on:
   push:
-    # Branches only: a tag push has no branch to sync.
-    tags-ignore: ["**"]
+    # Every branch, and by the same token no tag: a push filter that names
+    # only branches ignores tag events. (A `tags-ignore` filter ALONE would
+    # do the opposite — consider tags only — and the workflow would never
+    # run for a branch push.)
+    branches: ["**"]
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The documented sync workflow used `push: { tags-ignore: ["**"] }`. A push filter that names only tags makes the workflow consider tag events only, so it never ran for a branch push — found on the staging repo, where a manual dispatch synced fine and two real pushes started nothing. `branches: ["**"]` matches every branch and, by the same rule, no tag.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the documented GitHub Action trigger so the sync workflow actually runs on branch pushes.

**Bug Fixes**
- Replaces `tags-ignore: ["**"]` with `branches: ["**"]`, since a push filter naming only tags ignores branch pushes entirely.

<sup>Written for commit 5b7353142b3ea7125c662a8f84a85a7c1a900124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

