### PR TITLE
Grep-File-Path — Grep given a file path searches that file, never a quiet empty

### DIFF
--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -599,6 +599,22 @@ describe('grep with a path that names a file', () => {
     expect(await grepRes.json()).toEqual(await readRes.json());
   });
 
+  it('a READABLE path the filesystem cannot resolve fails exactly as read_file fails', async () => {
+    const loop = `${KB_DIR}/Knowledge/Tangle.md`;
+    const base = await start();
+    await mkdir(join(tempDir, KB_DIR, 'Knowledge'), { recursive: true });
+    await symlink('Tangle.md', join(tempDir, loop));
+    const [readRes, grepRes] = await Promise.all([
+      post(`${base}/api/agent/tools/read_file`, { path: loop }),
+      post(`${base}/api/agent/tools/grep`, { pattern: 'needle', path: loop }),
+    ]);
+    // The gate allows it, so the READ is what answers — and it is the same
+    // `fs.readFile` read_file calls. grep must not dress that up as absence
+    // (a false 404), nor invent a failure of its own: one path, one story.
+    expect(grepRes.status).toBe(readRes.status);
+    expect(await grepRes.json()).toEqual(await readRes.json());
+  });
+
   it('a DIRECTORY path still walks the whole subtree (unchanged)', async () => {
     const base = await start();
     await fs.writeFile('notes/one.md', 'needle here\n');

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -1,6 +1,6 @@
 import type { Server as HttpServer } from 'node:http';
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -565,6 +565,38 @@ describe('grep with a path that names a file', () => {
       expect(grepRes.status, path).toBe(readRes.status);
       expect(await grepRes.json(), path).toEqual(await readRes.json());
     }
+  });
+
+  it('a path UNDER an existing file is nothing-there too — the same 404, not a raw failure', async () => {
+    const base = await start();
+    await fs.writeFile('notes/deep.md', 'alpha\n');
+    // `notes/deep.md` is a FILE, so the filesystem answers ENOTDIR rather than
+    // ENOENT. Nothing can live at this path either, so it earns the same
+    // honest 404 as a plainly absent one.
+    const res = await post(`${base}/api/agent/tools/grep`, {
+      pattern: 'needle',
+      path: 'notes/deep.md/deeper.md',
+    });
+    expect(res.status).toBe(404);
+    const { error } = (await res.json()) as { error: string };
+    expect(error).toContain('notes/deep.md/deeper.md');
+  });
+
+  it("a denied path the filesystem cannot even stat still answers with read_file's 403", async () => {
+    const loop = `${KB_DIR}/Knowledge/Loop.md`;
+    const base = await start('write', denyReads(new Set(['Knowledge/Loop.md'])));
+    await mkdir(join(tempDir, KB_DIR, 'Knowledge'), { recursive: true });
+    // A symlink pointing at ITSELF: stat fails with ELOOP — neither absence
+    // nor a readable file. The permission verdict must still come FIRST, or
+    // grep would leak a filesystem complaint where read_file says only 403.
+    await symlink('Loop.md', join(tempDir, loop));
+    const [readRes, grepRes] = await Promise.all([
+      post(`${base}/api/agent/tools/read_file`, { path: loop }),
+      post(`${base}/api/agent/tools/grep`, { pattern: 'needle', path: loop }),
+    ]);
+    expect(grepRes.status).toBe(403);
+    expect(grepRes.status).toBe(readRes.status);
+    expect(await grepRes.json()).toEqual(await readRes.json());
   });
 
   it('a DIRECTORY path still walks the whole subtree (unchanged)', async () => {

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.tools.test.ts
@@ -482,6 +482,103 @@ describe('read-permission gating', () => {
 });
 
 /**
+ * `grep` given a `path` that names a FILE. The walk begins with `readdir`,
+ * which fails on a file and on an absent path alike — so such a grep used to
+ * answer an empty match list, indistinguishable from "your pattern is not in
+ * there". Every case now answers honestly: the file's matches, a note when
+ * there was no text to search, or an error when there is nothing at the path.
+ */
+describe('grep with a path that names a file', () => {
+  interface GrepResult {
+    matches: { path: string; line: number; text: string }[];
+    truncated: boolean;
+    note?: string;
+  }
+  const grep = async (base: string, body: Record<string, unknown>): Promise<GrepResult> =>
+    (await (await post(`${base}/api/agent/tools/grep`, body)).json()) as GrepResult;
+
+  it('searches exactly that file — the match carries that path and a 1-based line number', async () => {
+    const base = await start();
+    await fs.writeFile('notes/deep.md', 'alpha\nbeta needle\ngamma\n');
+    // A sibling holding the same term: a file grep must not reach it.
+    await fs.writeFile('notes/other.md', 'needle elsewhere\n');
+    const res = await grep(base, { pattern: 'needle', path: 'notes/deep.md' });
+    expect(res.matches).toEqual([{ path: 'notes/deep.md', line: 2, text: 'beta needle' }]);
+    expect(res.truncated).toBe(false);
+    expect(res.note).toBeUndefined();
+  });
+
+  it('a file the pattern is simply not in is an empty SUCCESS — no note, no error', async () => {
+    const base = await start();
+    const res = await grep(base, { pattern: 'absent-term', path: 'a.md' });
+    expect(res.matches).toEqual([]);
+    expect(res.truncated).toBe(false);
+    expect(res.note).toBeUndefined();
+  });
+
+  it('caps a file grep at max_results and reports truncated, exactly as a directory grep does', async () => {
+    const base = await start();
+    await fs.writeFile('many.md', 'needle\n'.repeat(5));
+    const res = await grep(base, { pattern: 'needle', path: 'many.md', max_results: 2 });
+    expect(res.matches.map((m) => m.line)).toEqual([1, 2]);
+    expect(res.truncated).toBe(true);
+  });
+
+  it('a file with no searchable text returns empty matches plus a note saying so', async () => {
+    const base = await start();
+    // "needle" followed by a NUL byte: binary content, so nothing to search —
+    // the byte pattern is present but the file is not text.
+    await fs.writeFile('data.bin', Buffer.from('needle\0tail', 'latin1'));
+    await fs.writeFile(
+      'logo.png',
+      Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', 'base64'),
+    );
+    for (const path of ['data.bin', 'logo.png']) {
+      const res = await grep(base, { pattern: 'needle', path });
+      expect(res.matches, path).toEqual([]);
+      expect(res.note, path).toContain('no searchable text');
+      expect(res.note, path).toContain(path);
+    }
+  });
+
+  it('a path with nothing at it fails with an error naming the path — never an empty success', async () => {
+    const base = await start();
+    const res = await post(`${base}/api/agent/tools/grep`, { pattern: 'needle', path: 'notes/ghost.md' });
+    expect(res.status).toBe(404);
+    const { error } = (await res.json()) as { error: string };
+    expect(error).toContain('notes/ghost.md');
+  });
+
+  it('a FILE the caller may not read answers exactly as read_file does — same status, same body', async () => {
+    const secret = `${KB_DIR}/Knowledge/Secret.md`;
+    // Denied AND absent: the two tools must agree here too, or grep's error
+    // would reveal an existence read_file refuses to confirm.
+    const ghost = `${KB_DIR}/Knowledge/Ghost.md`;
+    const base = await start('write', denyReads(new Set(['Knowledge/Secret.md', 'Knowledge/Ghost.md'])));
+    await fs.writeFile(secret, 'secret needle\n');
+    for (const path of [secret, ghost]) {
+      const [readRes, grepRes] = await Promise.all([
+        post(`${base}/api/agent/tools/read_file`, { path }),
+        post(`${base}/api/agent/tools/grep`, { pattern: 'needle', path }),
+      ]);
+      expect(grepRes.status, path).toBe(403);
+      expect(grepRes.status, path).toBe(readRes.status);
+      expect(await grepRes.json(), path).toEqual(await readRes.json());
+    }
+  });
+
+  it('a DIRECTORY path still walks the whole subtree (unchanged)', async () => {
+    const base = await start();
+    await fs.writeFile('notes/one.md', 'needle here\n');
+    await fs.writeFile('notes/sub/two.md', 'and needle there\n');
+    await fs.writeFile('outside.md', 'needle outside the subtree\n');
+    const res = await grep(base, { pattern: 'needle', path: 'notes' });
+    expect(res.matches.map((m) => m.path).sort()).toEqual(['notes/one.md', 'notes/sub/two.md']);
+    expect(res.note).toBeUndefined();
+  });
+});
+
+/**
  * Document reading: read_file/grep consume the doc-extract service for office
  * documents and PDFs; the agent text-editing tools refuse them. Fixtures are
  * REAL files built in-test (a docx is just a zip with word/document.xml).
@@ -625,6 +722,38 @@ describe('office documents and PDFs', () => {
     const markers = (await (await post(`${base}/api/agent/tools/grep`, { pattern: '\\[slide 2\\]' })).json()) as { matches: { path: string }[] };
     expect(markers.matches).toContainEqual(expect.objectContaining({ path: 'deck.pptx' }));
     expect(res.note).toBeUndefined();
+  });
+
+  it('grep on a path naming a DOCUMENT searches its extraction the way the walk does — markers included', async () => {
+    const base = await start();
+    await fs.writeFile('deck.pptx', pptx([['Intro'], ['Roadmap 2026']]));
+    // A second deck carrying the same term: a file grep must not reach it.
+    await fs.writeFile('decoy.pptx', pptx([['Roadmap 2026 decoy deck']]));
+    const res = (await (await post(`${base}/api/agent/tools/grep`, { pattern: 'Roadmap', path: 'deck.pptx' })).json()) as {
+      matches: { path: string; line: number; text: string }[];
+      note?: string;
+    };
+    // Same line arithmetic as the directory grep: marker 1, [slide 1] 2,
+    // Intro 3, [slide 2] 4, Roadmap 5.
+    expect(res.matches).toEqual([{ path: 'deck.pptx', line: 5, text: 'Roadmap 2026' }]);
+    expect(res.note).toBeUndefined();
+    // The structure markers are searchable on the single-file path too.
+    const markers = (await (await post(`${base}/api/agent/tools/grep`, { pattern: '\\[slide 2\\]', path: 'deck.pptx' })).json()) as {
+      matches: { path: string; line: number }[];
+    };
+    expect(markers.matches).toEqual([expect.objectContaining({ path: 'deck.pptx', line: 4 })]);
+  });
+
+  it('grep on a path naming a CORRUPT document notes it has no searchable text', async () => {
+    const base = await start();
+    await fs.writeFile('broken.docx', Buffer.from('not really a zip'));
+    const res = (await (await post(`${base}/api/agent/tools/grep`, { pattern: 'zip', path: 'broken.docx' })).json()) as {
+      matches: unknown[];
+      note?: string;
+    };
+    expect(res.matches).toEqual([]);
+    expect(res.note).toContain('no searchable text');
+    expect(res.note).toContain('broken.docx');
   });
 
   it('grep extracts at most 20 uncached documents per call and notes the skipped rest; a re-run covers them', async () => {

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -26,7 +26,7 @@ import type { IAccessControl } from '../access/access-control.interface.js';
 import { toKbRelative, resolveReadableMap } from '../access-model/kb-read-filter.js';
 import type { SpillStore } from './spill-store.js';
 import type { DocExtractService } from './file-readers/doc-extract.service.js';
-import type { FileReaderRegistry } from './file-readers/file-reader.js';
+import { displayPath, type FileReaderRegistry } from './file-readers/file-reader.js';
 import { createFileReaderRegistry } from './file-readers/file-reader.registry.js';
 import { DocumentReader } from './file-readers/document-reader.js';
 import { mcpImageResult } from '@bevel-software/platform-mcp-core';
@@ -211,6 +211,89 @@ async function assertNotBinaryOverwrite(
   return existing;
 }
 
+/**
+ * What searching ONE file amounted to. The walk ignores this (a file with
+ * nothing searchable is just a file with no matches), but a grep whose path
+ * NAMES that one file has nothing else to report: without this it could only
+ * answer an empty match list, which reads as "your pattern is not in there"
+ * when the truth is "there was never any text to look at".
+ */
+type FileGrepOutcome =
+  /** Its text was searched; any matches are in `out`. */
+  | 'searched'
+  /** No searchable text at all: an image, binary content, a corrupt document. */
+  | 'no-text'
+  /** A cold document the per-call extraction budget could not afford (counted in `docs`). */
+  | 'budget-skipped';
+
+/**
+ * Search ONE file and append its matches to `out`. Shared by the directory
+ * walk and by a grep whose `path` names a file, so both produce the same match
+ * shape (that path, 1-based line numbers, 300-char text) under the same cap.
+ *
+ * What is searched is the file's reader's business: text content for the text
+ * reader (null on NUL bytes / invalid UTF-8 — binary is not searchable), the
+ * EXTRACTION for a document reader (marker line included, so the
+ * `[slide N]`/`[sheet: …]`/`[page N]` lines are themselves searchable and line
+ * numbers match what read_file returns), nothing for images.
+ *
+ * Throws whatever reading the file throws — the caller decides whether that is
+ * a file to skip (the walk) or an error to surface (a single-file grep).
+ */
+async function grepOneFile(
+  fs: LocalFilesystem,
+  path: string,
+  re: RegExp,
+  out: { path: string; line: number; text: string }[],
+  max: number,
+  docs: DocGrepState,
+): Promise<FileGrepOutcome> {
+  const reader = docs.readers.readerFor(path);
+  const bytes = asBytes(await fs.readFile(path));
+  let content = reader.greppableText ? await reader.greppableText(bytes, path) : null;
+  if (content === null && reader instanceof DocumentReader) {
+    // Cold document (extraction not yet cached): cached ones above are free,
+    // extracting draws on the per-walk budget (see UNCACHED_DOCS_PER_GREP) —
+    // beyond it the search skips the document and counts it.
+    if (docs.uncachedBudget <= 0) {
+      docs.skippedUncached++;
+      return 'budget-skipped';
+    }
+    docs.uncachedBudget--;
+    const res = await reader.read(bytes, path);
+    // A non-text outcome is a corrupt document — nothing searchable.
+    content = res.kind === 'text' ? res.text : null;
+  }
+  if (content === null) return 'no-text';
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length && out.length < max; i++) {
+    re.lastIndex = 0;
+    if (re.test(lines[i])) out.push({ path, line: i + 1, text: lines[i].slice(0, 300) });
+  }
+  return 'searched';
+}
+
+/**
+ * What a grep's `path` actually names. The walk starts with `readdir`, which
+ * fails on a file and on a path with nothing at it alike — both would end as a
+ * silent empty result — so the search root is resolved FIRST and each of the
+ * three cases gets its own honest answer.
+ */
+async function searchRootKind(
+  fs: LocalFilesystem,
+  path: string,
+): Promise<'directory' | 'file' | 'missing'> {
+  try {
+    return (await fs.stat(path)).type === 'directory' ? 'directory' : 'file';
+  } catch (err) {
+    // Only "nothing there" is missing (Mastra's FileNotFoundError carries code
+    // 'ENOENT', as do raw Node errors). Anything else — permissions, I/O — is a
+    // real failure and must not be reported as an absent path.
+    if ((err as { code?: unknown } | null)?.code === 'ENOENT') return 'missing';
+    throw err;
+  }
+}
+
 /** JS grep over the workspace tree (read methods only) — bounded by match + depth caps. */
 async function grepWalk(
   fs: LocalFilesystem,
@@ -244,37 +327,12 @@ async function grepWalk(
       // for a root-level grep that resolves to a neutral root. Record it so a
       // cross-ontology grep poisons later writes (closes the read-leak).
       await recordOntologyRead(p);
-      // What grep searches is the file's reader's business: text content for
-      // the text reader (null on NUL bytes — binary is not searchable), the
-      // EXTRACTION for a document reader (marker line included, so the
-      // [slide N]/[sheet: …]/[page N] lines are themselves searchable and
-      // line numbers match what read_file returns), nothing for images.
-      const reader = docs.readers.readerFor(p);
-      let content: string | null;
+      // A file the walk cannot read is silently skipped: one unreadable entry
+      // must not fail a search over the whole tree.
       try {
-        const bytes = asBytes(await fs.readFile(p));
-        content = reader.greppableText ? await reader.greppableText(bytes, p) : null;
-        if (content === null && reader instanceof DocumentReader) {
-          // Cold document (extraction not yet cached): cached ones above are
-          // free, extracting draws on the per-walk budget (see
-          // UNCACHED_DOCS_PER_GREP) — beyond it the walk skips and counts.
-          if (docs.uncachedBudget <= 0) {
-            docs.skippedUncached++;
-            continue;
-          }
-          docs.uncachedBudget--;
-          const res = await reader.read(bytes, p);
-          // A non-text outcome is a corrupt document — nothing searchable.
-          content = res.kind === 'text' ? res.text : null;
-        }
+        await grepOneFile(fs, p, re, out, max, docs);
       } catch {
         continue;
-      }
-      if (content === null) continue;
-      const lines = content.split('\n');
-      for (let i = 0; i < lines.length && out.length < max; i++) {
-        re.lastIndex = 0;
-        if (re.test(lines[i])) out.push({ path: p, line: i + 1, text: lines[i].slice(0, 300) });
       }
     }
   }
@@ -542,14 +600,14 @@ export function registerWorkspaceTools(
   mount({
     name: 'grep',
     description:
-      'Regex content search across the workspace. Returns `{ matches: [{ path, line, text }] }` (capped). Use to find where something is defined/referenced. Searches INSIDE Office and OpenDocument files (.docx/.pptx/.xlsx, .odt/.odp/.ods), PDFs and email files (.eml/.msg) via their extracted text — matches there carry the extraction\'s line numbers, and the `[slide N]`/`[sheet: Name]`/`[page N]`/`[from]`/`[subject]` marker lines locate them; a bounded number of not-yet-extracted documents is extracted per call, and the result notes how many were skipped (re-run to cover them).' +
+      'Regex content search across the workspace. Returns `{ matches: [{ path, line, text }] }` (capped). Use to find where something is defined/referenced. `path` may name a DIRECTORY (searches the subtree) or a single FILE (searches just that file); a path with nothing at it is an error, never an empty result. Searches INSIDE Office and OpenDocument files (.docx/.pptx/.xlsx, .odt/.odp/.ods), PDFs and email files (.eml/.msg) via their extracted text — matches there carry the extraction\'s line numbers, and the `[slide N]`/`[sheet: Name]`/`[page N]`/`[from]`/`[subject]` marker lines locate them; a bounded number of not-yet-extracted documents is extracted per call, and the result notes how many were skipped (re-run to cover them).' +
       ONTOLOGY_BOUNDARY_NOTE,
     inputs: {
       type: 'object',
       properties: {
         branch: BRANCH_INPUT,
         pattern: str('JavaScript regular expression.'),
-        path: str('Subtree to search (default: whole workspace).'),
+        path: str('Subtree to search, or a single file to search on its own (default: whole workspace).'),
         ignore_case: { type: 'boolean', description: 'Case-insensitive match.' },
         max_results: { type: 'integer', minimum: 1, maximum: 1000, description: 'Cap on matches (default 200).' },
         sessionId: SESSION_ID_INPUT,
@@ -570,7 +628,7 @@ export function registerWorkspaceTools(
           },
         },
         truncated: { type: 'boolean', description: 'True if the match cap was hit and results may be incomplete.' },
-        note: str('Present when some documents (office/PDF/email files) were not searched because their text was not yet extracted and the per-call extraction budget ran out — re-run grep to cover them.'),
+        note: str('Present when the empty/partial result needs explaining: a `path` naming a file with no searchable text (image, binary, corrupt document), or documents (office/PDF/email files) left unsearched because their text was not yet extracted and the per-call extraction budget ran out — re-run grep to cover those.'),
       },
       required: ['matches', 'truncated'],
     },
@@ -588,31 +646,63 @@ export function registerWorkspaceTools(
       // recorded per-file below, so a root-level grep that reaches into multiple
       // ontologies still records each one (and can poison later writes).
       await recordOntologyRead(sessionOntologyGate, ctx, searchRoot);
+      const fs = await ctx.getFilesystem(a.branch as string);
+      const gate = readGateFor(a.branch as string, ctx);
       const out: { path: string; line: number; text: string }[] = [];
       const max = typeof a.max_results === 'number' ? Math.min(a.max_results, 1000) : 200;
       const docs: DocGrepState = { readers, uncachedBudget: UNCACHED_DOCS_PER_GREP, skippedUncached: 0 };
-      await grepWalk(
-        await ctx.getFilesystem(a.branch as string),
-        searchRoot,
-        re,
-        out,
-        max,
-        0,
-        readGateFor(a.branch as string, ctx),
-        (p) => recordOntologyRead(sessionOntologyGate, ctx, p),
-        docs,
-      );
+      // The empty root is the workspace itself — always a directory, and never
+      // worth a stat.
+      const kind = searchRoot === '' ? 'directory' : await searchRootKind(fs, searchRoot);
+      /** Why a single-file search found nothing, when "no matches" would be a lie. */
+      let fileNote: string | undefined;
+      if (kind === 'directory') {
+        await grepWalk(
+          fs,
+          searchRoot,
+          re,
+          out,
+          max,
+          0,
+          gate,
+          (p) => recordOntologyRead(sessionOntologyGate, ctx, p),
+          docs,
+        );
+      } else {
+        // Not a directory: the permission verdict comes BEFORE the existence
+        // one, and it is `read_file`'s own gate on the same path — so grep
+        // answers a path the caller may not read exactly as read_file does,
+        // and can never confirm the existence of one read_file would hide.
+        await assertCanRead(gate, searchRoot);
+        if (kind === 'missing') {
+          throw new ToolError(
+            `Nothing to search: there is no file or directory at "${displayPath(searchRoot)}" in this workspace. ` +
+              `Paths are workspace-relative and content lives under \`${kbDirName}/\` — use list_files to find the right one.`,
+            404,
+          );
+        }
+        // A named FILE is searched directly: routing it through the walk would
+        // fail its readdir and answer an empty match list, which the caller
+        // cannot tell from "the pattern is not in this file".
+        const outcome = await grepOneFile(fs, searchRoot, re, out, max, docs);
+        if (outcome === 'no-text') {
+          fileNote =
+            `"${displayPath(searchRoot)}" has no searchable text — it is an image, binary content, or a document ` +
+            'whose text could not be extracted. There were no matches because there was nothing to search, not ' +
+            'because the pattern is absent.';
+        }
+      }
+      const note =
+        fileNote ??
+        (docs.skippedUncached > 0
+          ? `${docs.skippedUncached} document(s) (office/PDF/email files) were not searched: their text was not yet ` +
+            `extracted and this call's extraction budget (${UNCACHED_DOCS_PER_GREP}) ran out. Re-run the ` +
+            'same grep to extract and search the next batch.'
+          : undefined);
       return {
         matches: out,
         truncated: out.length >= max,
-        ...(docs.skippedUncached > 0
-          ? {
-              note:
-                `${docs.skippedUncached} document(s) (office/PDF/email files) were not searched: their text was not yet ` +
-                `extracted and this call's extraction budget (${UNCACHED_DOCS_PER_GREP}) ran out. Re-run the ` +
-                'same grep to extract and search the next batch.',
-            }
-          : {}),
+        ...(note !== undefined ? { note } : {}),
       };
     },
   });

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -277,20 +277,33 @@ async function grepOneFile(
  * What a grep's `path` actually names. The walk starts with `readdir`, which
  * fails on a file and on a path with nothing at it alike — both would end as a
  * silent empty result — so the search root is resolved FIRST and each of the
- * three cases gets its own honest answer.
+ * four cases gets its own honest answer.
+ *
+ * A failed stat is NOT resolved here into an error to throw: the caller owes
+ * the path's read gate its verdict first (see the handler), so an unreadable
+ * root reports the gate's answer rather than whatever the filesystem said.
+ * `unknown` carries that failure back for the caller to rethrow if the gate
+ * lets the path through.
  */
 async function searchRootKind(
   fs: LocalFilesystem,
   path: string,
-): Promise<'directory' | 'file' | 'missing'> {
+): Promise<
+  | { kind: 'directory' | 'file' | 'missing' }
+  | { kind: 'unknown'; err: unknown }
+> {
   try {
-    return (await fs.stat(path)).type === 'directory' ? 'directory' : 'file';
+    return { kind: (await fs.stat(path)).type === 'directory' ? 'directory' : 'file' };
   } catch (err) {
-    // Only "nothing there" is missing (Mastra's FileNotFoundError carries code
-    // 'ENOENT', as do raw Node errors). Anything else — permissions, I/O — is a
-    // real failure and must not be reported as an absent path.
-    if ((err as { code?: unknown } | null)?.code === 'ENOENT') return 'missing';
-    throw err;
+    // "Nothing there" is absence: plain ENOENT, and ENOTDIR for a path whose
+    // parent is an existing FILE (`notes.md/deeper`) — nothing can live there
+    // either, so it earns the same honest 404 rather than a raw failure.
+    // (Mastra's FileNotFoundError carries these codes, as do raw Node errors.)
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return { kind: 'missing' };
+    // Anything else — permissions, I/O, symlink loops — is a real failure and
+    // must not be reported as an absent path.
+    return { kind: 'unknown', err };
   }
 }
 
@@ -653,7 +666,11 @@ export function registerWorkspaceTools(
       const docs: DocGrepState = { readers, uncachedBudget: UNCACHED_DOCS_PER_GREP, skippedUncached: 0 };
       // The empty root is the workspace itself — always a directory, and never
       // worth a stat.
-      const kind = searchRoot === '' ? 'directory' : await searchRootKind(fs, searchRoot);
+      const root =
+        searchRoot === ''
+          ? ({ kind: 'directory' } as const)
+          : await searchRootKind(fs, searchRoot);
+      const kind = root.kind;
       /** Why a single-file search found nothing, when "no matches" would be a lie. */
       let fileNote: string | undefined;
       if (kind === 'directory') {
@@ -669,11 +686,16 @@ export function registerWorkspaceTools(
           docs,
         );
       } else {
-        // Not a directory: the permission verdict comes BEFORE the existence
+        // Not a directory: the permission verdict comes BEFORE every other
         // one, and it is `read_file`'s own gate on the same path — so grep
         // answers a path the caller may not read exactly as read_file does,
         // and can never confirm the existence of one read_file would hide.
+        // That ordering holds even when the stat itself failed: a denied path
+        // gets the 403, never the filesystem's complaint about it.
         await assertCanRead(gate, searchRoot);
+        // Readable, but the filesystem would not say what is there. Nothing
+        // honest is left to answer — surface the real failure.
+        if (root.kind === 'unknown') throw root.err;
         if (kind === 'missing') {
           throw new ToolError(
             `Nothing to search: there is no file or directory at "${displayPath(searchRoot)}" in this workspace. ` +

--- a/packages/core-backend/src/modules/workspace/workspace.tools.ts
+++ b/packages/core-backend/src/modules/workspace/workspace.tools.ts
@@ -276,34 +276,34 @@ async function grepOneFile(
 /**
  * What a grep's `path` actually names. The walk starts with `readdir`, which
  * fails on a file and on a path with nothing at it alike — both would end as a
- * silent empty result — so the search root is resolved FIRST and each of the
- * four cases gets its own honest answer.
+ * silent empty result — so the search root is resolved FIRST and each case
+ * gets its own honest answer.
  *
- * A failed stat is NOT resolved here into an error to throw: the caller owes
- * the path's read gate its verdict first (see the handler), so an unreadable
- * root reports the gate's answer rather than whatever the filesystem said.
- * `unknown` carries that failure back for the caller to rethrow if the gate
- * lets the path through.
+ * This helper never raises an error of its own. Only a DIRECTORY answer earns
+ * the walk; everything else takes the single-file route, where the read gate
+ * speaks first and the answer is then produced by the very `fs.readFile` that
+ * `read_file` calls. That is what makes grep tell read_file's story for an odd
+ * path by CONSTRUCTION rather than by coincidence.
  */
 async function searchRootKind(
   fs: LocalFilesystem,
   path: string,
-): Promise<
-  | { kind: 'directory' | 'file' | 'missing' }
-  | { kind: 'unknown'; err: unknown }
-> {
+): Promise<'directory' | 'file' | 'missing'> {
   try {
-    return { kind: (await fs.stat(path)).type === 'directory' ? 'directory' : 'file' };
+    return (await fs.stat(path)).type === 'directory' ? 'directory' : 'file';
   } catch (err) {
     // "Nothing there" is absence: plain ENOENT, and ENOTDIR for a path whose
     // parent is an existing FILE (`notes.md/deeper`) — nothing can live there
     // either, so it earns the same honest 404 rather than a raw failure.
     // (Mastra's FileNotFoundError carries these codes, as do raw Node errors.)
     const code = (err as { code?: unknown } | null)?.code;
-    if (code === 'ENOENT' || code === 'ENOTDIR') return { kind: 'missing' };
-    // Anything else — permissions, I/O, symlink loops — is a real failure and
-    // must not be reported as an absent path.
-    return { kind: 'unknown', err };
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 'missing';
+    // Any OTHER stat failure — permissions, I/O, a symlink loop — is not
+    // absence and is not this helper's to report. Calling it a file sends the
+    // path down the ordinary single-file route: the gate answers 403 if the
+    // caller may not read it, and otherwise the read itself fails exactly as
+    // `read_file`'s does. Nothing is invented, and nothing extra is disclosed.
+    return 'file';
   }
 }
 
@@ -666,11 +666,7 @@ export function registerWorkspaceTools(
       const docs: DocGrepState = { readers, uncachedBudget: UNCACHED_DOCS_PER_GREP, skippedUncached: 0 };
       // The empty root is the workspace itself — always a directory, and never
       // worth a stat.
-      const root =
-        searchRoot === ''
-          ? ({ kind: 'directory' } as const)
-          : await searchRootKind(fs, searchRoot);
-      const kind = root.kind;
+      const kind = searchRoot === '' ? 'directory' : await searchRootKind(fs, searchRoot);
       /** Why a single-file search found nothing, when "no matches" would be a lie. */
       let fileNote: string | undefined;
       if (kind === 'directory') {
@@ -693,9 +689,6 @@ export function registerWorkspaceTools(
         // That ordering holds even when the stat itself failed: a denied path
         // gets the 403, never the filesystem's complaint about it.
         await assertCanRead(gate, searchRoot);
-        // Readable, but the filesystem would not say what is there. Nothing
-        // honest is left to answer — surface the real failure.
-        if (root.kind === 'unknown') throw root.err;
         if (kind === 'missing') {
           throw new ToolError(
             `Nothing to search: there is no file or directory at "${displayPath(searchRoot)}" in this workspace. ` +


### PR DESCRIPTION
Fixes ticket: `Data/Engineering/Knowledge/Hexis/Tickets/Grep-File-Path.md`

## Summary
`grep` now treats a path naming a readable file the same way `read_file` and the directory walk treat it, instead of silently returning an empty match set:

- A path naming a readable text file is searched directly: matches carry that path, 1-based line numbers, and the same match shape/cap behavior as a directory grep.
- A path naming a readable document file (office/PDF/email) is searched via the same extraction the directory walk uses — marker lines included, extraction budget and the existing `note` for unextracted documents respected.
- A path that exists but has no searchable text (image, binary with NUL bytes, corrupt document) returns empty matches plus a `note` explaining there is no searchable text.
- A path that does not exist fails with a structured error naming the path, never an empty success.
- A file path the caller may not read responds exactly as `read_file` does for that same path (same error and shape), so `grep` and `read_file` tell one story.
- Directory grep behavior is unchanged: unreadable entries are still silently filtered from walks, and depth/match caps are unchanged.

## Testing
- `packages/core-backend` vitest: 195 files / 2340 tests passed.
- `tsc --noEmit` clean for all packages except `apps/server` (pre-existing unbuilt-dist error, unrelated to this change).
- Live verification against a from-source build (`deployment/docker-compose.build.yml`) covering all acceptance criteria: file hit, file miss, cap/truncation, document (pptx) extraction with marker lines, document extraction budget note, no-searchable-text note (binary/image/corrupt doc), missing path error, unreadable file parity with `read_file`, and an unchanged directory-grep regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Grep-File-Path ticket: `grep` given a path naming a readable file now searches that file directly, instead of silently returning an empty match set.

- Missing paths fail with a structured 404 naming the path, including paths under an existing file (ENOTDIR).
- Files with no searchable text (image, binary, corrupt document) return empty matches plus a `note`.
- Any stat failure that isn't absence routes as a file, so the read gate answers first: an unreadable path gets `read_file`'s exact 403, and a readable but unresolvable path fails with `read_file`'s own error — nothing is invented or disclosed.
- Document files go through the same extraction as the directory walk, marker lines and extraction budget note included.
- Directory grep is unchanged: unreadable entries still silently filtered, depth and match caps unchanged.

<sup>Written for commit b338e2f4a0e6f80b91ed23c1548d7d30d248eb88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

