### PR TITLE
Menus follow-up: the scrim judges the gesture, Escape peels one layer

### DIFF
--- a/.changeset/menu-layer-followup.md
+++ b/.changeset/menu-layer-followup.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+Dialogs and menus dismiss more precisely. A drag that starts inside a dialog and releases on the backdrop (selecting text and overshooting the edge) no longer closes the dialog, and when two menus are open at once — reachable with the keyboard — Escape closes them one at a time, newest first, instead of both on one press.

--- a/packages/core-backend/src/core/create-core-services.ts
+++ b/packages/core-backend/src/core/create-core-services.ts
@@ -351,7 +351,7 @@ export async function createCoreServices(
   // rescues (`roles.yaml` and any `access.md`) — the SAME list
   // `AdminAccessService` below is given, so the admin surfaces and the write
   // gate cannot disagree about who the owner is. They did: the owner could
-  // open Roles & Members and then be refused the save, with the UI showing
+  // open App roles and then be refused the save, with the UI showing
   // them as an admin and the gate saying "Eligible: Admin".
   const accessControl = new AccessControlService(workspaceService, kbDirName, [
     config.adminEmail,

--- a/packages/core-backend/src/modules/access-model/roles-yaml-guard.ts
+++ b/packages/core-backend/src/modules/access-model/roles-yaml-guard.ts
@@ -5,7 +5,7 @@
  * app. The runtime resolver's `loadModel` HARD-THROWS `AccessConfigError` on a
  * parse failure, and `isAdmin` swallows that into `false` for EVERYONE — so a
  * single malformed `roles.yaml` is an app-wide, in-app-unrecoverable admin
- * lockout. The dedicated Roles & Members service already validates every
+ * lockout. The dedicated App roles service already validates every
  * candidate before writing (`assertLoadable`), but the two RAW write paths do
  * not:
  *   - the human editor save  (`PUT /workspace/:id/file`)

--- a/packages/core-backend/src/modules/access/access-control.interface.ts
+++ b/packages/core-backend/src/modules/access/access-control.interface.ts
@@ -322,7 +322,7 @@ export interface IAccessControl {
 
   /**
    * Validate a candidate `roles.yaml` text against the resolver's OWN loader,
-   * WITHOUT writing it. The single safety gate behind the admin Roles & Members
+   * WITHOUT writing it. The single safety gate behind the admin App roles
    * surface: `roles.yaml` has no admin-rescue and `loadModel` hard-throws on a
    * parse failure (which `isAdmin` swallows into `false` for everyone), so a
    * malformed write would be a permanent, app-wide, in-app-unrecoverable admin

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -160,7 +160,7 @@ function roleKnown(roles: RolesIndex, canonicalRole: string): boolean {
  * nothing, bare grant tokens fall through to roles, and group-backed denies
  * drop (the owner's explicit degrade-loudly decision, NOT fail-closed). The
  * marker is carried on the loaded model and surfaced by the groups admin
- * endpoints so the Groups page can banner it.
+ * endpoints so the Groups & Members page can banner it.
  */
 export type GroupsHealth = { ok: true } | { ok: false; file: string; reason: string };
 

--- a/packages/core-backend/src/modules/access/access.routes.ts
+++ b/packages/core-backend/src/modules/access/access.routes.ts
@@ -997,7 +997,7 @@ export function createAccessRoutes(
   });
 
   // -------------------------------------------------------------------------
-  // Roles & Members (admin) — MEMBERSHIP editing on the DEFAULT-branch
+  // App roles (admin) — MEMBERSHIP editing on the DEFAULT-branch
   // roles.yaml. Roles are app-defined capabilities: there is deliberately NO
   // create/rename/delete route — the admin surface cannot mint, rebrand, or
   // retire a role (legacy people-set roles migrate out via convert-to-group).

--- a/packages/core-backend/src/modules/access/groups-admin.service.ts
+++ b/packages/core-backend/src/modules/access/groups-admin.service.ts
@@ -18,10 +18,10 @@
  *     precedence then resolves (group first, `role/<name>` for the role).
  *   - DEGRADE LOUDLY: a broken groups source never fails access resolution
  *     closed — groups contribute nothing and the model carries a
- *     `groupsHealth` marker, which the roster exposes so the Groups page can
+ *     `groupsHealth` marker, which the roster exposes so the Groups & Members page can
  *     banner it. A broken MANUAL groups.yaml additionally makes the roster
  *     answer 422 with the parse message (the operator must see what to fix —
- *     never a dead Groups page, never a silent empty roster they might
+ *     never a dead Groups & Members page, never a silent empty roster they might
  *     "repair" by re-creating groups over live bytes).
  */
 
@@ -87,7 +87,7 @@ export interface GroupsRoster {
   /**
    * Health of the active groups source — `ok: false` when the source exists
    * but is unreadable/unparseable (resolution degrades: groups contribute
-   * nothing). Shipped for the Groups page banner (frontend increment).
+   * nothing). Shipped for the Groups & Members page banner (frontend increment).
    */
   groupsHealth: GroupsHealth;
 }

--- a/packages/core-backend/src/modules/access/roles-admin.service.ts
+++ b/packages/core-backend/src/modules/access/roles-admin.service.ts
@@ -1,6 +1,6 @@
 /**
- * Admin Roles & Members service — MEMBERSHIP editing on the default-branch
- * `roles.yaml`.
+ * Admin App roles service (the page formerly labelled "Roles & Members") —
+ * MEMBERSHIP editing on the default-branch `roles.yaml`.
  *
  * Roles are APP-DEFINED capabilities (see `capability-registry.ts`): the
  * product decides which roles exist; users can never create, rename, or
@@ -77,7 +77,7 @@ export class RolesAdminError extends WorkflowDomainError {
   }
 }
 
-/** One role as the Roles & Members page renders it. */
+/** One role as the App roles page renders it. */
 export interface RoleRosterEntry {
   canonical: string;
   displayName: string;

--- a/packages/core-backend/src/modules/auth/auth.service.ts
+++ b/packages/core-backend/src/modules/auth/auth.service.ts
@@ -77,7 +77,7 @@ export class AuthService {
    *     variable disables it immediately. Lets a fresh deployment sign in
    *     before any account exists.
    *  2. A per-user account: the `users` row's scrypt `password_hash`
-   *     (created by an admin from Roles & Members, or set by the user on
+   *     (created by an admin from App roles, or set by the user on
    *     their Account page). Accounts that only ever signed in via SSO have
    *     no hash and are refused here.
    *
@@ -146,7 +146,7 @@ export class AuthService {
   }
 
   /**
-   * Admin-driven account provisioning (Roles & Members → Accounts). Upserts
+   * Admin-driven account provisioning (App roles → Accounts). Upserts
    * the user by email and sets their password — re-provisioning an existing
    * account (e.g. one that first arrived via SSO, or a reset for a locked-out
    * user) is deliberate admin behavior, not an error.

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -2412,7 +2412,7 @@ export class WorkflowService implements IWorkflowService {
     // roles.yaml differs from the base branch's, we restore the base version on
     // the source branch (commit + push) BEFORE merging, so the merged diff
     // carries no roles.yaml change. roles.yaml is mutable ONLY via the admin
-    // Roles & Members surface (itself admin-gated). The rest of the CR merges
+    // App roles surface (itself admin-gated). The rest of the CR merges
     // normally. Best-effort by design is NOT acceptable here — a failure to
     // neutralise must abort the merge, never fall through.
     const preserved = await this.preserveBaseRolesYaml(number, user, baseBranch);

--- a/packages/core-backend/src/modules/workspace/workspace.routes.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.routes.ts
@@ -877,7 +877,7 @@ export function createWorkspaceRoutes(
     try {
       // Refuse a hand-edit that would leave roles.yaml unparseable BEFORE any
       // byte hits disk — a broken roles.yaml is an app-wide admin lockout
-      // (loadModel hard-throws). The dedicated Roles & Members surface has its
+      // (loadModel hard-throws). The dedicated App roles surface has its
       // own validate gate; this covers the raw-text editor path.
       if (isRolesYamlPath(filePath, kbDirName)) assertRolesYamlParsable(content);
       // Creator read grant: a brand-new file at a spot whose access chain

--- a/packages/core-frontend/src/core/registry.ts
+++ b/packages/core-frontend/src/core/registry.ts
@@ -75,7 +75,7 @@ export interface AdminMenuItemHelpers {
 
 /**
  * One row of the profile menu. Core rows (External agent access, Secrets,
- * Browse available tools, Account, Roles & Members, User accounts) are built
+ * Browse available tools, Account, App roles, User accounts) are built
  * into ProfileMenu and navigate to standalone routed pages; enterprise rows
  * are contributed here. A row opens a dialog (`dialog` — mounted persistently
  * by ProfileMenu, driven by an open flag, so existing dialog components need

--- a/packages/core-frontend/src/lib/email.ts
+++ b/packages/core-frontend/src/lib/email.ts
@@ -1,6 +1,6 @@
 /**
  * ONE email-validation rule for every access/admin surface (Manage Access,
- * Roles & Members, Groups). Mirrors the backend's `EMAIL_REGEX`
+ * App roles, Groups). Mirrors the backend's `EMAIL_REGEX`
  * (access-control.service.ts): no whitespace, no `<`/`>` (angle-bracket
  * forms like `Name <a@b.c>` are a different grammar), and exactly one `@`.
  *

--- a/packages/core-frontend/src/modules/access/__tests__/ManageAccessDialog.test.tsx
+++ b/packages/core-frontend/src/modules/access/__tests__/ManageAccessDialog.test.tsx
@@ -746,23 +746,28 @@ describe('ManageAccessDialog: dismissing a verb menu', () => {
     expect(screen.queryByRole('button', { name: /^can download$/i })).not.toBeInTheDocument();
   });
 
-  it('subscribes its document listeners once per open menu, not once per render', async () => {
+  it('a menu re-rendered with fresh callbacks still dismisses cleanly, once', async () => {
+    // The dismiss hook mirrors a fresh-per-render `onDismiss` arrow into a
+    // ref itself. Asserted through the surface a user sees: after re-renders
+    // of the OPEN menu (each verb toggle re-renders the dialog with new
+    // arrows), one Escape closes the menu — and only the menu, exactly once,
+    // with the dialog left standing.
     const user = userEvent.setup();
-    render(<ManageAccessDialog entry={ENTRY} onClose={() => {}} />);
+    const onClose = vi.fn();
+    render(<ManageAccessDialog entry={ENTRY} onClose={onClose} />);
     const [addRowTrigger] = await screen.findAllByRole('button', { name: /^can edit$/i });
 
-    const addSpy = vi.spyOn(document, 'addEventListener');
     await user.click(addRowTrigger);
-    const mousedowns = () => addSpy.mock.calls.filter(([type]) => type === 'mousedown').length;
-    expect(mousedowns()).toBe(1);
-
-    // Toggling a verb re-renders the dialog with the menu still open. The
-    // dismiss hook lists `onClose` in its deps, so a fresh arrow per render
-    // would tear the listeners down and re-add them here.
+    // Two re-renders of the open menu with fresh callback identities.
+    await user.click(screen.getByRole('button', { name: /^owner$/i }));
     await user.click(screen.getByRole('button', { name: /^owner$/i }));
     expect(screen.getByRole('button', { name: /^can download$/i })).toBeInTheDocument();
-    expect(mousedowns()).toBe(1);
-    addSpy.mockRestore();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('button', { name: /^can download$/i })).not.toBeInTheDocument();
+    // The dialog is still up: the menu's layer owned that Escape.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('the trigger itself still toggles: one click opens, a second closes', async () => {

--- a/packages/core-frontend/src/modules/access/components/ManageAccessDialog.tsx
+++ b/packages/core-frontend/src/modules/access/components/ManageAccessDialog.tsx
@@ -18,7 +18,6 @@ import {
   MenuItem,
   MenuPanel,
   useDismissableMenu,
-  useModalLayer,
 } from '../../../shared/components';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 import { useAuth } from '../../auth/state/auth.context';
@@ -351,23 +350,16 @@ function AnchoredMenu({
   children: ReactNode;
 }) {
   const dismissable = onDismiss !== undefined;
-  // Callers pass a fresh `onDismiss` arrow each render, and the hook lists
-  // `onClose` in its effect deps: handed the arrow directly it would tear down
-  // and re-add its document listeners on every render of the open menu — each
-  // verb toggled in the checklist included. Mirror the arrow into a ref (the
-  // same shape `Dialog` uses for its `onClose`) and give the hook one stable
-  // callback, so it subscribes once for the life of the open menu.
-  const onDismissRef = useRef(onDismiss);
-  useEffect(() => {
-    onDismissRef.current = onDismiss;
-  }, [onDismiss]);
-  const close = useCallback(() => onDismissRef.current?.(), []);
+  // The hook owns both contracts this component used to carry by hand: it
+  // mirrors a fresh `onDismiss` arrow into a ref itself (so its document
+  // listeners subscribe once per open menu), and it registers the open menu
+  // as a modal layer (so Escape peels it before the Dialog hosting it, and
+  // one press never closes two layers).
   const panelRef = useDismissableMenu<HTMLDivElement>({
     open: dismissable,
-    onClose: close,
+    onClose: () => onDismiss?.(),
     returnFocusTo: triggerRef,
   });
-  useModalLayer(dismissable);
   const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);
 
   useLayoutEffect(() => {

--- a/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AddMemberInput.tsx
@@ -54,7 +54,7 @@ export interface AddMemberInputProps {
 }
 
 /**
- * The add-member input shared by Roles & Members and the Groups page: an
+ * The add-member input shared by App roles and the Groups & Members page: an
  * email field that suggests people from the deployment as you type, plus its
  * Add button.
  *

--- a/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/AdminRolesPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { Loader2, UsersRound, X } from 'lucide-react';
 import { PageShell } from '../../../shared/components/PageShell';
+import { useLatestRef } from '../../../shared/components/useLatestRef';
 import { useAdmin } from '../state/admin.context';
 import {
   addMember,
@@ -47,7 +48,7 @@ export function AdminRolesPage() {
 
   // Bump on every load so a stale in-flight response never overwrites the
   // current roster. (The initial fetch does NOT go through the exclusive
-  // runner, so — unlike the Groups page — a mutation response can still race
+  // runner, so — unlike the Groups & Members page — a mutation response can still race
   // it; the bump in applyRoster is what drops the superseded load.)
   const requestId = useRef(0);
 
@@ -154,7 +155,7 @@ function RoleCard({
 
   // Add-member input + people autocomplete (same suggest source as Manage
   // Access, scoped to people/emails — a role's members are emails). The
-  // suggestion mechanics live in AddMemberInput, shared with the Groups page;
+  // suggestion mechanics live in AddMemberInput, shared with the Groups & Members page;
   // the submit rules below stay here.
   const [memberEmail, setMemberEmail] = useState('');
 
@@ -554,10 +555,7 @@ function ConfirmDialog({
   const panelRef = useRef<HTMLDivElement>(null);
   // Latest onCancel without re-running the mount effect on every parent render
   // (the parent passes a fresh closure each time, e.g. when `busy` flips).
-  const onCancelRef = useRef(onCancel);
-  useEffect(() => {
-    onCancelRef.current = onCancel;
-  }, [onCancel]);
+  const onCancelRef = useLatestRef(onCancel);
 
   // Real modal behaviour: hand focus to the dialog on open, restore it to the
   // trigger on close, close on Escape, and trap Tab/Shift+Tab inside the panel
@@ -600,7 +598,8 @@ function ConfirmDialog({
       document.removeEventListener('keydown', onKeyDown, true);
       previouslyFocused?.focus?.();
     };
-  }, []);
+    // The ref is stable for the component's life; listed for the linter.
+  }, [onCancelRef]);
 
   return (
     <div

--- a/packages/core-frontend/src/modules/admin/services/roles.api.ts
+++ b/packages/core-frontend/src/modules/admin/services/roles.api.ts
@@ -1,7 +1,7 @@
 import { authFetch } from '../../../lib/api';
 
 /**
- * Typed client for the admin Roles & Members surface — MEMBERSHIP editing
+ * Typed client for the admin App roles surface — MEMBERSHIP editing
  * only (roles are app-defined capabilities; there is no create/rename/delete).
  * Mirrors the backend shape in `roles-admin.service.ts`. Re-declared here
  * (rather than imported from `@bevel-software/platform-shared`) to match the

--- a/packages/core-frontend/src/shared/components/Dialog.tsx
+++ b/packages/core-frontend/src/shared/components/Dialog.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import { X } from 'lucide-react';
 import { useModalLayer } from './useModalLayer';
+import { useLatestRef } from './useLatestRef';
 
 /**
  * The one centered-modal primitive for the app. Before this existed every
@@ -78,28 +79,29 @@ export function Dialog({
 
   // Callers pass a fresh `onClose` arrow each render; mirror it into a ref so
   // the trap effect below doesn't re-fire (and re-snapshot focus) every render.
-  const onCloseRef = useRef(onClose);
-  useEffect(() => {
-    onCloseRef.current = onClose;
-  }, [onClose]);
-
-  const busyRef = useRef(busy);
-  useEffect(() => {
-    busyRef.current = busy;
-  }, [busy]);
+  const onCloseRef = useLatestRef(onClose);
+  const busyRef = useLatestRef(busy);
 
   // Only the topmost open modal layer reacts to Escape / backdrop clicks, so a
   // nested modal (its own or a hand-rolled one that opts in) can be dismissed
   // without also closing this dialog behind it.
   const isTopLayer = useModalLayer(open);
-  // Whether this dialog was the top layer when the pointer went DOWN on the
-  // scrim. A menu inside the dialog dismisses itself on `mousedown` and pops
-  // its layer as it unmounts, so by the time the scrim's `click` fires the
-  // dialog is topmost again — and would close on the same gesture that
-  // closed the menu, discarding whatever was in progress under it. Escape
-  // peels one layer at a time; so does the scrim. Recorded here rather than
-  // in each menu, so no menu has to learn to defer its own pop.
-  const topLayerAtPointerDown = useRef(false);
+  // Whether the pointer went DOWN on the scrim itself, with this dialog as
+  // the top layer. Both halves matter, and both must be judged at mousedown:
+  //
+  // - A menu inside the dialog dismisses itself on `mousedown` and pops its
+  //   layer as it unmounts, so by the time the scrim's `click` fires the
+  //   dialog is topmost again — and would close on the same gesture that
+  //   closed the menu. Escape peels one layer at a time; so does the scrim.
+  // - A drag that STARTS inside the panel and releases on the scrim (text
+  //   selection overshooting the panel edge) makes the browser fire `click`
+  //   on their common ancestor — this scrim container. The panel's own
+  //   stopPropagation can't help: the click never happened inside it. Only
+  //   the mousedown target says where the gesture began.
+  //
+  // Recorded here rather than in each menu, so no menu has to learn to defer
+  // its own pop.
+  const scrimPointerDown = useRef(false);
 
   // Dialog a11y: move focus into the panel on open, trap focus + Escape closes
   // + restore focus on close.
@@ -148,20 +150,21 @@ export function Dialog({
       document.removeEventListener('keydown', onKeyDown);
       previouslyFocused?.focus?.();
     };
-  }, [open, isTopLayer]);
+    // The refs are stable for the component's life; listed for the linter.
+  }, [open, isTopLayer, onCloseRef, busyRef]);
 
   if (!open) return null;
 
   return (
     <div
       className="fixed inset-0 z-50 bg-scrim flex items-center justify-center p-4"
-      onMouseDown={() => {
-        topLayerAtPointerDown.current = isTopLayer();
+      onMouseDown={(e) => {
+        scrimPointerDown.current = e.target === e.currentTarget && isTopLayer();
       }}
       onClick={() => {
-        const wasTop = topLayerAtPointerDown.current;
-        topLayerAtPointerDown.current = false;
-        if (busy || !wasTop || !isTopLayer()) return;
+        const startedOnScrim = scrimPointerDown.current;
+        scrimPointerDown.current = false;
+        if (busy || !startedOnScrim || !isTopLayer()) return;
         onClose();
       }}
     >

--- a/packages/core-frontend/src/shared/components/PageShell.tsx
+++ b/packages/core-frontend/src/shared/components/PageShell.tsx
@@ -9,7 +9,7 @@ export type PageShellWidth = keyof typeof WIDTH_CLASS;
 
 /**
  * Minimal shared chrome for the shell's standalone routed pages (Secrets,
- * External agent access, Roles & Members): a full-height scrolling canvas
+ * External agent access, App roles): a full-height scrolling canvas
  * with a centered max-width column, a page-title row and a white content
  * card. Deliberately tiny — it mirrors the Tailwind idioms the tools
  * explorer page already uses; it is not a design system.

--- a/packages/core-frontend/src/shared/components/__tests__/primitives.test.tsx
+++ b/packages/core-frontend/src/shared/components/__tests__/primitives.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState, type ReactElement } from 'react';
 import { cn } from '../../../lib/utils';
@@ -9,7 +9,6 @@ import {
   Dialog,
   IconButton,
   useDismissableMenu,
-  useModalLayer,
   Surface,
   ListRow,
   Badge,
@@ -338,14 +337,14 @@ describe('Menu', () => {
 describe('Dialog', () => {
   /**
    * A menu hosted inside the dialog, built the way `ManageAccessDialog`'s
-   * are: it dismisses on an outside `mousedown` and holds the top modal layer
-   * while open. The layer pops when it unmounts — before the same gesture's
-   * `click` reaches the scrim.
+   * are: it dismisses on an outside `mousedown`, and the HOOK holds the top
+   * modal layer while it is open (registering a second layer here would sit
+   * above the hook's own and steal its Escape). The layer pops when the menu
+   * unmounts — before the same gesture's `click` reaches the scrim.
    */
-  function HostedMenu({ onClose }: { onClose(): void }) {
+  function HostedMenu({ name, onClose }: { name?: string; onClose(): void }) {
     const ref = useDismissableMenu<HTMLDivElement>({ open: true, onClose });
-    useModalLayer(true);
-    return <div ref={ref} role="menu" />;
+    return <div ref={ref} role="menu" aria-label={name ?? 'menu'} />;
   }
   // The menu opens from a control inside the dialog, so its layer lands on
   // the stack ABOVE the dialog's — mounted together, the child's effect
@@ -375,6 +374,74 @@ describe('Dialog', () => {
 
     // The next scrim click began with the dialog on top, and closes it.
     await user.click(scrim);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('a drag that starts inside the panel and releases on the scrim does not close the dialog', async () => {
+    // Selecting text and overshooting the panel edge makes the browser fire
+    // `click` on the common ancestor of mousedown and mouseup — the scrim
+    // container. The panel's stopPropagation never sees that click, so the
+    // scrim must judge the gesture by where the POINTER WENT DOWN.
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Dialog open onClose={onClose} title="Host">
+        <p>Some selectable text</p>
+      </Dialog>,
+    );
+    const panel = screen.getByRole('dialog');
+    const scrim = panel.parentElement!;
+
+    fireEvent.mouseDown(panel);
+    fireEvent.mouseUp(scrim);
+    fireEvent.click(scrim);
+    expect(onClose).not.toHaveBeenCalled();
+
+    // A genuine scrim click — down and up on the scrim — still closes.
+    await user.click(scrim);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape peels one layer at a time when two menus are open above the dialog', async () => {
+    // Reachable by keyboard only: opening a menu by Enter fires no mousedown,
+    // so nothing dismisses the first menu when the second opens. Each press
+    // of Escape must close exactly the topmost layer, newest first — never
+    // both menus, and never the dialog underneath them.
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    function TwoMenuHost() {
+      const [first, setFirst] = useState(false);
+      const [second, setSecond] = useState(false);
+      return (
+        <Dialog open onClose={onClose} title="Host">
+          <button onClick={() => setFirst(true)}>Open first</button>
+          <button onClick={() => setSecond(true)}>Open second</button>
+          {first && <HostedMenu name="first" onClose={() => setFirst(false)} />}
+          {second && <HostedMenu name="second" onClose={() => setSecond(false)} />}
+        </Dialog>
+      );
+    }
+    render(<TwoMenuHost />);
+    // Enter, not click: a click's mousedown would dismiss the first menu
+    // before the second ever opens — which is why this state is
+    // keyboard-only in the first place.
+    screen.getByRole('button', { name: 'Open first' }).focus();
+    await user.keyboard('{Enter}');
+    screen.getByRole('button', { name: 'Open second' }).focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getAllByRole('menu')).toHaveLength(2);
+
+    await user.keyboard('{Escape}');
+    // Only the newest layer went; its sibling and the dialog stand.
+    expect(screen.getByRole('menu', { name: 'first' })).toBeInTheDocument();
+    expect(screen.queryByRole('menu', { name: 'second' })).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core-frontend/src/shared/components/index.ts
+++ b/packages/core-frontend/src/shared/components/index.ts
@@ -44,6 +44,7 @@ export type { DialogSize } from './Dialog';
 export { PageShell } from './PageShell';
 export type { PageShellWidth } from './PageShell';
 export { useModalLayer } from './useModalLayer';
+export { useLatestRef } from './useLatestRef';
 export { useDismissableMenu } from './useDismissableMenu';
 export type { DismissableMenuOptions } from './useDismissableMenu';
 export { useFocusHandoff } from './useFocusHandoff';

--- a/packages/core-frontend/src/shared/components/useDismissableMenu.ts
+++ b/packages/core-frontend/src/shared/components/useDismissableMenu.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef, type RefObject } from 'react';
+import { useModalLayer } from './useModalLayer';
+import { useLatestRef } from './useLatestRef';
 
 /**
  * The behaviour `MenuPanel` deliberately does not provide.
@@ -15,14 +17,31 @@ import { useEffect, useRef, type RefObject } from 'react';
  * whatever opened the menu — otherwise focus is left on a node that just
  * unmounted and the next Tab starts from the top of the document.
  *
+ * The hook owns two contracts its callers used to carry:
+ *
+ * - **It is a modal layer.** An open menu registers on the modal-layer stack,
+ *   and its Escape acts only while the menu is the TOPMOST layer. That is
+ *   what makes Escape peel one layer at a time in every composition: a menu
+ *   inside a `<Dialog>` closes before the dialog (the dialog's own Escape
+ *   guard sees it is not topmost), and two menus open at once — reachable by
+ *   keyboard, where no mousedown dismisses the first — close one per press,
+ *   newest first, instead of both on one press. Outside-click is different on
+ *   purpose: clicking away is "dismiss everything light-weight", so it stays
+ *   unguarded.
+ * - **`onClose` may be a fresh arrow every render.** The hook mirrors it into
+ *   a ref itself, so its document listeners subscribe once for the life of
+ *   the open menu. Callers must not wrap it in their own ref-plus-stable-
+ *   callback scaffolding — that pattern's drift is exactly what this replaces.
+ *
  * Returns the ref to put on the panel.
  */
 export interface DismissableMenuOptions {
   open: boolean;
+  /** Close the menu. May be a fresh arrow each render — the hook mirrors it. */
   onClose: () => void;
   /**
    * The control that opened the menu. Clicks on it are ignored (its own
-   * handler toggles), and Escape hands focus back to it.
+   * handler toggles), and Escape hands focus back to it. A stable ref.
    */
   returnFocusTo?: RefObject<HTMLElement | null>;
 }
@@ -33,6 +52,8 @@ export function useDismissableMenu<T extends HTMLElement>({
   returnFocusTo,
 }: DismissableMenuOptions): RefObject<T | null> {
   const panelRef = useRef<T>(null);
+  const onCloseRef = useLatestRef(onClose);
+  const isTop = useModalLayer(open);
 
   useEffect(() => {
     if (!open) return;
@@ -43,19 +64,20 @@ export function useDismissableMenu<T extends HTMLElement>({
       // A click on the trigger is the trigger's business — closing here too
       // would make a toggle button close-then-reopen on a single click.
       if (returnFocusTo?.current?.contains(target)) return;
-      onClose();
+      onCloseRef.current();
     }
 
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return;
-      // Stops window-level Escape handlers from also acting on this key. It
-      // does NOT protect against a `<Dialog>` hosting the menu — Dialog binds
-      // on `document` too, and same-node listeners are unaffected by
-      // stopPropagation. Nothing here mounts a menu inside a dialog; if
-      // something ever does, the fix is `useModalLayer`, not a third
-      // listener.
+      // Only the topmost layer owns this Escape. Same-node `document`
+      // listeners are unaffected by stopPropagation, so without this guard a
+      // second open menu — or the `<Dialog>` hosting this one — would act on
+      // the same keypress. Listeners run in subscription order (oldest
+      // first), so every layer below the top returns here and exactly one
+      // closes per press.
+      if (!isTop()) return;
       e.stopPropagation();
-      onClose();
+      onCloseRef.current();
       returnFocusTo?.current?.focus();
     }
 
@@ -65,7 +87,7 @@ export function useDismissableMenu<T extends HTMLElement>({
       document.removeEventListener('mousedown', onPointerDown);
       document.removeEventListener('keydown', onKey);
     };
-  }, [open, onClose, returnFocusTo]);
+  }, [open, isTop, returnFocusTo, onCloseRef]);
 
   return panelRef;
 }

--- a/packages/core-frontend/src/shared/components/useLatestRef.ts
+++ b/packages/core-frontend/src/shared/components/useLatestRef.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Mirror a fresh-every-render value into a stable ref.
+ *
+ * The pattern this replaces was hand-rolled in three places (Dialog's
+ * `onClose`/`busy`, AnchoredMenu's `onDismiss`, AdminRolesPage's `onCancel`)
+ * and exists for one reason: callers pass a fresh arrow each render, and an
+ * effect that lists it in its deps tears down and re-subscribes its document
+ * listeners on every render of an open overlay. Reading the value through
+ * this ref instead gives the effect a dependency-free view of the latest
+ * callback, so it subscribes once for the life of the overlay.
+ *
+ * The write happens in a passive effect, after paint — the same timing every
+ * hand-rolled copy used. Do not read the ref during render; it is for event
+ * handlers and effects.
+ */
+export function useLatestRef<T>(value: T): RefObject<T> {
+  const ref = useRef<T>(value);
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref;
+}


### PR DESCRIPTION
Post-merge review follow-up to #135 (merged as 598a972). Two edge-case bugs found in the merged code, fixed at their mechanisms, plus the cleanups the review flagged:

1. **Drag-out-of-dialog no longer closes it.** The scrim recorded only the layer state at mousedown; a text-selection drag that began in the panel and released on the backdrop fired `click` on their common ancestor and closed the dialog. The scrim now also requires the pointer to have gone DOWN on the scrim itself. Pinned by a test that fails against the previous code.
2. **Escape peels exactly one layer, always.** `useDismissableMenu` now registers the open menu as a modal layer itself and acts on Escape only while topmost — two keyboard-opened menus (reachable because Enter fires no dismissing mousedown) close one per press, newest first, and a menu inside a `Dialog` closes before it. Also pinned by a mutation-checked test.
3. **`useLatestRef`** replaces the three hand-rolled copies of the mirror-a-fresh-arrow idiom (Dialog, AnchoredMenu, AdminRolesPage); the hook now accepts an unstable `onClose` outright, so no caller ever rebuilds the scaffold.
4. The `document.addEventListener` spy test is rewritten through the public surface (re-render open menu with fresh callbacks → one Escape closes the menu, only the menu, dialog stands).
5. Comment sweep: both packages stop calling the admin pages "Roles & Members"/"the Groups page"; "formerly" breadcrumbs kept at the two defining sites so greps land from either era.

Verification: full core-frontend suite 1702/1702; both behavioral tests mutation-checked (reverting each fix fails exactly its test); typecheck clean; lint clean on touched files (two pre-existing baseline `set-state-in-effect` errors in untouched effects remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, dragging from inside a dialog onto its backdrop could close the dialog, and Escape could dismiss multiple overlays at once. The scrim now checks where the pointer went down, while Escape closes only the topmost menu or dialog, one layer per press.

- `useDismissableMenu` now owns modal-layer registration and accepts fresh `onClose` callbacks without resubscribing document listeners; outside-click dismissal is unchanged.
- Added `useLatestRef` and replaced duplicate callback-ref logic in dialogs, anchored menus, and the admin confirmation dialog.
- Added regression coverage for drag-out gestures, stacked menus, nested menus, and callback updates.

<sup>Written for commit feac8bea1293aae0347413c1eb6656d2c4e141ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

