### PR TITLE
A branch the host deleted answers 410 and a screen that says so

### DIFF
--- a/packages/core-backend/src/modules/workflow/git/git.service.ts
+++ b/packages/core-backend/src/modules/workflow/git/git.service.ts
@@ -34,6 +34,7 @@ import {
   ProtectedBranchError,
   PullRebaseConflictError,
   RemoteBranchGoneError,
+  isMissingRemoteBranchFailure,
 } from '../../../shared/domain-errors.js';
 
 const execFileAsync = promisify(execFile);
@@ -1603,7 +1604,7 @@ export class GitService implements IGitService {
       return await this.refreshRemoteBranchRef(cwd, branch);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (/couldn't find remote ref/i.test(msg)) throw new RemoteBranchGoneError(branch);
+      if (isMissingRemoteBranchFailure(msg)) throw new RemoteBranchGoneError(branch);
       throw err;
     }
   }

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.service.missing-branch.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.service.missing-branch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isMissingRemoteBranchFailure } from '../workspace.service.js';
+import { isMissingRemoteBranchFailure } from '../../../shared/domain-errors.js';
 
 /**
  * The one line that decides whether a failed bootstrap is "this branch does

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.service.missing-branch.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.service.missing-branch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isMissingRemoteBranchFailure } from '../workspace.service.js';
+
+/**
+ * The one line that decides whether a failed bootstrap is "this branch does
+ * not exist" (410, the browser says so) or "something is wrong" (500). Git's
+ * two wordings for a missing ref are matched; an unreachable host or a
+ * refused credential must NOT be, or a deployment outage would read as
+ * "your branch is gone".
+ */
+describe('isMissingRemoteBranchFailure', () => {
+  it('recognises both of git’s wordings for a ref origin does not have', () => {
+    expect(
+      isMissingRemoteBranchFailure(
+        "Command failed: git clone -b sync-test/conflict-2 https://[REDACTED]@github.com/x/y.git /w\nfatal: Remote branch sync-test/conflict-2 not found in upstream origin",
+      ),
+    ).toBe(true);
+    expect(isMissingRemoteBranchFailure("fatal: couldn't find remote ref refs/heads/ali/x")).toBe(true);
+  });
+
+  it('does not mistake an unreachable host or a refused credential for a missing branch', () => {
+    expect(
+      isMissingRemoteBranchFailure("fatal: unable to access 'https://github.com/x/y.git/': Could not resolve host: github.com"),
+    ).toBe(false);
+    expect(isMissingRemoteBranchFailure('remote: Invalid username or password.\nfatal: Authentication failed')).toBe(false);
+    expect(isMissingRemoteBranchFailure('fatal: repository not found')).toBe(false);
+  });
+});

