### PR TITLE
hexis-all is a plugin holding everything, not a dependency list

### DIFF
--- a/.changeset/self-contained-bundle.md
+++ b/.changeset/self-contained-bundle.md
@@ -1,0 +1,6 @@
+---
+'@bevel-software/platform-core-backend': patch
+'@bevel-software/platform-core-frontend': patch
+---
+
+`hexis-all` is now a plugin of its own holding every skill the person may read and the knowledge base's MCP endpoint, instead of a manifest that only names the other plugins as dependencies. Only Claude Code resolves a dependency list; Cowork and claude.ai installed an empty plugin. One install now means the same thing on every surface. Codex's catalogue no longer lists the bundle, since Codex installs every entry on add and would have installed everything twice.

--- a/docs/claude-cowork.md
+++ b/docs/claude-cowork.md
@@ -43,7 +43,9 @@ they can add the marketplace.
 2. Copy the marketplace URL from **External agent access → Marketplaces**.
    It is the same URL Claude Code clones.
 3. In Cowork (or claude.ai), open **Plugins → Add marketplace** and paste it.
-4. Install the plugins you want. **Update** in Claude pulls what changed.
+4. Install **hexis-all** for everything you may read in one plugin (every
+   skill, and the knowledge base as an MCP server), or single plugins for a
+   subset. **Update** in Claude pulls what changed.
 
 Your connection appears under **Marketplaces → Your Claude connections**,
 where you can disconnect it. Disconnecting stops updates; connecting again

--- a/packages/core-backend/kb-template/AGENTS.md
+++ b/packages/core-backend/kb-template/AGENTS.md
@@ -235,7 +235,8 @@ its owners, never distributed to agents).
 the app's external-agent page that holds a plugin marketplace compiled from
 exactly the skills they may read — one plugin per plugin here, a
 `skills-and-knowledge` plugin for the rest plus this knowledge base's MCP
-server, and a `hexis-all` bundle that installs everything.
+server, and `hexis-all`, one plugin holding every skill they may read and
+the MCP server, for a single install.
 
 ## Tool Manuals (`{{pluginsDir}}/<Plugin>/software.bevel.hexis/tools/*.tool`)
 

