### PR TITLE
A rebase conflict names its files on the banner whichever path hit it

### DIFF
--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.service.releaseLock.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.service.releaseLock.test.ts
@@ -8,9 +8,10 @@ import type { IAccessControl } from '../../access/access-control.interface.js';
 import { FileLockService } from '../file-lock.service.js';
 import { PendingCommitsService } from '../pending-commits.service.js';
 import { WorkflowEventBus } from '../event-bus.js';
-import { WorkflowService } from '../workflow.service.js';
+import { WorkflowService, syncConflictMessage } from '../workflow.service.js';
 import type { Database } from '../../database/connection.js';
 import {
+  PullRebaseConflictError,
   PullRebaseConflictError,
   PushNeedsAgentResolutionError,
   WorkflowValidationError,
@@ -87,7 +88,7 @@ function makePending(): PendingCommitsService {
 function makeGit(overrides: Partial<{
   commitFile: Change | null;
   pushBehavior: 'ok' | 'nff' | 'auth-fail';
-  pullBehavior: 'ok' | 'fail';
+  pullBehavior: 'ok' | 'fail' | 'conflict';
   pushAfterPullBehavior: 'ok' | 'fail';
   hasUnpushedCommits: boolean;
 }> = {}): GitService {
@@ -120,6 +121,7 @@ function makeGit(overrides: Partial<{
     }),
     pull: vi.fn().mockImplementation(async () => {
       if (pullBehavior === 'fail') throw new Error('git pull failed: merge conflict');
+      if (pullBehavior === 'conflict') throw new PullRebaseConflictError('feat/x', ['foo.md'], 'CONFLICT (content)');
       return { treeChanged: true };
     }),
   } as unknown as GitService;
@@ -459,6 +461,29 @@ describe('WorkflowService.runPendingCommit — worker entry point', () => {
     expect(emitSpy.mock.calls.map((c) => (c[0] as { kind: string }).kind)).toEqual([
       'git-sync-failed',
     ]);
+  });
+
+  it('a rebase CONFLICT on the recovery path raises the banner WITH its files, like the remote sync does', async () => {
+    // The banner keeps the latest failure per branch. The remote sync raises
+    // the conflict variant (files as links); if this path then raised the
+    // generic variant for the same conflict, the retry would take the links
+    // away — seen on staging. Every path names the files.
+    const git = makeGit({
+      commitFile: null,
+      hasUnpushedCommits: true,
+      pushBehavior: 'nff',
+      pullBehavior: 'conflict',
+    });
+    const svc = makeFacade(git, makeFileLocks(USER.id), makePending(), events);
+    await expect(svc.runPendingCommit('ws-1', 'feat/x', 'foo.md', USER)).rejects.toBeInstanceOf(
+      PushNeedsAgentResolutionError,
+    );
+    const failed = emitSpy.mock.calls.map((c) => c[0] as Record<string, unknown>).find((e) => e.kind === 'git-sync-failed');
+    expect(failed).toMatchObject({
+      branch: 'feat/x',
+      conflictedPaths: ['foo.md'],
+      reason: syncConflictMessage('feat/x', ['foo.md']),
+    });
   });
 
   it('recovers from non-fast-forward push via pull --rebase + retry, emits file-changed exactly once', async () => {

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -1258,15 +1258,29 @@ export class WorkflowService implements IWorkflowService {
     branch: string,
     err: unknown,
     /**
-     * Set only by a remote-sync conflict: the files a person must reconcile,
-     * and the sentence we composed about them. That sentence is ours (branch
-     * name + repo paths, no git stderr), so it goes out verbatim — the same
-     * string the sync response and the log carry — rather than through the
-     * sanitiser, whose 200-character clip would make the banner disagree
-     * with them.
+     * The files a person must reconcile, and the sentence we composed about
+     * them. That sentence is ours (branch name + repo paths, no git stderr),
+     * so it goes out verbatim — the same string the sync response and the
+     * log carry — rather than through the sanitiser, whose 200-character
+     * clip would make the banner disagree with them. Callers that already
+     * hold the sentence pass it; otherwise it is derived below.
      */
-    conflict?: { paths: string[]; message: string },
+    explicitConflict?: { paths: string[]; message: string },
   ): void {
+    // A rebase conflict is a conflict whichever path ran into it. The remote
+    // sync names its files on purpose; the push-recovery paths (autosave, the
+    // lock release, the queued retries) raise the same banner with the raw
+    // error — and the banner keeps the LATEST failure per branch, so a retry
+    // landing after the sync would replace the conflict variant, with the
+    // files as links, by the generic "check the server logs" one. Seen on
+    // staging: the sync's 409 named the file, the worker's retry a moment
+    // later took the links away. Derive the paths from the error itself so
+    // every path agrees.
+    const conflict =
+      explicitConflict ??
+      (err instanceof PullRebaseConflictError
+        ? { paths: err.conflictedPaths, message: syncConflictMessage(branch, err.conflictedPaths) }
+        : undefined);
     // Same canonicalization as `noteGitSyncOk` — the pair must agree on keys.
     const id = branchForWorkspaceId(workspaceId);
     this.gitSyncFailing.add(id);


### PR DESCRIPTION
Found while testing the remote sync's conflict path on staging (PR #136 follow-up).

The sync's 409 raised the conflict banner with the file as a link. A moment later the queued recovery retried, hit the same rebase conflict, and raised the generic push-failure banner with the raw git error. The banner keeps the latest failure per branch, so the links disappeared and the copy became "an administrator should check the server logs" — for a conflict the author can act on.

`noteGitSyncFailed` now derives the conflicted paths and the sync's sentence from `PullRebaseConflictError` itself, so autosave, lock release, the worker's retries and the sync all raise the same variant. One test on the recovery path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the rebase conflict banner show the conflicted files as links no matter which code path hits the conflict. The remote sync raised the conflict variant, but the recovery paths (autosave, lock release, worker retries) raised the generic banner with the raw git error, and the banner keeps the latest failure per branch — so a retry right after the sync dropped the links.

- `noteGitSyncFailed` now derives the conflicted paths and banner sentence from `PullRebaseConflictError` when no explicit conflict is passed.
- Adds a test covering the recovery path.

<sup>Written for commit c099429764144dbb9da1fdf2f23b165e684fa237. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

