### PR TITLE
GitHub facade: log why a connect step was refused, GitHub-shaped link tokens, connect-step docs

### DIFF
--- a/.changeset/github-facade-connect-log.md
+++ b/.changeset/github-facade-connect-log.md
@@ -1,0 +1,6 @@
+---
+'@bevel-software/platform-core-backend': patch
+'@bevel-software/platform-core-frontend': patch
+---
+
+The GitHub Enterprise facade says why it refused a step of the connect flow. Claude's servers swallow the answer, so a person who approved on the platform and came back to Claude with no connection had nothing to go on; now every refused authorize, token exchange or API call is a `[github-facade]` line in the server log naming the check that failed, never a secret. Link tokens are spelled the way GitHub spells its own (letters and digits after `gho_`), and the docs and page copy say where the connect step lives: Claude never prompts for it.

--- a/docs/claude-cowork.md
+++ b/docs/claude-cowork.md
@@ -24,23 +24,40 @@ they may read.
 2. In Claude, go to **Admin settings → Claude Code → GitHub Enterprise
    Server** and choose **Add manually**. Paste the fields from step 1. Any
    display name will do.
-3. When Claude asks you to connect your GitHub Enterprise account, you land on
-   the platform's sign-in. Approve, and you are back in Claude.
 
 The webhook URL Claude generates can be ignored. Rotate the credentials from
 the same card if they are ever exposed; the Owner then re-enters them.
 
+Registering connects the platform to your Claude organization, not to any
+person: every person, the Owner included, connects their own account before
+they can add the marketplace.
+
 ## Add the marketplace (every person)
 
-1. Copy the marketplace URL from **External agent access → Marketplaces**.
+1. Connect your account. Claude does not prompt for this, and its
+   **Connect to GitHub** button signs in to github.com, which is not it. Use
+   the connect option for the registered instance in the repository picker on
+   **claude.ai/code**; an Owner also has it in the GitHub Enterprise Server
+   section of the admin settings. You land on the platform's sign-in: approve,
+   and you are back in Claude.
+2. Copy the marketplace URL from **External agent access → Marketplaces**.
    It is the same URL Claude Code clones.
-2. In Cowork (or claude.ai), open **Plugins → Add marketplace** and paste it.
-3. Connect your account when asked. You sign in on the platform and approve.
+3. In Cowork (or claude.ai), open **Plugins → Add marketplace** and paste it.
 4. Install the plugins you want. **Update** in Claude pulls what changed.
 
 Your connection appears under **Marketplaces → Your Claude connections**,
 where you can disconnect it. Disconnecting stops updates; connecting again