--- a/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/compile-marketplace.test.ts
@@ -127,8 +127,19 @@ describe('compileMarketplace', () => {
     expect(paths).toContain('skills/pitch/SKILL.md');
     expect(paths).toContain('skills/outreach/SKILL.md');
 
-    // The bundle depends on every other plugin; the catalogues list them all.
-    expect(json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json').dependencies.sort()).toEqual(['gtm', 'skills-and-knowledge']);
+    // The bundle IS everything the caller may read — every skill once and the
+    // knowledge base's MCP endpoint — with no dependency list: only Claude
+    // Code resolves one, and Cowork and claude.ai install content alone.
+    const bundleManifest = json(tree, 'plugins/hexis-all/.claude-plugin/plugin.json');
+    expect(bundleManifest).not.toHaveProperty('dependencies');
+    expect(bundleManifest.version).toMatch(/^0\.0\.0-/);
+    for (const name of ['deploy', 'pitch', 'outreach']) expect(paths).toContain(`plugins/hexis-all/skills/${name}/SKILL.md`);
+    expect(paths).toContain('plugins/hexis-all/skills/deploy/references/notes.md');
+    expect(json(tree, 'plugins/hexis-all/.mcp.json')).toEqual({
+      mcpServers: { hexis: { type: 'streamable-http', url: 'https://kb.acme.com/api/mcp' } },
+    });
+    // Claude's catalogue lists it; Codex's does not, since Codex installs
+    // every entry on add and the bundle repeats what the others carry.
     const claude = json(tree, '.claude-plugin/marketplace.json');
     expect(claude.name).toBe('acme-hexis');
     expect(claude.plugins.map((p: { name: string; source: string }) => [p.name, p.source])).toEqual([
@@ -137,6 +148,7 @@ describe('compileMarketplace', () => {
       ['hexis-all', './plugins/hexis-all'],
     ]);
     const codex = json(tree, '.agents/plugins/marketplace.json');
+    expect(codex.plugins.map((p: { name: string }) => p.name)).toEqual(['gtm', 'skills-and-knowledge']);
     expect(codex.plugins.every((p: { policy: { installation: string } }) => p.policy.installation === 'INSTALLED_BY_DEFAULT')).toBe(true);
     expect(codex.plugins[0].source).toEqual({ source: 'local', path: './plugins/gtm' });
     expect(text(tree, 'README.md')).toContain('Compiled from Acme');

--- a/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
+++ b/packages/core-backend/src/modules/plugins/compile/compile-marketplace.ts
@@ -28,9 +28,11 @@ import type { DiscoveredPlugin } from '../discovery/plugin-source.js';
  *
  * What comes out, for one caller:
  *
- *   .claude-plugin/marketplace.json      Claude Code's catalogue
+ *   .claude-plugin/marketplace.json      Claude Code's catalogue (and Cowork's,
+ *                                        claude.ai's): every plugin below
  *   .agents/plugins/marketplace.json     Codex's catalogue, every entry
- *                                        INSTALLED_BY_DEFAULT
+ *                                        INSTALLED_BY_DEFAULT — without the
+ *                                        bundle, which would install it all twice
  *   plugins/<slug>/…                     one per plugin the caller may read
  *                                        anything of: inline + linked skills,
  *                                        the portable half of mcp.json
@@ -39,10 +41,12 @@ import type { DiscoveredPlugin } from '../discovery/plugin-source.js';
  *                                        only in plugins the caller cannot see,
  *                                        is still one install away — plus the
  *                                        knowledge base's own MCP endpoint
- *   plugins/hexis-all/…                  a bundle whose only content is a
- *                                        dependency on every plugin above —
- *                                        Claude Code installs them all from
- *                                        one `claude plugin install`
+ *   plugins/hexis-all/…                  the one-install bundle: a plugin of
+ *                                        its own holding every readable skill
+ *                                        once and the knowledge base's MCP
+ *                                        endpoint — content, not a dependency
+ *                                        list, because only Claude Code
+ *                                        resolves one
  *   skills/<name>/…                      every readable skill once, flat, for
  *                                        `npx skills add <url> --all`
  *   README.md                            names the source commit
@@ -245,42 +249,55 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
     }
   }
 
-  // 4. The one-install bundle: a Claude manifest with nothing but dependencies.
-  const bundle = pluginManifestName(options.bundleName ?? BUNDLE_NAME);
-  const slugs = out.map((p) => p.slug);
-  if (slugs.includes(bundle)) {
-    // Only reachable with a non-default bundle name that folds to a real
-    // plugin's slug: the default is reserved above. Skipping the bundle
-    // beats overwriting that plugin's manifests with a dependency list.
-    warnings.push(`the bundle name "${bundle}" collides with a plugin's manifest name — no bundle plugin emitted`);
-  }
-  if (slugs.length > 0 && !slugs.includes(bundle)) {
-    const shortSha = options.sourceCommit.slice(0, 12) || '0';
-    const description = `Everything in ${options.owner}'s marketplace you may read — one install.`;
-    put(
-      `plugins/${bundle}/.claude-plugin/plugin.json`,
-      `${JSON.stringify({ name: bundle, version: `0.0.0-${shortSha}`, description, dependencies: slugs }, null, 2)}\n`,
-    );
-    put(
-      `plugins/${bundle}/${PLUGIN_MANIFEST_FILE}`,
-      `${JSON.stringify({ $schema: PLUGIN_MANIFEST_SCHEMA, name: bundle, description }, null, 2)}\n`,
-    );
-    put(
-      `plugins/${bundle}/.codex-plugin/plugin.json`,
-      `${JSON.stringify({ name: bundle, description }, null, 2)}\n`,
-    );
-  }
-
-  // 5. The flat root skills/ folder, every readable skill once.
+  // 4. Every readable skill once, by name — ONE set, carried twice: the flat
+  //    root skills/ folder, and the one-install bundle below.
   const flat = dedupeByName(
     [...readableSkills.values()].sort((a, b) => a.path.localeCompare(b.path)),
-    (s, other) => warnings.push(`skills/: "${s.name}" at ${s.path} shares its name with ${other.path} — left out`),
+    (s, other) =>
+      warnings.push(`"${s.name}" at ${s.path} shares its name with ${other.path} — left out of skills/ and the bundle`),
   );
   for (const s of flat) await copySkill(kbRoot, s, `skills/${s.name}`, put);
 
-  // 6. The two catalogues + a README naming the source.
-  const bundleEmitted = slugs.length > 0 && !slugs.includes(bundle);
-  const entries = [...out.map((p) => ({ slug: p.slug, description: p.description ?? p.displayName })), ...(bundleEmitted ? [{ slug: bundle, description: 'Everything you may read, one install' }] : [])];
+  // 5. The one-install bundle: a plugin of its own that IS everything the
+  //    caller may read — every skill once, plus the knowledge base's MCP
+  //    endpoint — not a manifest naming the plugins above as dependencies.
+  //    Only Claude Code resolves a dependency list; Cowork and claude.ai
+  //    install a plugin's content and nothing more, so for one install to
+  //    mean the same thing on every surface, the content has to be there.
+  //    Its version is the source commit, so an auto-update sees every change.
+  const bundle = pluginManifestName(options.bundleName ?? BUNDLE_NAME);
+  const bundleTaken = out.some((p) => p.slug === bundle);
+  if (bundleTaken) {
+    // Only reachable with a non-default bundle name that folds to a real
+    // plugin's slug: the default is reserved above. Skipping the bundle
+    // beats overwriting that plugin's tree with everything.
+    warnings.push(`the bundle name "${bundle}" collides with a plugin's manifest name — no bundle plugin emitted`);
+  }
+  const bundleEmitted = !bundleTaken && (flat.length > 0 || kbMcp !== undefined);
+  if (bundleEmitted) {
+    const base = `plugins/${bundle}`;
+    const shortSha = options.sourceCommit.slice(0, 12) || '0';
+    const description = `Everything in ${options.owner}'s marketplace you may read — one install.`;
+    put(
+      `${base}/.claude-plugin/plugin.json`,
+      `${JSON.stringify({ name: bundle, version: `0.0.0-${shortSha}`, description }, null, 2)}\n`,
+    );
+    put(
+      `${base}/${PLUGIN_MANIFEST_FILE}`,
+      `${JSON.stringify({ $schema: PLUGIN_MANIFEST_SCHEMA, name: bundle, description }, null, 2)}\n`,
+    );
+    if (kbMcp) {
+      put(`${base}/${PLUGIN_MCP_FILE}`, `${JSON.stringify({ $schema: PLUGIN_MCP_SCHEMA, mcpServers: kbMcp }, null, 2)}\n`);
+      put(`${base}/.mcp.json`, `${JSON.stringify({ mcpServers: kbMcp }, null, 2)}\n`);
+    }
+    for (const s of flat) await copySkill(kbRoot, s, `${base}/skills/${s.name}`, put);
+  }
+
+  // 6. The two catalogues + a README naming the source. The bundle is listed
+  //    for Claude's surfaces only: Codex installs every catalogue entry on
+  //    add, and the bundle repeats what the other entries already carry.
+  const entries = out.map((p) => ({ slug: p.slug, description: p.description ?? p.displayName }));
+  const claudeEntries = [...entries, ...(bundleEmitted ? [{ slug: bundle, description: 'Everything you may read, one install' }] : [])];
   put(
     '.claude-plugin/marketplace.json',
     `${JSON.stringify(
@@ -288,7 +305,7 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
         name: options.name,
         owner: { name: options.owner },
         ...(options.description ? { description: options.description } : {}),
-        plugins: entries.map((e) => ({ name: e.slug, source: `./plugins/${e.slug}`, description: e.description })),
+        plugins: claudeEntries.map((e) => ({ name: e.slug, source: `./plugins/${e.slug}`, description: e.description })),
       },
       null,
       2,
@@ -318,12 +335,12 @@ export async function compileMarketplace(input: CompileInput): Promise<VirtualTr
       `Compiled from ${options.owner}'s knowledge base at commit \`${options.sourceCommit}\`.`,
       'This tree is generated: edit the knowledge base, not these files.',
       '',
-      `Plugins: ${entries.map((e) => e.slug).join(', ') || 'none'}.`,
+      `Plugins: ${claudeEntries.map((e) => e.slug).join(', ') || 'none'}.`,
       '',
     ].join('\n'),
   );
 
-  return { files, warnings, plugins: entries.map((e) => e.slug) };
+  return { files, warnings, plugins: claudeEntries.map((e) => e.slug) };
 }
 
 // --- helpers ------------------------------------------------------------------

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -362,7 +362,11 @@ export function ExternalAgentAccessPage() {
                     sign-in: approve, and you are back in Claude.
                   </li>
                   <li>In Cowork (or claude.ai), open Plugins → Add marketplace and paste the URL below.</li>
-                  <li>Install the plugins you want. Update in Claude pulls what changed.</li>
+                  <li>
+                    Install <b>hexis-all</b> for everything you may read in one plugin (every skill,
+                    and the knowledge base as an MCP server), or single plugins for a subset. Update
+                    in Claude pulls what changed.
+                  </li>
                 </ol>
                 <CopyBlock label="Marketplace URL" value={marketplaceGitUrl()} rows={2} />
                 <div className="space-y-1">

--- a/packages/core-frontend/src/shared/marketplace-url.ts
+++ b/packages/core-frontend/src/shared/marketplace-url.ts
@@ -57,7 +57,11 @@ export function withConnectionKey(key: string): string {
 
 /** The marketplace's registered name — what `plugin@<name>` refers to in Claude Code. */
 export const MARKETPLACE_NAME = 'hexis';
-/** The one-install bundle plugin every compiled marketplace carries. */
+/**
+ * The one-install plugin every compiled marketplace carries: every skill the
+ * person may read plus the knowledge base's MCP endpoint, as content — the
+ * same plugin on Claude Code, Cowork and claude.ai.
+ */
 export const BUNDLE_PLUGIN = 'hexis-all';
 
 /**


### PR DESCRIPTION
## Why

Connecting Cowork and claude.ai to the marketplace now works (PR #154), but installing `hexis-all` there installed nothing else. The bundle was a Claude manifest whose only content was a `dependencies` list naming every other plugin. Claude's reference documents dependency resolution for the Claude Code CLI only; Cowork and claude.ai install a plugin's content and stop, so they installed an empty plugin.

## What changes

- **`hexis-all` is now content.** It holds every skill the person may read, once by name, plus the knowledge base's MCP endpoint, and carries no dependency list. It is the same set the flat root `skills/` folder holds, computed once and carried twice. One install means the same thing on Claude Code, Cowork and claude.ai. Its version stays the source commit, so auto-update sees every change.
- **Codex's catalogue no longer lists the bundle.** Every Codex entry is `INSTALLED_BY_DEFAULT`, so listing the bundle would have installed everything twice. Claude's catalogue lists it as before.
- **Copy and docs** (the Cowork drawer, the Cowork doc, the KB template's AGENTS.md) say what the plugin is: everything you may read in one plugin, or single plugins for a subset.

Trade-off, agreed with Razvan: in Claude Code the skills of a `hexis-all` install are namespaced `hexis-all:<skill>` rather than `<plugin>:<skill>`; someone who installs the bundle and an individual plugin sees that plugin's skills twice, namespaced. Per-plugin installs remain for anyone who wants the plugin names.

## Proof

- The compiler test asserts the bundle carries every readable skill (and a skill's bundled files), the MCP endpoint, no `dependencies`, and that Codex's catalogue omits it while Claude's lists it. With the bundle's skill copy removed the test fails (`expected […] to include 'plugins/hexis-all/skills/deploy/SKILL.md'`).
- Backend 195 files / 2328 tests, frontend 136 / 1682, both typechecks clean, no new lint findings.

## Next

Deploy, `Update` the marketplace in Cowork, reinstall `hexis-all`, and run a skill. In Claude Code, `claude plugin update hexis-all` picks up the new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `hexis-all` a self-contained plugin instead of a dependency-only manifest. Cowork and claude.ai previously installed an empty plugin; they now receive every readable skill and the knowledge base MCP endpoint, matching Claude Code.

- The bundle version follows the source commit so updates include skill changes.
- Codex omits the bundle because it installs every catalogue entry by default.
- Installing the bundle alongside an individual plugin exposes duplicate skills under the `hexis-all:<skill>` namespace.
- The compiler tests, Cowork instructions, and external-agent UI now document and verify the new layout.
- After deployment, refresh the marketplace and reinstall `hexis-all`; Claude Code users can run `claude plugin update hexis-all`.

<sup>Written for commit 6b2d1faedf6cb84140fc0bc820b6a36bfc075e46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

