### PR TITLE
feat(library): the Skills root is a collapsible folder row, not a section heading

### DIFF
--- a/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/SkillsTree.test.tsx
@@ -8,9 +8,10 @@ import { SkillsTree } from '../components/SkillsTree';
 
 /**
  * The Skills section of the Library nav: the shared root as Knowledge's tree
- * rows, headed by a label instead of a root row, with the two things that
- * differ from Knowledge — where a click goes (the skill page, on the default
- * branch) and which row is current (the file the URL names).
+ * rows, the root itself a collapsible folder row like Knowledge and Data in
+ * the explorer, with the two things that differ from Knowledge — where a
+ * click goes (the skill page, on the default branch) and which row is
+ * current (the file the URL names).
  */
 
 const KB = 'knowledge-base';
@@ -61,15 +62,23 @@ function renderTree(url: string, over: Partial<WorkspaceContextValue> = {}) {
 const row = (name: string) => screen.getByRole('button', { name });
 
 describe('SkillsTree', () => {
-  it('heads the scopes with a Skills label and draws no root row', () => {
+  it('draws the root as a folder row, open with its scopes collapsed under it', () => {
     renderTree('/skills-and-tools');
-    expect(screen.getByText('Skills')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Skills' })).not.toBeInTheDocument();
-    // The scopes are the top level, collapsed until opened.
+    expect(row('Skills')).toHaveAttribute('aria-expanded', 'true');
+    // The scopes sit under the root, collapsed until opened.
     expect(row('Engineering')).toBeInTheDocument();
     expect(row('Sales')).toBeInTheDocument();
     expect(screen.queryByText('deploy')).not.toBeInTheDocument();
     expect(screen.queryByText('discovery-call')).not.toBeInTheDocument();
+  });
+
+  it('collapses and reopens like any folder — Knowledge and Data get the same row', () => {
+    renderTree('/skills-and-tools');
+    fireEvent.click(row('Skills'));
+    expect(row('Skills')).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('button', { name: 'Engineering' })).not.toBeInTheDocument();
+    fireEvent.click(row('Skills'));
+    expect(row('Engineering')).toBeInTheDocument();
   });
 
   it('reveals and marks the file the URL names — the Library never sets an open tab', () => {
@@ -92,25 +101,31 @@ describe('SkillsTree', () => {
     );
   });
 
-  it('renders nothing when the tree has no Skills root — no heading over nothing', () => {
+  it('renders nothing when the tree has no Skills root — no folder over nothing', () => {
     const noSkills = dir('.', [dir(KB, [dir(`${KB}/KnowledgeBase`, [])])]);
     renderTree('/skills-and-tools', { fileTree: noSkills });
     expect(screen.queryByText('Skills')).not.toBeInTheDocument();
   });
 
-  it('takes a drop on its heading — the heading is the root row, so it uploads into Skills/', () => {
+  it('takes a drop on the root row, uploading into Skills/', () => {
     const dispatchUpload = vi.fn().mockResolvedValue(undefined);
     renderTree('/skills-and-tools', { dispatchUpload });
     const dropped = new File(['x'], 'notes.md');
-    fireEvent.drop(screen.getByText('Skills'), {
+    fireEvent.drop(row('Skills'), {
       dataTransfer: { getData: () => '', items: undefined, files: [dropped] },
     });
     expect(dispatchUpload).toHaveBeenCalledWith({ kind: 'files', files: [dropped] }, `${KB}/Skills`);
   });
 
-  it("opens the folder's menu on the heading, minus what a reserved root must not do", () => {
+  it('cannot be dragged away — a reserved root stays where the platform put it', () => {
     renderTree('/skills-and-tools');
-    fireEvent.contextMenu(screen.getByText('Skills'));
+    expect(row('Skills').closest('[draggable]')).toHaveAttribute('draggable', 'false');
+    expect(row('Engineering').closest('[draggable]')).toHaveAttribute('draggable', 'true');
+  });
+
+  it("opens the folder's menu on the root row, minus what a reserved root must not do", () => {
+    renderTree('/skills-and-tools');
+    fireEvent.contextMenu(row('Skills'));
     const menu = screen.getByRole('menu', { name: 'Actions for Skills' });
     expect(within(menu).getByRole('menuitem', { name: /New folder/ })).toBeInTheDocument();
     expect(within(menu).getByRole('menuitem', { name: /Manage access/ })).toBeInTheDocument();
@@ -119,15 +134,13 @@ describe('SkillsTree', () => {
     expect(within(menu).queryByRole('menuitem', { name: /Pin/ })).not.toBeInTheDocument();
   });
 
-  it('hands focus back to the heading when its menu closes on Escape', () => {
+  it('hands focus back to the root row when its menu closes on Escape', () => {
     renderTree('/skills-and-tools');
-    const heading = screen.getByText('Skills').closest('div[tabindex]') as HTMLElement;
-    expect(heading).not.toBeNull();
-    fireEvent.contextMenu(screen.getByText('Skills'));
+    fireEvent.contextMenu(row('Skills'));
     screen.getByRole('menu', { name: 'Actions for Skills' });
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('menu', { name: 'Actions for Skills' })).not.toBeInTheDocument();
-    expect(document.activeElement).toBe(heading);
+    expect(document.activeElement).toBe(row('Skills'));
   });
 
   it('keeps a right-click anywhere in the section from reaching the nav behind it', () => {
@@ -142,12 +155,12 @@ describe('SkillsTree', () => {
         </WorkspaceContext.Provider>
       </MemoryRouter>,
     );
-    fireEvent.contextMenu(screen.getByText('Skills'));
+    fireEvent.contextMenu(row('Skills'));
     fireEvent.contextMenu(screen.getByTestId('skills-tree'));
     expect(onNav).not.toHaveBeenCalled();
   });
 
-  it("the heading's New folder button creates a scope directly under the root", () => {
+  it("the root row's New folder button creates a scope directly under the root", () => {
     const createDirectory = vi.fn().mockResolvedValue(undefined);
     renderTree('/skills-and-tools', { createDirectory });
     fireEvent.click(screen.getByRole('button', { name: 'New folder in Skills' }));

--- a/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
+++ b/packages/core-frontend/src/modules/library/components/SkillsTree.tsx
@@ -19,10 +19,12 @@ import {
  * move, drop to upload, the caller's proposed files shown in accent. One tree
  * component in the app, holding a different root.
  *
- * The root's row is drawn as the section's HEADING (`FileTreeNode.heading`),
- * so the heading is a real row: drop files on it to upload into `Skills/`,
- * hover it for the create buttons and the pickers, right-click it for the
- * folder's menu. Its scopes sit directly under it at the nav's own indent.
+ * The root is a collapsible folder row called Skills, exactly as Knowledge
+ * and Data are top-level folders in the Knowledge explorer: open by default
+ * with its scopes collapsed under it, a drop target for uploads into
+ * `Skills/`, the create buttons on hover, the folder's menu on right-click —
+ * minus what a platform-owned root must not offer (`FileTreeNode.reserved`:
+ * no rename, delete, drag or pin).
  *
  * Two things differ from Knowledge, and both are the surroundings' (see
  * `TreeChrome`), not the rows':
@@ -35,8 +37,8 @@ import {
  *    open tab, which the Library never sets.
  *
  * Renders nothing while the tree is loading or when the caller can read no
- * part of the root — an empty "SKILLS" heading over nothing would be a
- * question, not a section.
+ * part of the root — an empty Skills folder would be a question, not a
+ * section.
  */
 export function SkillsTree() {
   const { kbDirName } = useWorkspace();
@@ -64,10 +66,10 @@ export function SkillsTree() {
       {/* A right-click that lands between the tree's rows is the tree's, not
           the plugin nav's behind it: with nothing wired for the gap the
           browser's own menu is the honest answer, as in Knowledge. The rows
-          and the heading stop their own events before reaching here. */}
+          stop their own events before reaching here. */}
       <div data-testid="skills-tree" onContextMenu={(e) => e.stopPropagation()}>
         <UploadNotices />
-        <FileTreeNode entry={root} depth={0} heading="Skills" collapseChildren />
+        <FileTreeNode entry={root} depth={0} reserved collapseChildren />
       </div>
     </TreeChrome>
   );

--- a/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
+++ b/packages/core-frontend/src/modules/workspace/components/FileExplorer.tsx
@@ -201,7 +201,7 @@ function ContextMenu({
   y: number;
   entry: FileTreeEntry;
   isRoot: boolean;
-  /** False for a folder the platform owns (a reserved root drawn as a heading): no Delete. */
+  /** False for a folder the platform owns (a reserved root): no Delete. */
   deletable?: boolean;
   onClose: () => void;
   onCreateFile?: () => void;
@@ -468,8 +468,7 @@ export function FileTreeNode({
   depth,
   initiallyExpanded,
   collapseChildren,
-  heading,
-  outdent = false,
+  reserved = false,
 }: {
   entry: FileTreeEntry;
   depth: number;
@@ -481,26 +480,13 @@ export function FileTreeNode({
   // reveals the ontologies without cascading them all open).
   collapseChildren?: boolean;
   /**
-   * Draw this folder's row as a SECTION HEADING carrying this text, always
-   * open, with its children at the nav's own indent. For a reserved root the
-   * Library heads a section with — "SKILLS" over its scopes, not a folder
-   * row called Skills with the scopes indented under it.
-   *
-   * The heading IS the row, not a label standing in for one: it takes drops,
-   * offers the create buttons and the file/folder pickers, and opens the
-   * folder's menu on right-click — everything the row does, minus what a
-   * reserved root must not do (rename, delete, be dragged, be pinned).
-   * Rendering the label elsewhere and hiding the row here is how a section
-   * ends up without a drop target.
+   * The folder is a root the platform owns (`Skills/` in the Library). It is
+   * an ordinary collapsible folder row — the same row Knowledge and Data get
+   * at the top of the explorer: it takes drops, offers the create buttons,
+   * opens the folder's menu on right-click — minus what a reserved root must
+   * not do: be renamed, deleted, dragged, or pinned.
    */
-  heading?: string;
-  /**
-   * Draw this node's descendants one indent step to the left. Set by a
-   * heading row for its whole subtree: the children keep their LOGICAL depth
-   * (so what starts open and what starts shut is exactly as under a plain
-   * row), but sit where the nav's first level sits.
-   */
-  outdent?: boolean;
+  reserved?: boolean;
 }) {
   const { createFile, createDirectory, dispatchUpload, isUploading, moveEntry, workspaceId, pendingUploads } = useWorkspace();
   const nav = useTreeNav();
@@ -584,7 +570,7 @@ export function FileTreeNode({
   const [dragging, setDragging] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
-  const paddingLeft = indentFor(depth) - (outdent ? 13 : 0);
+  const paddingLeft = indentFor(depth);
   const isRoot = entry.relativePath === '.';
   const isPending = pendingUploads.has(entry.relativePath);
   // A folder with nothing in it doesn't get a caret, because there is nothing
@@ -592,9 +578,6 @@ export function FileTreeNode({
   const hasChildren = (entry.children?.length ?? 0) > 0;
   // Escape inside the context menu hands focus back to the row it came from.
   const rowRef = useRef<HTMLButtonElement>(null);
-  // The heading form of the row is a div, not a button; it is focusable so
-  // Escape in its menu has somewhere to hand focus back to.
-  const headingRef = useRef<HTMLDivElement>(null);
 
   // Auto-expand a directory whenever the open file lives inside it (so
   // deep-link URLs reveal the file's row in the tree) or while files
@@ -617,8 +600,7 @@ export function FileTreeNode({
     }
   }, [autoTrigger]);
 
-  const isHeading = heading !== undefined;
-  const isExpanded = isHeading || (userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2)));
+  const isExpanded = userIntent ?? (autoExpanded || (initiallyExpanded ?? depth < 2));
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -628,11 +610,11 @@ export function FileTreeNode({
 
   // ── Drag source (internal reorder) ──
   const handleDragStart = useCallback((e: React.DragEvent) => {
-    if (isRoot) { e.preventDefault(); return; }
+    if (isRoot || reserved) { e.preventDefault(); return; }
     e.dataTransfer.setData(DRAG_MIME, entry.relativePath);
     e.dataTransfer.effectAllowed = 'move';
     setDragging(true);
-  }, [entry.relativePath, isRoot]);
+  }, [entry.relativePath, isRoot, reserved]);
 
   const handleDragEnd = useCallback(() => {
     setDragging(false);
@@ -700,8 +682,6 @@ export function FileTreeNode({
 
   if (entry.type === 'directory') {
     const dirPath = isRoot ? '' : entry.relativePath;
-    // The verbs a folder row offers, built once so the plain row and the
-    // heading row cannot offer different ones.
     const createButtons = (
       <>
         <IconButton
@@ -773,31 +753,6 @@ export function FileTreeNode({
     );
     return (
       <div>
-        {isHeading ? (
-          // The same heading as the Library's `SectionLabel` and the
-          // explorer's "Company Context" — a heading over a list of places —
-          // that happens to be this folder's row: it takes drops, opens the
-          // folder's menu, and shows the row's verbs on hover.
-          <div
-            ref={headingRef}
-            tabIndex={0}
-            className={cn(
-              'group/label flex items-center gap-1 rounded-sm px-2.5 pb-1.5 pt-5',
-              'focus-visible:outline-2 focus-visible:-outline-offset-1 focus-visible:outline-ink-muted',
-              dragOver && 'bg-hover ring-1 ring-accent/40',
-            )}
-            onDrop={handleDrop}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onContextMenu={handleContextMenu}
-          >
-            <span className="text-label uppercase text-ink-faint">{heading}</span>
-            <span className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/label:opacity-100">
-              {createButtons}
-              {pickerButtons}
-            </span>
-          </div>
-        ) : (
         <div
           className={cn(
             ROW_CLASS,
@@ -806,7 +761,7 @@ export function FileTreeNode({
             dragOver && 'bg-hover text-ink ring-1 ring-accent/40',
           )}
           style={{ paddingLeft, opacity: dragging ? 0.5 : isPending ? 0.6 : 1 }}
-          draggable={!isRoot && !renaming && !isPending}
+          draggable={!isRoot && !reserved && !renaming && !isPending}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
           onDrop={handleDrop}
@@ -853,16 +808,13 @@ export function FileTreeNode({
           </div>
           {isRoot && pickerButtons}
         </div>
-        )}
         {isExpanded && (
           <div>
             {creating && (
               // Line the input up with the child rows it is about to join:
               // one more indent step (13px), plus the caret slot (13px) and
-              // the row gap (6px) the child's name starts after. A heading's
-              // children are outdented a step, so only the slot and the gap
-              // remain.
-              <div style={{ paddingLeft: paddingLeft + (isHeading ? 19 : 32) }} className="px-2 py-0.5">
+              // the row gap (6px) the child's name starts after.
+              <div style={{ paddingLeft: paddingLeft + 32 }} className="px-2 py-0.5">
                 <InlineInput
                   placeholder={creating === 'file' ? 'filename' : 'folder name'}
                   onSubmit={async (name) => {
@@ -896,7 +848,6 @@ export function FileTreeNode({
                 key={child.relativePath}
                 entry={child}
                 depth={depth + 1}
-                outdent={isHeading || outdent}
                 initiallyExpanded={collapseChildren ? false : undefined}
               />
             ))}
@@ -911,11 +862,13 @@ export function FileTreeNode({
             onClose={() => setContextMenu(null)}
             onCreateFile={() => { setUserIntent(true); setCreating('file'); }}
             onCreateFolder={() => { setUserIntent(true); setCreating('directory'); }}
-            // A reserved root drawn as a heading is the platform's: no rename, no delete.
-            onRename={isHeading ? undefined : () => setRenaming(true)}
-            deletable={!isHeading}
+            // A reserved root is the platform's: no rename, no delete. (No pin
+            // either, but that needs no gate: only the Knowledge explorer
+            // offers pinning, and its roots are not reserved.)
+            onRename={reserved ? undefined : () => setRenaming(true)}
+            deletable={!reserved}
             onDownload={handleDownload}
-            returnFocusTo={isHeading ? headingRef : rowRef}
+            returnFocusTo={rowRef}
           />
         )}
       </div>


### PR DESCRIPTION
## What

The Library nav drew the shared `Skills/` root as an uppercase SKILLS label with its scopes outdented beneath it. It is now a top-level folder row exactly like Knowledge and Data in the Knowledge explorer: a caret that opens and closes, the scopes indented under it, open by default with the scopes collapsed.

## How

`FileTreeNode` loses the `heading`/`outdent` mode and gains `reserved`: the same ordinary folder row Knowledge gets, minus what a platform-owned root must not offer (rename, delete, drag). Drops, the create buttons, the folder's menu and Escape-returns-focus work on the row as before. No pin gate is needed: only the Knowledge explorer offers pinning, and its roots are not reserved.

## Test

`SkillsTree.test.tsx` follows the row: open by default, collapses and reopens on click, a drop uploads into `Skills/`, not draggable, menu without Rename/Delete, focus back to the row on Escape, New folder creates a scope under the root. Removing the draggable, rename or delete guard on its own fails a test. Frontend suite: 135 files, 1670 tests, green; `pnpm ds:check` has no regressions (19 fewer flagged classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the Library nav's `Skills/` root from an uppercased SKILLS label with its scopes outdented beneath it to a collapsible folder row, matching Knowledge and Data in the Knowledge explorer. The root opens by default with its scopes collapsed under it, and drop-to-upload, create buttons, the folder menu, and Escape-returns-focus all work on the row as before.

**Refactors**
- `FileTreeNode` replaces the `heading`/`outdent` props with `reserved`, which blocks rename, delete, and drag on a platform-owned root.
- No pin gate is needed: only the Knowledge explorer offers pinning, and its roots aren't reserved.
- Tests assert each guard (drag, rename, delete) and fail if any one is removed.

<sup>Written for commit a9e6bd7dd896e6daf5d7a6b75445cbb56915c623. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