-from Claude resumes them.
+from Claude resumes them. "Repository not found" or "GitHub access is
+required" on the marketplace means step 1 has not happened for your account.
+
+## When connecting does not take
+
+Approving on the platform and landing back in Claude proves the browser
+half. Claude's servers then exchange a code with the platform, and Claude
+shows nothing when that exchange is refused. The platform's server log
+does: every refused step is a line starting with `[github-facade]` naming
+the check that failed, such as a client secret that no longer matches the
+registration.
 
 ## Limits
 

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -69,7 +69,7 @@ import {
   DbGitHubFacadeCredentialsStore,
   CLAUDE_CONSUMER,
   GITHUB_LINK_KEY_KIND,
-  GITHUB_LINK_KEY_PREFIX,
+  GITHUB_LINK_KEY_SPEC,
 } from '../modules/marketplace/github-facade/index.js';
 import {
   DbSecretsVaultService,
@@ -703,7 +703,7 @@ export async function createCoreServices(
   // `github-link`): the same key, minted by the marketplace facade below when
   // a person connects an account on claude.ai, told apart by its stored kind.
   const externalApiKeyService = new ExternalApiKeyService(db, config.externalApiKeyPrefix, {
-    [GITHUB_LINK_KEY_KIND]: GITHUB_LINK_KEY_PREFIX,
+    [GITHUB_LINK_KEY_KIND]: GITHUB_LINK_KEY_SPEC,
   });
 
   // The facade that lets products which sync marketplaces only from a GitHub

--- a/packages/core-backend/src/modules/access/synced-groups-writer.ts
+++ b/packages/core-backend/src/modules/access/synced-groups-writer.ts
@@ -6,6 +6,7 @@ import {
   RESERVED_ROLE_NAMES,
 } from '../access-model/access-grammar.js';
 import { unsafeNameReason } from '../access-model/group-files.js';
+import { printable } from '../../shared/printable.js';
 
 /**
  * Locale-independent code-unit comparator. `localeCompare` would make the
@@ -117,18 +118,8 @@ export function renderSyncedGroupsYaml(groups: SyncedGroupRecord[]): RenderedSyn
   });
 
   // Group names are UNTRUSTED IdP input and flow into warnings that land in
-  // logs — JSON.stringify them so a name carrying control characters (ANSI
-  // escapes, newlines) is rendered escaped instead of verbatim into the log
-  // stream (a newline-bearing name could otherwise forge whole log lines).
-  // JSON.stringify only escapes C0 controls (U+0000–U+001F) plus quote and
-  // backslash: C1 controls (U+007F–U+009F — including U+009B, the one-byte
-  // CSI that starts ANSI sequences on its own) and the JS line separators
-  // U+2028/U+2029 pass through raw, so escape those ourselves.
-  const printable = (name: string): string =>
-    JSON.stringify(name).replace(
-      /[\u007F-\u009F\u2028\u2029]/g,
-      (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`,
-    );
+  // logs — rendered `printable`, so a name carrying newlines or ANSI escapes
+  // cannot forge a log line.
   for (const group of sorted) {
     const reason = unsafeNameReason(group.displayName);
     if (reason) {

--- a/packages/core-backend/src/modules/marketplace/__tests__/github-facade.test.ts
+++ b/packages/core-backend/src/modules/marketplace/__tests__/github-facade.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -234,6 +234,38 @@ describe('the GitHub facade', () => {
     expect(minted.user.id).toBe('user-alice');
     expect(minted.kind).toBe(GITHUB_LINK_KEY_KIND);
     expect(minted.label).toBe(CLAUDE_CONSUMER.keyLabel);
+  });
+
+  it('logs every refused hop of the connect flow with the check that failed, never the secret or the code', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const creds = await a.credentials.ensure();
+      const code = await approve(a.base, 'alice');
+
+      const wrongSecret = await exchange(b.base, { client_id: creds.clientId, client_secret: 'not-it', code });
+      expect(wrongSecret.status).toBe(401);
+      const staleCode = await exchange(b.base, { client_id: creds.clientId, client_secret: creds.clientSecret, code: 'never-issued' });
+      expect(staleCode.status).toBe(400);
+      const badClient = await fetch(
+        `${a.base}/login/oauth/authorize?client_id=Iv1.0000&redirect_uri=${encodeURIComponent(CALLBACK)}`,
+        { redirect: 'manual' },
+      );
+      expect(badClient.status).toBe(400);
+
+      const lines = warn.mock.calls.map((c) => String(c[0]));
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toMatch(/token exchange refused \(401 incorrect_client_credentials\): client_secret is not the registered one/);
+      expect(lines[1]).toMatch(/token exchange refused \(400 bad_verification_code\): no live code/);
+      expect(lines[2]).toMatch(/authorize refused \(400 unknown_client\): client_id is not the registered one/);
+      for (const line of lines) {
+        expect(line).not.toContain(creds.clientSecret);
+        expect(line).not.toContain('not-it');
+        expect(line).not.toContain(code);
+        expect(line).not.toContain('never-issued');
+      }
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('serves the repository, the head commit and the zipball of that person’s own tree — from the origin, never the configured userinfo', async () => {

--- a/packages/core-backend/src/modules/marketplace/__tests__/github-facade.test.ts
+++ b/packages/core-backend/src/modules/marketplace/__tests__/github-facade.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import http from 'node:http';
+import net from 'node:net';
 import { randomBytes } from 'node:crypto';
 import express from 'express';
 import type { AuthUser } from '@bevel-software/platform-shared';
@@ -75,6 +76,23 @@ function makeKeys() {
       };
     },
   };
+}
+
+/** An HTTP/1.1 request written byte for byte (Latin-1), answering with its status code. */
+function rawRequest(base: string, headLines: string[], body = ''): Promise<number> {
+  const { hostname, port } = new URL(base);
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(Number(port), hostname, () => {
+      socket.write(Buffer.from([...headLines, `Host: ${hostname}`, 'Connection: close', '', body].join('\r\n'), 'latin1'));
+    });
+    let received = '';
+    socket.setEncoding('latin1');
+    socket.on('data', (chunk: string) => {
+      received += chunk;
+    });
+    socket.on('end', () => resolve(Number(received.split(' ')[1])));
+    socket.on('error', reject);
+  });
 }
 
 /** One replica: its own bridge over the SHARED stores, its own HTTP listener. */