--- a/packages/core-backend/src/modules/workspace/workspace.routes.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.routes.ts
@@ -282,6 +282,13 @@ export function createWorkspaceRoutes(
       );
       res.json({ workspace, fileTree });
     } catch (error) {
+      // A typed domain answer — a branch origin no longer has (410), a name
+      // git refuses (400) — is the client's to act on, not a failure of ours;
+      // it keeps its status so the browser can say what happened.
+      if (error instanceof WorkflowDomainError) {
+        sendError(res, error);
+        return;
+      }
       // Log the full stack so the next 500 isn't a guessing game — the
       // bare `error.message` we returned before lost most diagnostic
       // signal (cause chain, stack frames, error class).

--- a/packages/core-backend/src/modules/workspace/workspace.service.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.service.ts
@@ -7,7 +7,7 @@ import type { AuthUser, IWorkspaceService, WorkspaceInfo, FileTreeEntry } from '
 import { assertValidRelativePath, validateFilename, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { BevelIgnoreStack } from './bevel-ignore.js';
 import { workspaceIdForBranch, branchForWorkspaceId } from '../../shared/workspace-id.js';
-import { WorkflowDomainError } from '../../shared/domain-errors.js';
+import { RemoteBranchGoneError, WorkflowDomainError } from '../../shared/domain-errors.js';
 import { assertValidBranchName } from '../kb-fs/branch-name.js';
 import {
   cloneCredentialArgs,
@@ -100,6 +100,16 @@ const FETCH_CACHE_TTL_MS = 30_000;
  * (it gets a function, not the access module). See `modules/access-model/kb-read-filter.ts`.
  */
 export type ReadTreeFilter = (wsRelPaths: string[]) => Promise<Map<string, boolean>>;
+
+/**
+ * Whether a failed `git clone -b <branch>` failed because origin has no such
+ * branch, as opposed to being unreachable or refusing the credential. Git's
+ * wording for the two shapes: `Remote branch <x> not found in upstream origin`
+ * (clone) and `couldn't find remote ref refs/heads/<x>` (fetch).
+ */
+export function isMissingRemoteBranchFailure(message: string): boolean {
+  return /Remote branch .* not found in upstream|couldn't find remote ref/i.test(message);
+}
 
 export class WorkspaceService implements IWorkspaceService {
   /** Maps branch → absolute directory path. Lazily populated. */
@@ -696,9 +706,18 @@ export class WorkspaceService implements IWorkspaceService {
       }
     } catch (err) {
       const redacted = redactError(err);
-      console.error(`[workspace] Failed to clone for branch "${branch}":`, redacted);
       // Roll back partial state so the next bootstrap retries cleanly.
       await fs.rm(targetDir, { recursive: true, force: true }).catch(() => {});
+      // A branch origin does not have is a fact about the branch, not a
+      // failure of ours: the host deleted it (and the sync retired the
+      // clone), or the link was to a branch that never existed. Typed, so the
+      // routes answer 410 with the branch named and the browser can say "this
+      // branch no longer exists" instead of "something went wrong".
+      if (isMissingRemoteBranchFailure(redacted)) {
+        console.log(`[workspace] branch "${branch}" does not exist on origin — nothing to clone`);
+        throw new RemoteBranchGoneError(branch);
+      }
+      console.error(`[workspace] Failed to clone for branch "${branch}":`, redacted);
       throw new Error(`Failed to clone process map: ${redacted}`);
     }
   }

--- a/packages/core-backend/src/modules/workspace/workspace.service.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.service.ts
@@ -7,7 +7,11 @@ import type { AuthUser, IWorkspaceService, WorkspaceInfo, FileTreeEntry } from '
 import { assertValidRelativePath, validateFilename, DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { BevelIgnoreStack } from './bevel-ignore.js';
 import { workspaceIdForBranch, branchForWorkspaceId } from '../../shared/workspace-id.js';
-import { RemoteBranchGoneError, WorkflowDomainError } from '../../shared/domain-errors.js';
+import {
+  RemoteBranchGoneError,
+  WorkflowDomainError,
+  isMissingRemoteBranchFailure,
+} from '../../shared/domain-errors.js';
 import { assertValidBranchName } from '../kb-fs/branch-name.js';
 import {
   cloneCredentialArgs,
@@ -100,16 +104,6 @@ const FETCH_CACHE_TTL_MS = 30_000;
  * (it gets a function, not the access module). See `modules/access-model/kb-read-filter.ts`.
  */
 export type ReadTreeFilter = (wsRelPaths: string[]) => Promise<Map<string, boolean>>;
-
-/**
- * Whether a failed `git clone -b <branch>` failed because origin has no such
- * branch, as opposed to being unreachable or refusing the credential. Git's
- * wording for the two shapes: `Remote branch <x> not found in upstream origin`
- * (clone) and `couldn't find remote ref refs/heads/<x>` (fetch).
- */
-export function isMissingRemoteBranchFailure(message: string): boolean {
-  return /Remote branch .* not found in upstream|couldn't find remote ref/i.test(message);
-}
 
 export class WorkspaceService implements IWorkspaceService {
   /** Maps branch → absolute directory path. Lazily populated. */

--- a/packages/core-backend/src/shared/domain-errors.ts
+++ b/packages/core-backend/src/shared/domain-errors.ts
@@ -184,6 +184,18 @@ export class RemoteBranchGoneError extends WorkflowDomainError {
 }
 
 /**
+ * Whether a failed clone or fetch failed because origin has no such branch, as
+ * opposed to being unreachable or refusing the credential. Git's wording for
+ * the two shapes: `Remote branch <x> not found in upstream origin` (clone) and
+ * `couldn't find remote ref refs/heads/<x>` (fetch). The ONE classifier for
+ * this fact — the workspace bootstrap and the git layer both consult it, so
+ * a wording learned by one is learned by both.
+ */
+export function isMissingRemoteBranchFailure(message: string): boolean {
+  return /Remote branch .* not found in upstream|couldn't find remote ref/i.test(message);
+}
+
+/**
  * Generic 400 for workflow-input validation (malformed branch names, missing
  * fields, etc.). Carries an optional payload so callers can attach typed
  * discriminators (`kind: '...'`) when the frontend needs to switch on the

--- a/packages/core-frontend/src/modules/workspace/__tests__/testFixtures.ts
+++ b/packages/core-frontend/src/modules/workspace/__tests__/testFixtures.ts
@@ -13,6 +13,7 @@ export function makeWorkspaceFixture(
     workspaceId: 'ws-1',
     kbDirName: 'knowledge-base',
     fileTree: null,
+    bootstrapError: null,
     openTabs: [],
     activeTab: null,
     dirtyTabFilenames: [],

--- a/packages/core-frontend/src/modules/workspace/components/FileRoute.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileRoute.tsx
@@ -330,13 +330,23 @@ export function FileRoute() {
     );
   }
 
-  if (error?.kind === 'branch-gone') {
-    // The branch was deleted on the git host and its clone retired; there
-    // is nothing here to load or to retry. Point at the branch that exists.
+  // The branch was deleted on the git host and its clone retired; there is
+  // nothing here to load or to retry. Two ways to learn it: a file read on a
+  // workspace we already had (410 from the read → `error`), or the bootstrap
+  // of the branch itself failing before there was a workspace at all (410
+  // from `GET /workspace` → `bootstrapError`, matched to THIS branch so a
+  // stale failure from a branch we left cannot paint over the current one).
+  const goneBranch =
+    error?.kind === 'branch-gone'
+      ? error.branch
+      : workspace.bootstrapError?.status === 410 && workspace.bootstrapError.branch === branchFromUrl
+        ? branchFromUrl
+        : null;
+  if (goneBranch !== null) {
     return (
       <ErrorScreen title="This branch no longer exists">
         <p className="text-ui text-ink-muted">
-          <span className="font-mono text-ink">{error.branch}</span> was deleted in the git
+          <span className="font-mono text-ink">{goneBranch}</span> was deleted in the git
           repository. Anything merged from it lives on{' '}
           <span className="font-mono text-ink">{DEFAULT_BRANCH}</span>.
         </p>

--- a/packages/core-frontend/src/modules/workspace/components/FileRoute.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileRoute.tsx
@@ -4,8 +4,10 @@ import { useWorkspace } from '../state/workspace.context';
 import { WorkspaceApiError } from '../services/workspace.api';
 import { useGit } from '../../git/state/git.context';
 import { readPersistedTabs } from '../utils/tab-persistence';
+import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import {
   NODE_ID_LINK_RE,
+  kbFileUrl,
   kbNodeUrl,
   fetchNodeWorkspacePath,
   fetchNodeId,
@@ -16,6 +18,8 @@ import { FileViewer } from './FileViewer';
 type SyncError =
   | { kind: 'dirty'; current: string; target: string; dirtyFilenames: string[] }
   | { kind: 'file-missing'; path: string }
+  /** The branch itself is gone from the repository (deleted on the host). */
+  | { kind: 'branch-gone'; branch: string }
   | { kind: 'file-denied'; path: string }
   | { kind: 'file-load-failed'; path: string; message: string }
   | null;
@@ -201,6 +205,10 @@ export function FileRoute() {
           }
         } catch (err) {
           if (!cancelled) {
+            if (err instanceof WorkspaceApiError && err.status === 410) {
+              setError({ kind: 'branch-gone', branch: branchFromUrl });
+              return;
+            }
             const message = err instanceof Error ? err.message : 'Unknown error';
             setError({ kind: 'file-load-failed', path: pathFromUrl, message });
           }
@@ -221,6 +229,8 @@ export function FileRoute() {
               setError({ kind: 'file-missing', path: pathFromUrl });
             } else if (err instanceof WorkspaceApiError && err.status === 403) {
               setError({ kind: 'file-denied', path: pathFromUrl });
+            } else if (err instanceof WorkspaceApiError && err.status === 410) {
+              setError({ kind: 'branch-gone', branch: branchFromUrl });
             } else {
               const message = err instanceof Error ? err.message : 'Unknown error';
               setError({ kind: 'file-load-failed', path: pathFromUrl, message });
@@ -272,6 +282,8 @@ export function FileRoute() {
         setError({ kind: 'file-missing', path });
       } else if (err instanceof WorkspaceApiError && err.status === 403) {
         setError({ kind: 'file-denied', path });
+      } else if (err instanceof WorkspaceApiError && err.status === 410) {
+        setError({ kind: 'branch-gone', branch: branchFromUrl });
       } else {
         const message = err instanceof Error ? err.message : 'Unknown error';
         setError({ kind: 'file-load-failed', path, message });
@@ -314,6 +326,21 @@ export function FileRoute() {
             </ul>
           </Surface>
         )}
+      </ErrorScreen>
+    );
+  }
+
+  if (error?.kind === 'branch-gone') {
+    // The branch was deleted on the git host and its clone retired; there
+    // is nothing here to load or to retry. Point at the branch that exists.
+    return (
+      <ErrorScreen title="This branch no longer exists">
+        <p className="text-ui text-ink-muted">
+          <span className="font-mono text-ink">{error.branch}</span> was deleted in the git
+          repository. Anything merged from it lives on{' '}
+          <span className="font-mono text-ink">{DEFAULT_BRANCH}</span>.
+        </p>
+        <Button onClick={() => navigate(kbFileUrl(DEFAULT_BRANCH))}>Go to {DEFAULT_BRANCH}</Button>
       </ErrorScreen>
     );
   }

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
@@ -265,6 +265,29 @@ describe('FileRoute', () => {
     expect(screen.getByRole('button', { name: /Go to/ })).toBeInTheDocument();
     expect(screen.queryByText(/Couldn't load this file/i)).not.toBeInTheDocument();
   });
+  it('renders the branch-gone screen when the BOOTSTRAP of the URL branch answered 410', async () => {
+    // No workspace ever came up for this branch: GET /workspace said the
+    // branch is gone. The state surfaces that; the route must not sit waiting.
+    const workspace = makeWorkspace({ bootstrapError: { branch: 'alice/draft', status: 410 } });
+    const git = makeGit({ status: makeStatus('main') });
+
+    renderAt('/workspace/alice%2Fdraft/Knowledge/Foo.md', { git, workspace });
+
+    await waitFor(() => {
+      expect(screen.getByText(/This branch no longer exists/i)).toBeInTheDocument();
+    });
+  });
+
+  it('a stale bootstrap failure from another branch does not paint over this one', async () => {
+    const workspace = makeWorkspace({ bootstrapError: { branch: 'someone/else', status: 410 } });
+    const git = makeGit({ status: makeStatus('alice/draft') });
+
+    renderAt('/workspace/alice%2Fdraft/Knowledge/Foo.md', { git, workspace });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/This branch no longer exists/i)).not.toBeInTheDocument();
+    });
+  });
   it('renders file-load-failed when hydrate throws a non-404 error', async () => {
     const hydrateTabs = vi.fn(async () => {
       throw new WorkspaceApiError(500);

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileRoute.test.tsx
@@ -249,6 +249,22 @@ describe('FileRoute', () => {
     expect(screen.queryByText(/File not found/i)).not.toBeInTheDocument();
   });
 
+  it('renders the branch-gone screen when hydrate answers 410 — the branch was deleted on the host', async () => {
+    const hydrateTabs = vi.fn(async () => {
+      throw new WorkspaceApiError(410);
+    });
+    const workspace = makeWorkspace({ hydrateTabs });
+    const git = makeGit({ status: makeStatus('alice/draft') });
+
+    renderAt('/workspace/alice%2Fdraft/Knowledge/Foo.md', { git, workspace });
+
+    await waitFor(() => {
+      expect(screen.getByText(/This branch no longer exists/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText('alice/draft')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Go to/ })).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load this file/i)).not.toBeInTheDocument();
+  });
   it('renders file-load-failed when hydrate throws a non-404 error', async () => {
     const hydrateTabs = vi.fn(async () => {
       throw new WorkspaceApiError(500);

--- a/packages/core-frontend/src/modules/workspace/components/__tests__/FileViewer.test.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/__tests__/FileViewer.test.tsx
@@ -248,6 +248,7 @@ function ViewerHarness({
     workspaceId: 'ws-1',
     kbDirName,
     fileTree,
+    bootstrapError: null,
     openTabs: tab ? [tab] : [],
     activeTab: tab,
     dirtyTabFilenames: [],

--- a/packages/core-frontend/src/modules/workspace/hooks/useWorkspaceState.ts
+++ b/packages/core-frontend/src/modules/workspace/hooks/useWorkspaceState.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
-import { isProtectedBranch, type FileTreeEntry } from '@bevel-software/platform-shared';
+import { DEFAULT_BRANCH, isProtectedBranch, type FileTreeEntry } from '@bevel-software/platform-shared';
 import { useEventBus, canonicalizeWorkspaceId } from '../../workflow/state/event-bus.context';
 import { AuthContext } from '../../auth/state/auth.context';
 import { fetchFileAccess } from '../../access/api';
@@ -181,8 +181,11 @@ export function useWorkspaceState(): UseWorkspaceStateReturn {
         // Surfaced, not just logged: a bootstrap that fails leaves
         // `workspaceId` where it was, and the route waiting on it needs to
         // know why — a branch the host deleted (410) has its own screen.
+        // No persistence branch means the server bootstrapped the DEFAULT
+        // branch, so that is the branch this failure is about — an empty
+        // name would never match the URL a route is on.
         setBootstrapError({
-          branch: branch ?? '',
+          branch: branch ?? DEFAULT_BRANCH,
           status: err instanceof WorkspaceApiError ? err.status : 0,
         });
       }

--- a/packages/core-frontend/src/modules/workspace/hooks/useWorkspaceState.ts
+++ b/packages/core-frontend/src/modules/workspace/hooks/useWorkspaceState.ts
@@ -99,6 +99,7 @@ interface UseWorkspaceStateReturn extends WorkspaceContextValue {
 
 export function useWorkspaceState(): UseWorkspaceStateReturn {
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [bootstrapError, setBootstrapError] = useState<{ branch: string; status: number } | null>(null);
   const [kbDirName, setKbDirName] = useState<string | null>(null);
   const [fileTree, setFileTree] = useState<FileTreeEntry | null>(null);
   const [openTabs, setOpenTabs] = useState<OpenTab[]>([]);
@@ -173,8 +174,17 @@ export function useWorkspaceState(): UseWorkspaceStateReturn {
         setWorkspaceId(workspace.id);
         setKbDirName(workspace.kbDirName);
         setFileTree(tree);
+        setBootstrapError(null);
       } catch (err) {
-        if (!cancelled) console.error('Failed to bootstrap workspace:', err);
+        if (cancelled) return;
+        console.error('Failed to bootstrap workspace:', err);
+        // Surfaced, not just logged: a bootstrap that fails leaves
+        // `workspaceId` where it was, and the route waiting on it needs to
+        // know why — a branch the host deleted (410) has its own screen.
+        setBootstrapError({
+          branch: branch ?? '',
+          status: err instanceof WorkspaceApiError ? err.status : 0,
+        });
       }
     })();
     return () => { cancelled = true; };
@@ -1371,6 +1381,7 @@ export function useWorkspaceState(): UseWorkspaceStateReturn {
     workspaceId,
     kbDirName,
     fileTree,
+    bootstrapError,
     openTabs,
     activeTab,
     dirtyTabFilenames,
@@ -1412,7 +1423,7 @@ export function useWorkspaceState(): UseWorkspaceStateReturn {
     setPersistenceBranch,
     deleteWorkspace,
   }), [
-    workspaceId, kbDirName, fileTree, openTabs, activeTab, dirtyTabFilenames,
+    workspaceId, kbDirName, fileTree, bootstrapError, openTabs, activeTab, dirtyTabFilenames,
     openFilePath, openFileContent, openFileSavedContent, hasUnsavedFileChanges, pendingFileContent,
     setHasUnsavedFileChanges, setActiveTabContent, fsRevision, uploadError, uploadNotice, clearUploadNotice, isUploading, uploadProgress, pendingUploads, refreshFileTree, bumpFs,
     addTab, closeTab, activateTab, reorderTab, closeAllTabs, hydrateTabs,

--- a/packages/core-frontend/src/modules/workspace/state/workspace.context.ts
+++ b/packages/core-frontend/src/modules/workspace/state/workspace.context.ts
@@ -59,6 +59,14 @@ export interface WorkspaceContextValue {
    */
   kbDirName: string | null;
   fileTree: FileTreeEntry | null;
+  /**
+   * Why the last workspace bootstrap failed, or null. A bootstrap that fails
+   * leaves `workspaceId` on whatever it was, so without this a route could
+   * only wait forever; `status` is the HTTP status the bootstrap answered
+   * (410: the branch no longer exists on the git host), 0 for a transport
+   * failure. Cleared by the next successful bootstrap.
+   */
+  bootstrapError: { branch: string; status: number } | null;
 
   /** All tabs currently open in the editor strip. */
   openTabs: OpenTab[];


### PR DESCRIPTION
Found while testing the remote sync on staging (follow-up to #136 and #149).

After the sync retired the clone of a branch deleted on GitHub, a tab still open on that branch tried to read its file. The lazy bootstrap ran `git clone -b <branch>`, git answered "Remote branch … not found in upstream origin", and that surfaced as a 500: "Something went wrong reading knowledge-base/…" with a Retry that could never succeed.

- `WorkspaceService` now tells git's "no such branch" apart from an unreachable host or a refused credential (pure classifier, unit-tested) and raises the typed `RemoteBranchGoneError`, which the workspace routes already map to its status, 410, with the branch named.
- `FileRoute` renders "This branch no longer exists" for a 410, with a button to the default branch, on the hydrate, navigate and retry paths. One test.

Pre-existing on this branch's base and untouched: the `react-hooks/set-state-in-effect` lint error at the top of `FileRoute`'s effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opening a tab on a branch deleted on the git host used to surface as a 500 with a Retry that could never succeed. It now answers 410 with a "This branch no longer exists" screen and a button to the default branch, whether the failure comes from reading a file on an existing workspace or from bootstrapping a branch that never came up.

- A single classifier in `shared/domain-errors` tells git's "no such branch" apart from an unreachable host or refused credential; the git layer and workspace bootstrap both consult it.
- The bootstrap route keeps a typed domain error's status (410) instead of folding it into a 500, and the failed bootstrap is surfaced on the workspace context keyed by the branch actually bootstrapped (the default branch when none is given), so the route can render the screen.
- Pre-existing on this branch's base and untouched: the `react-hooks/set-state-in-effect` lint error at the top of `FileRoute`'s effect.

<sup>Written for commit 996e3cda1fff70503362f7ad80c3ba942b51aac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

