### PR TITLE
The deployed sha is baked at build time, not passed at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,12 +122,17 @@ ENV PORT=3001
 
 # Bake the deployed commit sha into the image so `GET /api/health` can report
 # it. `.git` is in .dockerignore, so the sha can't be read inside the build —
-# pass it in explicitly: `--build-arg GIT_SHA=$(git rev-parse HEAD)`, which is
-# what CI does. `docker-compose.yml` deliberately does NOT declare it as a build
-# arg — naming it there made every deployment UI reading that file ask for a
-# value nobody sets by hand. Unset, health reports 'unknown'.
+# it must arrive as a build arg, under either of two names: CI passes GIT_SHA
+# (`--build-arg GIT_SHA=$(git rev-parse HEAD)`), and a from-source compose
+# deploy maps the orchestrator's SOURCE_COMMIT through as a build arg
+# (deployment/docker-compose.build.yml). Baked at BUILD time on purpose: the
+# runtime SOURCE_COMMIT pass-through tried first was materialized by a hosted
+# deployment UI as an EMPTY LITERAL that overrode the real value — a sha the
+# image itself owns leaves no runtime variable to blank. Neither arg set,
+# health reports 'unknown'.
 ARG GIT_SHA
-ENV GIT_SHA=${GIT_SHA}
+ARG SOURCE_COMMIT
+ENV GIT_SHA=${GIT_SHA:-$SOURCE_COMMIT}
 
 EXPOSE 3001
 

--- a/deployment/docker-compose.build.yml
+++ b/deployment/docker-compose.build.yml
@@ -50,16 +50,21 @@ services:
       # is also what makes the root .env the one compose reads. So `.` IS the
       # repository root here, subfolder or not.
       context: .
-      # No `args:` block, same reasoning as the root file once carried: the
-      # Dockerfile accepts GIT_SHA (reported by `GET /api/health`), but naming
-      # it here makes deployment UIs prompt for a value nobody sets by hand.
-      # CI passes it directly: `--build-arg GIT_SHA=$(git rev-parse HEAD)`.
+      # The commit sha `GET /api/health` reports, baked into the image at
+      # build time. `${SOURCE_COMMIT:-}` interpolates from the orchestrator's
+      # .env — Coolify writes the checked-out commit there on every deploy —
+      # and an operator building by hand can leave it unset (health then says
+      # 'unknown'). Build-time on purpose: the runtime pass-through this
+      # replaces was materialized by Coolify as an EMPTY LITERAL that
+      # overrode the real value; a sha baked into the image leaves no runtime
+      # variable to blank.
+      args:
+        SOURCE_COMMIT: ${SOURCE_COMMIT:-}
     expose:
       - "3001"
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - SOURCE_COMMIT
       - GIT_TOKEN
       - GIT_USERNAME
       - JWT_SECRET=${JWT_SECRET}

--- a/deployment/docker-compose.portainer.yml
+++ b/deployment/docker-compose.portainer.yml
@@ -43,7 +43,6 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - SOURCE_COMMIT
       - GIT_TOKEN
       - GIT_USERNAME
       - JWT_SECRET=${JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,20 +83,11 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      # The commit this build came from, reported by `GET /api/health`.
-      # Coolify injects SOURCE_COMMIT for git-based deploys — but only into the
-      # environment it hands compose, so without a pass-through here it never
-      # reached the container and health reported 'unknown' on every hosted
-      # deploy. `version.ts` has named this fallback all along; this is what
-      # makes it true. Nothing to fill in: absent, health still says 'unknown'.
-      #
-      # LEAVE COOLIFY'S "Include Source Commit in Build" OFF. It controls
-      # BUILD-time availability, and turning it on defeats layer caching across
-      # commits — the setting says so itself, and adds that SOURCE_COMMIT "will
-      # still be available at runtime" either way. Runtime is all we need:
-      # `version.ts` reads it from the process environment when the server
-      # starts, not from anything baked into the image.
-      - SOURCE_COMMIT
+      # The deployed commit sha `GET /api/health` reports is BAKED into the
+      # published image by CI (the Dockerfile's GIT_SHA build arg) — nothing
+      # to pass at runtime. A runtime SOURCE_COMMIT pass-through used to sit
+      # here; Coolify materialized it as an EMPTY LITERAL that overrode the
+      # real value, which is exactly the failure baking at build time removes.
       # Git host credential. The KB can live on any git server (GitHub, GitLab,
       # Bitbucket, Azure DevOps, self-hosted): GIT_TOKEN is the Basic-auth
       # password and GIT_USERNAME the Basic username (host-specific — see


### PR DESCRIPTION
## Why
Staging's `GET /api/health` reports `"sha": "unknown"`, which just stalled the delivery pipeline's Staging Deploy Gate (it verifies a deploy by that sha). The compose files passed `SOURCE_COMMIT` through as a runtime env var, and Coolify materialized that pass-through as an **empty literal** — overriding the real commit value Coolify itself writes into the deployment's `.env`.

## What
A runtime variable is only as good as whatever last touches the environment, so the sha now arrives at **build time** and is baked into the image, where no deployment UI can blank it:

- **Dockerfile**: accepts `SOURCE_COMMIT` as a second build arg and folds it into `GIT_SHA` via `${GIT_SHA:-$SOURCE_COMMIT}` — CI's explicit `GIT_SHA` still wins. Expansion semantics verified on dockerd 27: `SOURCE_COMMIT` alone → `GIT_SHA=abc123`; both args → CI's value.
- **deployment/docker-compose.build.yml** (what from-source deploys like staging use): maps `${SOURCE_COMMIT:-}` from the orchestrator's `.env` into that build arg. Coolify writes the checked-out commit there on every deploy; a manual builder can leave it unset and health says `unknown` as before.
- **docker-compose.yml / docker-compose.portainer.yml**: the runtime `SOURCE_COMMIT` pass-through is removed — these deploy CI-published images that already carry `GIT_SHA` baked by the docker-publish workflow.

## Testing
- Nested ARG default expansion tested with a minimal image on the staging host's dockerd (both arg combinations, output shown in the commit).
- No app code changes; `version.ts` already prefers `GIT_SHA` over `SOURCE_COMMIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GET /api/health` reporting `"sha": "unknown"` on staging by baking the commit sha into the image at build time. The runtime `SOURCE_COMMIT` pass-through was being materialized by Coolify as an empty literal, overriding the real value; the sha now lives in the image where nothing at runtime can blank it. CI's explicit `GIT_SHA` build arg still wins, and manual builds can leave the arg unset so health reports `unknown` as before.

- The `Dockerfile` accepts `SOURCE_COMMIT` as a second build arg and folds it into `GIT_SHA` via `${GIT_SHA:-$SOURCE_COMMIT}`.
- `deployment/docker-compose.build.yml` maps `${SOURCE_COMMIT:-}` from the orchestrator's `.env` into that build arg.
- The runtime `SOURCE_COMMIT` pass-through is removed from `docker-compose.yml` and `deployment/docker-compose.portainer.yml`.

<sup>Written for commit 6b0c71b10ba398b8eddcc4c10ff82cdfc3a1f599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