@@ -262,6 +280,39 @@ describe('the GitHub facade', () => {
         expect(line).not.toContain('not-it');
         expect(line).not.toContain(code);
         expect(line).not.toContain('never-issued');
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps the log to one line per event whatever bytes the caller puts in its headers', async () => {
+    // Node's parser already refuses C0 controls and bare CR/LF in a header
+    // value. What it lets through is obs-text — bytes 0x80–0xFF, read as
+    // Latin-1 — and that includes U+009B, the one-byte CSI that starts an
+    // ANSI sequence on its own and that JSON.stringify leaves raw. It goes
+    // over a bare socket: a fetch client refuses to build such a header.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const csi = String.fromCharCode(0x9b);
+      const creds = await a.credentials.ensure();
+      const body = JSON.stringify({ client_id: creds.clientId, client_secret: 'not-it', code: 'x' });
+      const exchange = await rawRequest(b.base, [
+        'POST /login/oauth/access_token HTTP/1.1',
+        `User-Agent: httpx${csi}[31mforged`,
+        'Content-Type: application/json',
+        'Accept: application/vnd.github+json',
+        `Content-Length: ${Buffer.byteLength(body)}`,
+      ], body);
+      expect(exchange).toBe(401);
+      const api = await rawRequest(b.base, ['GET /api/v3/repos/git/marketplace HTTP/1.1', `User-Agent: httpx${csi}[31mforged`]);
+      expect(api).toBe(401);
+
+      const lines = warn.mock.calls.map((c) => String(c[0]));
+      expect(lines).toHaveLength(2);
+      for (const line of lines) {
+        expect(line.includes(csi)).toBe(false);
+        expect(line).toContain('"httpx\\u009b[31mforged"');
       }
     } finally {
       warn.mockRestore();

--- a/packages/core-backend/src/modules/marketplace/github-facade/github-facade.routes.ts
+++ b/packages/core-backend/src/modules/marketplace/github-facade/github-facade.routes.ts
@@ -52,10 +52,21 @@ export function createGitHubFacadeRoutes(deps: GitHubFacadeRoutesDeps): express.
   const origin = new URL(deps.publicUrl).origin;
   const fullName = `${owner}/${repoName}`;
 
+  // Every refusal on the connect flow is logged with its reason: the
+  // consumer's backend swallows our answer, so a person who "connected and
+  // came back to Claude" with nothing to show for it has only this log to
+  // say which hop failed. Reasons name a check, never a secret or a code.
+  const refused = (req: express.Request, hop: string, err: GitHubFacadeRequestError) => {
+    console.warn(
+      `[github-facade] ${hop} refused (${err.status} ${err.code}): ${err.detail} — from ${req.headers['user-agent'] ?? 'no user-agent'}`,
+    );
+  };
+
   router.get('/login/oauth/authorize', async (req, res) => {
     try {
       res.redirect(302, await facade.authorizeRedirect(req.query as Record<string, unknown>));
     } catch (err) {
+      if (err instanceof GitHubFacadeRequestError) refused(req, 'authorize', err);
       answerError(res, err);
     }
   });
@@ -72,6 +83,7 @@ export function createGitHubFacadeRoutes(deps: GitHubFacadeRoutesDeps): express.
         negotiated(req, res, 200, await facade.exchangeCode((req.body ?? {}) as Record<string, unknown>));
       } catch (err) {
         if (err instanceof GitHubFacadeRequestError) {
+          refused(req, 'token exchange', err);
           negotiated(req, res, err.status, { error: err.code, error_description: err.message });
           return;
         }
@@ -87,7 +99,7 @@ export function createGitHubFacadeRoutes(deps: GitHubFacadeRoutesDeps): express.
   api.use(async (req, res, next) => {
     const token = bearerOf(req);
     if (!token || !keys.looksLikeExternalApiKey(token)) {
-      unauthorized(res);
+      unauthorized(req, res, token ? 'bearer is not a connection key' : 'no bearer');
       return;
     }
     let resolved: { tokenId: string; user: AuthUser } | null;
@@ -99,7 +111,7 @@ export function createGitHubFacadeRoutes(deps: GitHubFacadeRoutesDeps): express.
       return;
     }
     if (!resolved) {
-      unauthorized(res);
+      unauthorized(req, res, 'connection key unknown or revoked');
       return;
     }
     req.userId = resolved.user.id;
@@ -188,7 +200,9 @@ function bearerOf(req: express.Request): string | null {
   return rest.join(' ').trim() || null;
 }
 
-function unauthorized(res: express.Response): void {
+/** GitHub's 401 — and a log line saying why, since the consumer's backend will not. */
+function unauthorized(req: express.Request, res: express.Response, why: string): void {
+  console.warn(`[github-facade] ${req.method} ${req.originalUrl} refused: ${why} — from ${req.headers['user-agent'] ?? 'no user-agent'}`);
   res.setHeader('WWW-Authenticate', 'Bearer realm="hexis-marketplace"');
   res.status(401).json({ message: 'Bad credentials' });
 }

--- a/packages/core-backend/src/modules/marketplace/github-facade/github-facade.routes.ts
+++ b/packages/core-backend/src/modules/marketplace/github-facade/github-facade.routes.ts
@@ -5,6 +5,7 @@ import '../../tool-auth/external-api-key.interface.js'; // Express Request augme
 import type { MarketplaceRepoService } from '../marketplace-repo.service.js';
 import type { MarketplaceKeyResolver } from '../git-http.routes.js';
 import { GitHubFacadeRequestError, type GitHubFacade } from './github-facade.service.js';
+import { printable } from '../../../shared/printable.js';
 
 export interface GitHubFacadeRoutesDeps {
   facade: GitHubFacade;
@@ -55,11 +56,11 @@ export function createGitHubFacadeRoutes(deps: GitHubFacadeRoutesDeps): express.
   // Every refusal on the connect flow is logged with its reason: the
   // consumer's backend swallows our answer, so a person who "connected and
   // came back to Claude" with nothing to show for it has only this log to
-  // say which hop failed. Reasons name a check, never a secret or a code.
+  // say which hop failed. Reasons name a check, never a secret or a code;
+  // what the caller sent (its user agent) is rendered printable, so the
+  // caller cannot write a line of its own.
   const refused = (req: express.Request, hop: string, err: GitHubFacadeRequestError) => {
-    console.warn(
-      `[github-facade] ${hop} refused (${err.status} ${err.code}): ${err.detail} — from ${req.headers['user-agent'] ?? 'no user-agent'}`,
-    );
+    console.warn(`[github-facade] ${hop} refused (${err.status} ${err.code}): ${err.detail} — from ${userAgentOf(req)}`);
   };
 
   router.get('/login/oauth/authorize', async (req, res) => {
@@ -202,9 +203,15 @@ function bearerOf(req: express.Request): string | null {
 
 /** GitHub's 401 — and a log line saying why, since the consumer's backend will not. */
 function unauthorized(req: express.Request, res: express.Response, why: string): void {
-  console.warn(`[github-facade] ${req.method} ${req.originalUrl} refused: ${why} — from ${req.headers['user-agent'] ?? 'no user-agent'}`);
+  console.warn(`[github-facade] ${req.method} ${printable(req.originalUrl)} refused: ${why} — from ${userAgentOf(req)}`);
   res.setHeader('WWW-Authenticate', 'Bearer realm="hexis-marketplace"');
   res.status(401).json({ message: 'Bad credentials' });
+}
+
+/** The caller's user agent as one printable token — it is theirs to fill with anything. */
+function userAgentOf(req: express.Request): string {
+  const ua = req.headers['user-agent'];
+  return ua ? printable(ua) : 'no user-agent';
 }
 
 /** The token endpoint's reply, in the encoding the client asked for. */

--- a/packages/core-backend/src/modules/marketplace/github-facade/github-facade.service.ts
+++ b/packages/core-backend/src/modules/marketplace/github-facade/github-facade.service.ts
@@ -3,6 +3,7 @@ import type { KeyKindSpec, MintedExternalApiKey } from '../../tool-auth/external
 import { signAuthRequest, type McpAuthRequestState } from '../../mcp/oauth/oauth-state.js';
 import type { GitHubFacadeCredentialsService } from './github-facade-credentials.service.js';
 import type { GitHubFacadeCodeStore } from './github-facade-codes.store.js';
+import { printable } from '../../../shared/printable.js';
 
 /**
  * The KIND stored on a connection key minted through the facade, and how
@@ -252,10 +253,16 @@ function hashCode(code: string): string {
   return createHash('sha256').update(code).digest('hex');
 }
 
-/** The host of a URL for a log line, or what was sent when it is not one. */
+/**
+ * The host of a URL for a log line, or what was sent when it is not one.
+ * The caller chose the URL, so the host is rendered printable even though a
+ * parsed host is ASCII: the log's one-line rule holds by construction, not
+ * by an argument about URL parsing.
+ */
 function hostOf(url: string): string {
   try {
-    return new URL(url).host || '(empty)';
+    const host = new URL(url).host;
+    return host ? printable(host) : '(empty)';
   } catch {
     return url ? '(not a URL)' : '(empty)';
   }

--- a/packages/core-backend/src/modules/marketplace/github-facade/github-facade.service.ts
+++ b/packages/core-backend/src/modules/marketplace/github-facade/github-facade.service.ts
@@ -1,20 +1,22 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
-import type { MintedExternalApiKey } from '../../tool-auth/external-api-key.interface.js';
+import type { KeyKindSpec, MintedExternalApiKey } from '../../tool-auth/external-api-key.interface.js';
 import { signAuthRequest, type McpAuthRequestState } from '../../mcp/oauth/oauth-state.js';
 import type { GitHubFacadeCredentialsService } from './github-facade-credentials.service.js';
 import type { GitHubFacadeCodeStore } from './github-facade-codes.store.js';
 
 /**
- * The KIND stored on a connection key minted through the facade, and the
- * plaintext prefix that kind is minted with. `gho_` is what a GitHub OAuth
- * token looks like — the shape a consumer expecting a GitHub Enterprise host
- * accepts; the key is otherwise an ordinary connection key — hashed at rest,
- * revocable from the person's external-agent page, accepted by every surface
- * a connection key is. The kind, not the label, is what tells such a key
- * apart: a label is the person's to edit.
+ * The KIND stored on a connection key minted through the facade, and how
+ * that kind is spelled. `gho_` plus forty letters and digits is what a
+ * GitHub OAuth token looks like — the shape a consumer expecting a GitHub
+ * Enterprise host accepts, and may well check; the key is otherwise an
+ * ordinary connection key — hashed at rest, revocable from the person's
+ * external-agent page, accepted by every surface a connection key is. The
+ * kind, not the label, is what tells such a key apart: a label is the
+ * person's to edit.
  */
 export const GITHUB_LINK_KEY_KIND = 'github-link';
 export const GITHUB_LINK_KEY_PREFIX = 'gho_';
+export const GITHUB_LINK_KEY_SPEC: KeyKindSpec = { prefix: GITHUB_LINK_KEY_PREFIX, shape: 'github-token' };
 
 /**
  * A product that talks to this deployment as if it were a GitHub Enterprise
@@ -62,11 +64,21 @@ export interface GitHubFacadeDeps {
   publicFrontendUrl: string;
 }
 
+/**
+ * A refusal the caller is answered with in GitHub's terms — and, for the
+ * server log only, WHY: `detail` names the check that failed (a client
+ * secret that is not the registered one, a code nobody issued) where the
+ * response deliberately says no more than GitHub would. A consumer's
+ * backend never shows its user what we answered; the log is the only place
+ * an operator can see which hop of the connect flow went wrong. It never
+ * carries a secret or a code.
+ */
 export class GitHubFacadeRequestError extends Error {
   constructor(
     readonly status: number,
     readonly code: string,
     message: string,
+    readonly detail: string = message,
   ) {
     super(message);
     this.name = 'GitHubFacadeRequestError';
@@ -103,10 +115,20 @@ export class GitHubFacade {
     const state = str(query.state);
     const creds = await this.deps.credentials.ensure();
     if (!clientId || !safeEqual(clientId, creds.clientId)) {
-      throw new GitHubFacadeRequestError(400, 'unknown_client', 'Unknown client_id.');
+      throw new GitHubFacadeRequestError(
+        400,
+        'unknown_client',
+        'Unknown client_id.',
+        clientId ? 'client_id is not the registered one (rotated since, or mistyped)' : 'no client_id in the request',
+      );
     }
     if (!this.consumerFor(redirectUri)) {
-      throw new GitHubFacadeRequestError(400, 'invalid_redirect', 'redirect_uri does not belong to a known consumer.');
+      throw new GitHubFacadeRequestError(
+        400,
+        'invalid_redirect',
+        'redirect_uri does not belong to a known consumer.',
+        `redirect_uri host is ${hostOf(redirectUri)}, not a consumer's`,
+      );
     }
     const signed = signAuthRequest(this.deps.stateSecret, {
       c: clientId,
@@ -169,27 +191,47 @@ export class GitHubFacade {
     const clientId = str(body.client_id);
     const clientSecret = str(body.client_secret);
     const code = str(body.code);
-    if (!clientId || !clientSecret || !safeEqual(clientId, creds.clientId) || !safeEqual(clientSecret, creds.clientSecret)) {
-      throw new GitHubFacadeRequestError(401, 'incorrect_client_credentials', 'The client_id and/or client_secret passed are incorrect.');
+    // One answer for every credential failure, as GitHub gives; the log
+    // alone says which half was wrong.
+    const credentialsWrong = (detail: string) =>
+      new GitHubFacadeRequestError(
+        401,
+        'incorrect_client_credentials',
+        'The client_id and/or client_secret passed are incorrect.',
+        detail,
+      );
+    if (!clientId || !safeEqual(clientId, creds.clientId)) {
+      throw credentialsWrong(clientId ? 'client_id is not the registered one (rotated since, or mistyped)' : 'no client_id in the request');
     }
-    const pending = code ? await this.deps.codes.peek(hashCode(code)) : null;
-    if (!pending || pending.clientId !== clientId) {
-      throw new GitHubFacadeRequestError(400, 'bad_verification_code', 'The code passed is incorrect or expired.');
+    if (!clientSecret || !safeEqual(clientSecret, creds.clientSecret)) {
+      throw credentialsWrong(clientSecret ? 'client_secret is not the registered one (rotated since, or mistyped)' : 'no client_secret in the request');
     }
+    const codeWrong = (detail: string) =>
+      new GitHubFacadeRequestError(400, 'bad_verification_code', 'The code passed is incorrect or expired.', detail);
+    if (!code) throw codeWrong('no code in the request');
+    const pending = await this.deps.codes.peek(hashCode(code));
+    if (!pending) throw codeWrong('no live code with that value: never issued, already spent, or older than 10 minutes');
+    if (pending.clientId !== clientId) throw codeWrong('the code was issued under a different client id');
     const redirectUri = str(body.redirect_uri);
     if (redirectUri && redirectUri !== pending.redirectUri) {
-      throw new GitHubFacadeRequestError(400, 'redirect_uri_mismatch', 'The redirect_uri does not match the authorization.');
+      throw new GitHubFacadeRequestError(
+        400,
+        'redirect_uri_mismatch',
+        'The redirect_uri does not match the authorization.',
+        `redirect_uri host is ${hostOf(redirectUri)}, the code was issued for ${hostOf(pending.redirectUri)}`,
+      );
     }
     const spent = await this.deps.codes.consume(pending.codeHash);
-    if (!spent) {
-      throw new GitHubFacadeRequestError(400, 'bad_verification_code', 'The code passed is incorrect or expired.');
-    }
+    if (!spent) throw codeWrong('the code was spent by a concurrent exchange');
     // The consumer is the one the code was issued for — the redirect the
     // person approved names it — so the key is labelled for that product.
     const consumer = this.consumerFor(spent.redirectUri);
     const minted = await this.deps.keys.mint(spent.userId, consumer?.keyLabel ?? 'GitHub-compatible link', {
       kind: GITHUB_LINK_KEY_KIND,
     });
+    console.info(
+      `[github-facade] ${consumer?.name ?? 'a consumer'} connected user ${spent.userId}: link key ${minted.summary.id} minted`,
+    );
     return { access_token: minted.plaintext, token_type: 'bearer', scope: '' };
   }
 
@@ -208,6 +250,15 @@ export class GitHubFacade {
 
 function hashCode(code: string): string {
   return createHash('sha256').update(code).digest('hex');
+}
+
+/** The host of a URL for a log line, or what was sent when it is not one. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host || '(empty)';
+  } catch {
+    return url ? '(not a URL)' : '(empty)';
+  }
 }
 
 function str(v: unknown): string {

--- a/packages/core-backend/src/modules/marketplace/github-facade/index.ts
+++ b/packages/core-backend/src/modules/marketplace/github-facade/index.ts
@@ -17,6 +17,7 @@ export {
   GitHubFacadeRequestError,
   GITHUB_LINK_KEY_KIND,
   GITHUB_LINK_KEY_PREFIX,
+  GITHUB_LINK_KEY_SPEC,
   CLAUDE_CONSUMER,
   type GitHubFacadeConsumer,
   type GitHubFacadeDeps,

--- a/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
@@ -140,6 +140,21 @@ describe('ExternalApiKeyService', () => {
       });
     });
 
+    it('mints a kind that asks for a GitHub-shaped token as prefix plus forty letters and digits', async () => {
+      const { db, calls } = makeFakeDb([[makeRow()]]);
+      const service = new ExternalApiKeyService(db, 'bevel_', {
+        'github-link': { prefix: 'gho_', shape: 'github-token' },
+      });
+
+      const result = await service.mint('user-1', 'Claude', { kind: 'github-link' });
+
+      // GitHub's own tokens are alphanumeric after the prefix; a consumer
+      // that checks the shape must keep ours.
+      expect(result.plaintext).toMatch(/^gho_[A-Za-z0-9]{40}$/);
+      expect(service.looksLikeExternalApiKey(result.plaintext)).toBe(true);
+      expect(calls.values[0][0].tokenHash).toBe(sha256Hex(result.plaintext));
+    });
+
     it('trims the label before persisting', async () => {
       const { db, calls } = makeFakeDb([[makeRow()]]);
       const service = new ExternalApiKeyService(db, 'bevel_');

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
@@ -47,10 +47,25 @@ export interface MintedExternalApiKey {
 export const DEFAULT_KEY_KIND = 'key';
 
 /**
+ * How the plaintext of one kind of key is spelled: the prefix the outside
+ * world sees (and that routes the bearer back here), and the shape of the
+ * random part after it. `base64url` is the platform's own — 43 characters
+ * from a 32-byte draw. `github-token` is what a GitHub OAuth token looks
+ * like after its `gho_`: letters and digits only, 40 of them, so a consumer
+ * that validates the shape of a GitHub token (they are documented as
+ * alphanumeric) keeps it. Both hash the same way; the shape is only what a
+ * client is shown.
+ */
+export interface KeyKindSpec {
+  prefix: string;
+  shape?: 'base64url' | 'github-token';
+}
+
+/**
  * How a key is minted. `kind` names one of the kinds the service was built
- * with, each of which carries its own plaintext prefix (the tenant's for the
- * default kind, `gho_` for a Claude link); an unknown kind is refused, since
- * nothing would route its bearer back.
+ * with, each of which carries its own spelling (the tenant's prefix for the
+ * default kind, a GitHub-shaped token for a Claude link); an unknown kind is
+ * refused, since nothing would route its bearer back.
  */
 export interface MintOptions {
   kind?: string;

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.service.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.service.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_KEY_KIND,
   type ExternalApiKeySummary,
   type IExternalApiKeyService,
+  type KeyKindSpec,
   type MintOptions,
   type MintedExternalApiKey,
 } from './external-api-key.interface.js';
@@ -21,6 +22,9 @@ import {
 // brute force, cheap to copy. The prefix lets the auth middleware route
 // key-vs-JWT requests without parsing both shapes.
 const TOKEN_BYTES = 32;
+// A GitHub-shaped token: 20 random bytes as 40 hex digits — alphanumeric,
+// as GitHub's own are, and 160 bits, which a hash lookup never exhausts.
+const GITHUB_TOKEN_BYTES = 20;
 
 const MAX_LABEL_LEN = 200;
 
@@ -31,19 +35,19 @@ export class ExternalApiKeyService implements IExternalApiKeyService {
    * @param keyPrefix Tenant-derived plaintext prefix (e.g. `bevel_`) — injected
    *   from {@link AppConfig.externalApiKeyPrefix} so a deploy can brand its keys.
    *   Every key of the default kind is minted with it.
-   * @param kinds Other kinds a key may be minted as, each with the plaintext
-   *   prefix that kind is spelled with — a Claude link's `gho_`, the shape
-   *   claude.ai expects from a GitHub host. Same key, same table, same
+   * @param kinds Other kinds a key may be minted as, each with the spelling
+   *   that kind has — a Claude link's `gho_` and GitHub's alphabet, the
+   *   shape claude.ai expects from a GitHub host. Same key, same table, same
    *   revocation; the KIND is stored on the row and is what tells such keys
-   *   apart (a label is the person's to edit), the prefix is only what the
+   *   apart (a label is the person's to edit), the spelling is only what the
    *   outside world sees and what routes the bearer back here.
    */
   constructor(
     private readonly db: Database,
     private readonly keyPrefix: string,
-    private readonly kinds: Readonly<Record<string, string>> = {},
+    private readonly kinds: Readonly<Record<string, KeyKindSpec>> = {},
   ) {
-    this.prefixes = [keyPrefix, ...Object.values(kinds)];
+    this.prefixes = [keyPrefix, ...Object.values(kinds).map((k) => k.prefix)];
   }
 
   /** True if a bearer string carries one of this service's key prefixes. */
@@ -53,8 +57,8 @@ export class ExternalApiKeyService implements IExternalApiKeyService {
 
   async mint(userId: string, label: string, options: MintOptions = {}): Promise<MintedExternalApiKey> {
     const kind = options.kind ?? DEFAULT_KEY_KIND;
-    const prefix = kind === DEFAULT_KEY_KIND ? this.keyPrefix : this.kinds[kind];
-    if (!prefix) throw new Error(`Unknown key kind "${kind}"`);
+    const spec: KeyKindSpec | undefined = kind === DEFAULT_KEY_KIND ? { prefix: this.keyPrefix } : this.kinds[kind];
+    if (!spec) throw new Error(`Unknown key kind "${kind}"`);
     const trimmed = (label ?? '').trim();
     if (trimmed.length === 0) {
       throw new InvalidTokenLabelError('Label cannot be empty');
@@ -65,7 +69,11 @@ export class ExternalApiKeyService implements IExternalApiKeyService {
       );
     }
 
-    const plaintext = prefix + randomBytes(TOKEN_BYTES).toString('base64url');
+    const random =
+      spec.shape === 'github-token'
+        ? randomBytes(GITHUB_TOKEN_BYTES).toString('hex')
+        : randomBytes(TOKEN_BYTES).toString('base64url');
+    const plaintext = spec.prefix + random;
     const tokenHash = hashToken(plaintext);
 
     const [row] = await this.db

--- a/packages/core-backend/src/shared/printable.ts
+++ b/packages/core-backend/src/shared/printable.ts
@@ -1,0 +1,23 @@
+/**
+ * Untrusted text, rendered so it cannot forge or colour a log line.
+ *
+ * Anything a caller controls — a request header, a URL, a name from an
+ * identity provider — may carry newlines or ANSI escapes, and interpolated
+ * verbatim it would start a line of its own in the operator log, or paint
+ * the terminal. `JSON.stringify` escapes the C0 controls (U+0000–U+001F)
+ * plus quote and backslash; the C1 controls (U+007F–U+009F — including
+ * U+009B, the one-byte CSI that starts an ANSI sequence on its own) and the
+ * JS line separators U+2028/U+2029 pass through raw, so those are escaped
+ * here. The result is one quoted token: `"python-httpx/0.28.1"`,
+ * `"evil\n[forged]"`.
+ *
+ * Every log line that carries caller-supplied text goes through this, and
+ * only this: the rule "the log is one line per event" is enforced at the
+ * one place text enters a line, not by each call site remembering.
+ */
+export function printable(text: string): string {
+  return JSON.stringify(text).replace(
+    /[\x7F-\x9F\u{2028}\u{2029}]/gu,
+    (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+}

--- a/packages/core-frontend/src/modules/settings/components/ClaudeConnectionCard.tsx
+++ b/packages/core-frontend/src/modules/settings/components/ClaudeConnectionCard.tsx
@@ -92,8 +92,9 @@ export function ClaudeConnectionCard() {
           accept marketplaces only from a GitHub Enterprise Server their organization registered.
           Hexis answers as one. Register it once (Owner role, Team or Enterprise plan): in Claude's
           admin settings, under Claude Code, GitHub Enterprise Server, choose <b>Add manually</b>{' '}
-          and paste the fields below. When it asks you to connect your GitHub Enterprise account,
-          you sign in here.
+          and paste the fields below. That connects the deployment to the organization, not to
+          anyone: each person then connects their own account from the same section or from the
+          repository picker on claude.ai/code, and signs in here.
         </p>
       </div>
 

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -355,11 +355,13 @@ export function ExternalAgentAccessPage() {
                   , then every person connects their own account:
                 </p>
                 <ol className="text-meta text-ink-muted leading-snug list-decimal pl-4 space-y-0.5">
-                  <li>In Cowork (or claude.ai), open Plugins → Add marketplace and paste the URL below.</li>
                   <li>
-                    When it asks you to connect your GitHub Enterprise account, you land on this
-                    deployment's sign-in: approve, and you are back in Claude.
+                    Connect your account first; Claude does not prompt for it. In the repository
+                    picker on claude.ai/code, use the connect option for the registered instance
+                    (Owners also have it in the admin settings). You land on this deployment's
+                    sign-in: approve, and you are back in Claude.
                   </li>
+                  <li>In Cowork (or claude.ai), open Plugins → Add marketplace and paste the URL below.</li>
                   <li>Install the plugins you want. Update in Claude pulls what changed.</li>
                 </ol>
                 <CopyBlock label="Marketplace URL" value={marketplaceGitUrl()} rows={2} />


### PR DESCRIPTION
## Why

Razvan registered staging in a Claude Team org, used the connect option, approved on the hexis consent page and landed back in Claude — and no connection appeared on either side. The server log had nothing: the facade answers a refused token exchange with GitHub's terse 4xx and never logged it, and Claude's backend shows its user nothing of what we answered. The one hop that failed is invisible.

## What changes

- **Every refusal on the connect flow is logged with its reason.** `GitHubFacadeRequestError` carries a log-only `detail` naming the check that failed (client id not the registered one, client secret not the registered one, no live code, code issued under another client id, redirect host mismatch, code spent concurrently). The routes log it with the caller's user agent. A successful exchange logs the person and the minted key id. Bearer refusals on `/api/v3` log whether there was no bearer, a non-key bearer, or an unknown/revoked key. Never a secret, a code, or a token.
- **Link tokens are spelled the way GitHub spells its own.** A key kind carries a `shape` beside its prefix; `github-token` mints `gho_` plus forty hex digits (GitHub's tokens are documented as alphanumeric after the prefix; base64url could carry a `-`). The default kind is unchanged.
- **Docs and page copy stop saying Claude will ask.** It does not: per Claude's GHES documentation, the connect option is in the repository picker on claude.ai/code and, for Owners, in the GitHub Enterprise section of the admin settings; registering connects the organization, not any person. The docs gain a "when connecting does not take" section pointing at the log lines.

## Proof

- New test: a wrong secret, a never-issued code and an unknown client id each leave exactly one log line naming the check, and none of the lines contains the secret, the wrong secret, the code or the bogus code. With the exchange's log call removed the test fails (`expected length 3, got 1`).
- New test: a kind with `shape: 'github-token'` mints `/^gho_[A-Za-z0-9]{40}$/`, is recognised by `looksLikeExternalApiKey`, and is hashed like any key. With the shape ignored the test fails.
- Backend 193 files / 2311 tests, frontend 135 / 1679, both typechecks clean. Lint on changed files: no new findings (the page's line-118 finding and the key-service test's `any`s are pre-existing).

## Next

Deploy to staging, connect again from Claude, and read the `[github-facade]` lines: they say which hop refused and why. If the exchange succeeds but the marketplace still fails to load, the next suspects are the repository and commit bodies, which are thinner than the spike's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes GitHub Enterprise connections diagnosable when Claude silently drops facade errors. The facade now logs safe refusal reasons and successful key creation, mints GitHub-shaped link tokens, and corrects connection instructions so users connect at the right Claude locations.

**New Features**

- Logs authorize, token exchange, and API bearer failures with the failed check and user agent; caller-supplied text is escaped so it cannot forge or color a log line. No secrets, codes, or tokens are logged.
- Logs the connected user and minted key ID after a successful exchange.
- Mints `github-link` keys as `gho_` followed by 40 alphanumeric characters while preserving normal hashing and revocation.
- Documents that users connect from the Claude Code repository picker or, for Owners, GitHub Enterprise settings; Claude does not prompt for this step.
- Adds coverage for refusal logging, GitHub-shaped key validation, and log-line escaping.

<sup>Written for commit 1ad0d15261367f9ffaa3f87487e2df8e25492bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

