### PR TITLE
fix(marketplace): compile from the checkout, not from catalogs cached before the commit

### DIFF
--- a/packages/core-backend/src/modules/access/__tests__/access-control.invalidate-race.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.invalidate-race.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../access-control.service.js';
+
+const KB_DIR = 'knowledge-base';
+
+async function writeFile(repo: string, rel: string, contents: string): Promise<void> {
+  const abs = path.join(repo, rel);
+  await fs.mkdir(path.dirname(abs), { recursive: true });
+  await fs.writeFile(abs, contents);
+}
+
+/**
+ * `invalidate()` fires exactly when the tree changes under a model load that
+ * is still reading it: a marketplace compile for one caller drops the caches
+ * while a compile for another caller is mid-load, or a commit lands while the
+ * explorer builds. The load that started on the OLD tree must not store its
+ * model after the drop — otherwise every read for the next TTL resolves
+ * against a tree that is already gone.
+ */
+describe('AccessControlService — a load that straddles invalidate() never repopulates the cache', () => {
+  let root: string;
+  const workspaceId = 'ws-invalidate-race';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-invalidate-race-'));
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('a read that starts after the drop keeps seeing the new tree once the old load lands', async () => {
+    const workspaceDir = path.join(root, workspaceId);
+    const repo = path.join(workspaceDir, KB_DIR);
+    await writeFile(repo, 'roles.yaml', 'roles:\n  Admin:\n    - admin@x.io\n');
+    await writeFile(repo, 'access.md', '---\nwrite:\n  - Admin\n---\n');
+    // Notes is closed to zoe on the old tree.
+    await writeFile(repo, 'Notes/access.md', '---\nread:\n  - Admin\n---\n');
+    await writeFile(repo, 'Notes/plan.md', '# plan\n');
+    const service = new AccessControlService(
+      { getWorkspacePath: async () => workspaceDir } as unknown as WorkspaceService,
+      KB_DIR,
+    );
+
+    // Hold the OLD load exactly where the walk reads Notes/access.md: the
+    // bytes are read now (the closed rules), but the load cannot finish until
+    // released — which is what a slow disk or a large tree does for free.
+    const realReadFile = fs.readFile.bind(fs);
+    let release: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => (release = resolve));
+    let reachedHold: () => void = () => undefined;
+    const reached = new Promise<void>((resolve) => (reachedHold = resolve));
+    let holdOnce = true;
+    vi.spyOn(fs, 'readFile').mockImplementation(async (file, ...rest) => {
+      const result = await (realReadFile as (...a: unknown[]) => Promise<unknown>)(file, ...rest);
+      if (holdOnce && String(file).endsWith(path.join('Notes', 'access.md'))) {
+        holdOnce = false;
+        reachedHold();
+        await held;
+      }
+      return result as never;
+    });
+    const oldLoad = service.canRead(workspaceId, 'zoe@x.io', 'Notes/plan.md');
+    await reached;
+
+    // The tree moves and the caches are dropped while that load is in flight.
+    await writeFile(repo, 'Notes/access.md', '---\nread:\n  - Admin\n  - Zoe <zoe@x.io>\n---\n');
+    service.invalidate(workspaceId);
+    try {
+      await expect(service.canRead(workspaceId, 'zoe@x.io', 'Notes/plan.md')).resolves.toBe(true);
+    } finally {
+      // The old load lands (also on a failed assertion, so the test cannot hang).
+      release();
+    }
+
+    // It answers for the tree it read — closed — but must not become the
+    // cached model for the reads that follow.
+    await expect(oldLoad).resolves.toBe(false);
+    await expect(service.canRead(workspaceId, 'zoe@x.io', 'Notes/plan.md')).resolves.toBe(true);
+  });
+});

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -984,7 +984,23 @@ export class AccessControlService implements IAccessControl {
   invalidate(workspaceId: string): void {
     this.cache.delete(workspaceId);
     this.ownEntriesCache.delete(workspaceId);
+    this.generation.set(workspaceId, (this.generation.get(workspaceId) ?? 0) + 1);
   }
+
+  /**
+   * Per-workspace generation, bumped by every `invalidate()`. A model load
+   * reads the tree across many awaits, and an invalidation fires exactly when
+   * that tree changes underneath it: the load that started on the old tree
+   * would otherwise store its model AFTER the drop, and every read for the
+   * next TTL would resolve against a tree that is already gone. `loadModel`
+   * takes the generation before its first read and refuses to store a model
+   * fetched under an older one — the caller that started it still gets its
+   * answer, as old as the moment it started, and the next caller reloads.
+   * (The own-entries memo needs no token: it is keyed by the map object a
+   * reader took BEFORE its disk read, and `invalidate()` replaces the map, so
+   * a late store lands in an orphan nobody consults.)
+   */
+  private readonly generation = new Map<string, number>();
 
   /** Memoized `readOwnEntries` for the batch paths; see `ownEntriesCache`. */
   private async cachedOwnEntries(
@@ -1496,6 +1512,8 @@ export class AccessControlService implements IAccessControl {
     if (cached && Date.now() - cached.loadedAt < AccessControlService.CACHE_TTL_MS) {
       return cached.model;
     }
+    // Taken before the first read; see `generation`.
+    const generation = this.generation.get(workspaceId) ?? 0;
 
     const repoDir = await this.repoDir(workspaceId);
 
@@ -1587,7 +1605,11 @@ export class AccessControlService implements IAccessControl {
       groupsHealth: activeGroups.health,
       deploymentOwners: this.deploymentOwners,
     };
-    this.cache.set(workspaceId, { model, loadedAt: Date.now() });
+    // An invalidation landed mid-load: this model describes a tree that is
+    // already gone, so it is returned to this caller but never stored.
+    if ((this.generation.get(workspaceId) ?? 0) === generation) {
+      this.cache.set(workspaceId, { model, loadedAt: Date.now() });
+    }
     return model;
   }
 

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -250,6 +250,34 @@ describe('compileMarketplace', () => {
     expect(tree.warnings.some((w) => w.includes('Plugins/Twin') && w.includes('already used'))).toBe(true);
   });
 
+  it('a compile reads the checkout as it is now, not the catalogs a moment ago', async () => {
+    // Warm every cache: the skill catalog, the link index, the access model.
+    const before = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    expect([...before.files.keys()]).not.toContain('skills/late/SKILL.md');
+    expect([...before.files.keys()].some((p) => p.includes('secret'))).toBe(false);
+
+    // Then the knowledge base moves under them, the way an MCP `write_files`
+    // moves it: a new public skill, linked into GTM by its manifest, and a
+    // grant that opens the secret skill — all within every cache's TTL.
+    await write('Skills/Sales/late/SKILL.md', '---\ndescription: Just landed.\n---\n');
+    await write(
+      'Plugins/GTM/plugin.json',
+      JSON.stringify({
+        name: 'gtm',
+        version: '2.1.0',
+        description: 'Go to market',
+        extensions: { 'software.bevel.hexis': { skills: ['Skills/Eng/deploy', 'Skills/Sales/late'] } },
+      }),
+    );
+    await write('Skills/Eng/secret/access.md', '---\n---\nread:\n  - everyone\n');
+
+    const after = await compiler.compileFor({ userEmail: 'sam@x.io' });
+    const paths = [...after.files.keys()];
+    expect(paths).toContain('skills/late/SKILL.md');
+    expect(paths).toContain('plugins/gtm/skills/late/SKILL.md');
+    expect(paths).toContain('skills/secret/SKILL.md');
+  });
+
   it('a name clash inside one plugin keeps the first by path and says so', async () => {
     // A second `deploy` skill, linked from the same plugin via a folder root.
     await write('Skills/Ops/deploy/SKILL.md', '---\ndescription: Ops deploy.\n---\n');

--- a/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
+++ b/packages/core-backend/src/modules/plugins/compile/marketplace-compiler.service.ts
@@ -73,6 +73,19 @@ export class MarketplaceCompilerService {
     // one). A compile of a checkout git cannot describe still yields a
     // correct tree; only its README and bundle version lose the sha.
     const sourceCommit = knownCommit ?? (await this.sourceCommit().catch(() => 'unknown'));
+    // The tree is stamped with the checkout's commit, so every input must be
+    // read from that checkout NOW — not from a catalog scanned before the
+    // commit landed. The skill catalog, the link index and the access memo
+    // are TTL caches that nothing drops on an ordinary write (an MCP
+    // `write_files` moves HEAD and invalidates none of them), and the repo
+    // service keys freshness on the stamped commit: a tree compiled from a
+    // stale catalog under a fresh sha would be "current" until the NEXT
+    // commit, with the caller's marketplace frozen on content the knowledge
+    // base no longer has. Compiles run once per moved commit per caller, so
+    // the rescan is cheap where it matters.
+    this.skillService.invalidate();
+    this.links.invalidate();
+    this.accessControl.invalidate(wsId);
     const skills = await this.skillService.listSkills(undefined);
     const membership = await this.links.membership();
     const { plugins, warnings: discoveryWarnings } = await this.source.discover(kbRoot);


### PR DESCRIPTION
## What

`MarketplaceCompilerService.compileFor` now drops the skill catalog, the link index and the access memo before it reads them, so the tree it stamps with the checkout's commit is compiled from that checkout.

## Why

Found on staging while testing every skill shape end to end (standalone under `Skills/`, linked at depth 1 and depth 4, a linked folder of skills, inline in a plugin). Six skills written over MCP, `claude plugin marketplace update` 30 s later: the compile stamped the new commit but shipped none of them, and every later fetch said "unchanged" because the repo service keys freshness on the stamped commit. The marketplace stayed frozen until the next knowledge-base commit.

Mechanism: the compiler read `listSkills()` through its 60 s TTL cache (`SkillService.invalidate()` had no caller anywhere), the link index through its own, and the access model through its memo. An MCP `write_files` moves HEAD and invalidates none of them. A lag probe on staging showed a new skill reaching the catalog after 65 s, the cache window.

Compiles run once per moved commit per caller, so the rescan is paid exactly where it matters.

## Test

`compile-marketplace.test.ts` — "a compile reads the checkout as it is now, not the catalogs a moment ago": warm every cache with one compile, then add a public skill, link it by manifest, and open a hidden skill with a grant; the second compile must ship all three. Removing any one of the three invalidations fails the test on its own assertion. Full core-backend suite: 192 files, 2304 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes marketplace compiles so the tree stamped with a fresh checkout commit is compiled from that checkout, not from catalogs cached before the commit landed. `compileFor` now invalidates the skill catalog, link index, and access memo before reading, and `AccessControlService` now bumps a per-workspace generation on invalidation so a load that started before a drop never repopulates the cache (which could undo the compiler's invalidation).

- Compiles run once per moved commit per caller, so the rescan stays cheap.
- Adds regression tests: one warms all caches, moves the tree, and expects new skills in the next compile; one holds an old load across an invalidation and confirms the new grant is still seen.

<sup>Written for commit 7a49c653435983f9c378121c40c3e877a77cc1bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

