### PR TITLE
CR-Moved-File-View — A moved file in the change-request view shows its change, not an eternal "Loading…"

### DIFF
--- a/packages/core-frontend/src/modules/change-requests/__tests__/ChangeRequestDialog.moved.test.tsx
+++ b/packages/core-frontend/src/modules/change-requests/__tests__/ChangeRequestDialog.moved.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { PrFileStatus, PullRequestSummary } from '@bevel-software/platform-shared';
+
+/**
+ * A MOVED file in the change-request view.
+ *
+ * The pane reads the selected path on both branches. For a rename the
+ * selection is the NEW path — a path the default branch has never had — so
+ * that read 404s, and the pane, which had no way to tell a failed read from a
+ * slow one, sat on "Loading…" for as long as anyone cared to watch. The
+ * before-side of a move is the file at `previousPath`; these tests pin the
+ * three readings that follow from it (rename with edits, pure move, no
+ * readable old path), plus the general failed-read state and the unchanged
+ * behaviour for an ordinary modified file.
+ */
+
+const detailMock = vi.hoisted(() => ({ fetchPrDetail: vi.fn() }));
+vi.mock('../../pr/services/pr-detail.api', () => ({ fetchPrDetail: detailMock.fetchPrDetail }));
+
+const readMock = vi.hoisted(() => ({ readFileOnBranch: vi.fn() }));
+vi.mock('../services/change-requests.api', () => ({
+  readFileOnBranch: readMock.readFileOnBranch,
+}));
+vi.mock('../../pr/services/pr-approvals.api', () => ({
+  approvePrFile: vi.fn(),
+  revertPrFile: vi.fn(),
+  unapprovePrFile: vi.fn(),
+}));
+vi.mock('../../pr/services/pr-merge.api', () => ({ mergePullRequest: vi.fn() }));
+vi.mock('../../pr/services/pr-cancel.api', () => ({
+  cancelPullRequest: vi.fn(),
+  deleteChangeRequest: vi.fn(),
+}));
+
+import { ChangeRequestDialog } from '../components/ChangeRequestDialog';
+
+/** What `test-setup.ts` pins the default branch to. */
+const MAIN = 'target-company-state';
+const CR_BRANCH = 'ali.raza/move-the-runbook';
+
+const OLD_PATH = 'Ops/runbook.yaml';
+const NEW_PATH = 'Docs/Ops/runbook.yaml';
+
+const CR: PullRequestSummary = {
+  number: 12,
+  title: 'Move the runbook under Docs',
+  authorId: 'abc',
+  author: { login: 'user-abc', name: 'Ali' },
+  appAuthor: { name: 'Ali' },
+  branch: CR_BRANCH,
+  base: 'main',
+  state: 'open',
+  createdAt: '2026-08-07T00:00:00.000Z',
+  touchedNodePaths: [],
+  review: { approvals: 0, changesRequested: 0, pendingLogins: [] },
+  url: '/change-requests/12',
+} as unknown as PullRequestSummary;
+
+function detailWith(file: {
+  path: string;
+  status: PrFileStatus;
+  previousPath?: string;
+}) {
+  return {
+    ...CR,
+    body: '',
+    headSha: 'h',
+    baseSha: 'b',
+    files: [{ ...file, additions: 1, deletions: 1, isBinary: false, sha: '', rawUrl: '' }],
+    comments: [],
+    approvals: [],
+    mergeableInBevel: true,
+    mergeBlockedReasons: [],
+    mergeWarnings: [],
+    viewerCanBypassMerge: false,
+    viewerCanCancel: false,
+  };
+}
+
+/** Reads answered per (branch, path); anything unlisted rejects, as the API does. */
+function reads(answers: Record<string, string>) {
+  readMock.readFileOnBranch.mockImplementation(async (branch: string, path: string) => {
+    const key = `${branch}::${path}`;
+    if (!(key in answers)) throw new Error(`404 ${key}`);
+    return answers[key];
+  });
+}
+
+const marks = () => ({
+  removed: [...document.querySelectorAll('del')].map((n) => n.textContent),
+  added: [...document.querySelectorAll('ins')].map((n) => n.textContent),
+});
+
+beforeEach(() => {
+  detailMock.fetchPrDetail.mockReset();
+  readMock.readFileOnBranch.mockReset();
+});
+
+describe('ChangeRequestDialog: a moved file', () => {
+  it('diffs the OLD path on the default branch against the new one, and names the move', async () => {
+    detailMock.fetchPrDetail.mockResolvedValue(
+      detailWith({ path: NEW_PATH, status: 'renamed', previousPath: OLD_PATH }),
+    );
+    reads({
+      [`${MAIN}::${OLD_PATH}`]: 'steps:\n  - stop the writer\n',
+      [`${CR_BRANCH}::${NEW_PATH}`]: 'steps:\n  - stop the writer, then drain\n',
+    });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    expect(await screen.findByText(`Moved: ${OLD_PATH} → ${NEW_PATH}`)).toBeInTheDocument();
+    // The standard marked-up reading: the edit, not the move, is what is marked.
+    await screen.findByText('- stop the writer, then drain', { exact: false });
+    expect(marks().removed).toEqual(['  - stop the writer']);
+    expect(marks().added).toEqual(['  - stop the writer, then drain']);
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+    // Never the new path on the default branch — that read is the 404 that hung.
+    expect(readMock.readFileOnBranch).not.toHaveBeenCalledWith(MAIN, NEW_PATH);
+  });
+
+  it('a pure move shows the move note and the content, with nothing marked', async () => {
+    const body = 'steps:\n  - stop the writer\n';
+    detailMock.fetchPrDetail.mockResolvedValue(
+      detailWith({ path: NEW_PATH, status: 'renamed', previousPath: OLD_PATH }),
+    );
+    reads({ [`${MAIN}::${OLD_PATH}`]: body, [`${CR_BRANCH}::${NEW_PATH}`]: body });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    expect(await screen.findByText(`Moved: ${OLD_PATH} → ${NEW_PATH}`)).toBeInTheDocument();
+    await screen.findByText('- stop the writer', { exact: false });
+    expect(marks()).toEqual({ removed: [], added: [] });
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+
+  it('an unreadable old path says so and shows the NEW content, unmarked', async () => {
+    detailMock.fetchPrDetail.mockResolvedValue(
+      detailWith({ path: NEW_PATH, status: 'renamed', previousPath: OLD_PATH }),
+    );
+    // The old path is gone from the default branch too (or unreadable there).
+    reads({ [`${CR_BRANCH}::${NEW_PATH}`]: 'steps:\n  - stop the writer\n' });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    expect(await screen.findByText(/old path couldn't be read/)).toBeInTheDocument();
+    // Review proceeds on what the request actually proposes.
+    await screen.findByText('- stop the writer', { exact: false });
+    expect(marks()).toEqual({ removed: [], added: [] });
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+
+  it('a rename with no previousPath at all lands in the same fallback', async () => {
+    detailMock.fetchPrDetail.mockResolvedValue({
+      ...detailWith({ path: NEW_PATH, status: 'renamed' }),
+    });
+    reads({
+      [`${MAIN}::${NEW_PATH}`]: 'never asked for',
+      [`${CR_BRANCH}::${NEW_PATH}`]: 'steps:\n  - stop the writer\n',
+    });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    expect(await screen.findByText(/old path couldn't be read/)).toBeInTheDocument();
+    await screen.findByText('- stop the writer', { exact: false });
+    // With no old path there is nothing to name, so no move line is claimed.
+    expect(screen.queryByText(/^Moved:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+});
+
+describe('ChangeRequestDialog: a default-branch read that fails', () => {
+  it("resolves to the pane's couldn't-be-read state rather than an endless Loading", async () => {
+    detailMock.fetchPrDetail.mockResolvedValue(
+      detailWith({ path: NEW_PATH, status: 'modified' }),
+    );
+    reads({ [`${CR_BRANCH}::${NEW_PATH}`]: 'steps:\n  - stop the writer\n' });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    expect(await screen.findByText(/couldn't be read/)).toBeInTheDocument();
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+  });
+
+  it('an ordinary modified file still reads exactly as it did', async () => {
+    detailMock.fetchPrDetail.mockResolvedValue(
+      detailWith({ path: NEW_PATH, status: 'modified' }),
+    );
+    reads({
+      [`${MAIN}::${NEW_PATH}`]: 'steps:\n  - stop the writer\n',
+      [`${CR_BRANCH}::${NEW_PATH}`]: 'steps:\n  - stop the writer, then drain\n',
+    });
+
+    render(<ChangeRequestDialog cr={CR} onClose={() => {}} onResolved={() => {}} />);
+
+    await screen.findByText('- stop the writer, then drain', { exact: false });
+    expect(marks().removed).toEqual(['  - stop the writer']);
+    expect(marks().added).toEqual(['  - stop the writer, then drain']);
+    expect(screen.queryByText(/^Moved:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/couldn't be read/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/core-frontend/src/modules/change-requests/__tests__/useFileOnBranch.test.tsx
+++ b/packages/core-frontend/src/modules/change-requests/__tests__/useFileOnBranch.test.tsx
@@ -6,7 +6,7 @@ vi.mock('../services/change-requests.api', () => ({
   readFileOnBranch: api.readFileOnBranch,
 }));
 
-import { useFileOnBranch } from '../hooks/useFileOnBranch';
+import { useFileOnBranch, useFileOnBranchRead } from '../hooks/useFileOnBranch';
 
 beforeEach(() => {
   api.readFileOnBranch
@@ -68,5 +68,51 @@ describe('useFileOnBranch', () => {
     const { result } = renderHook(() => useFileOnBranch('main', 'skill/SKILL.md'));
     await new Promise((r) => setTimeout(r, 0));
     expect(result.current).toBeNull();
+  });
+});
+
+/**
+ * A caller that cannot tell "failed" from "in flight" can only render
+ * "Loading…" for both — which is what left the change-request pane hanging on
+ * a file the default branch does not have.
+ */
+describe('useFileOnBranchRead', () => {
+  it('reports a settled failure as a failure, not as a wait', async () => {
+    api.readFileOnBranch.mockRejectedValue(new Error('404'));
+    const { result } = renderHook(() => useFileOnBranchRead('main', 'Ops/gone.yaml'));
+    expect(result.current).toEqual({ content: null, failed: false });
+    await waitFor(() => expect(result.current).toEqual({ content: null, failed: true }));
+    // Settled means settled: the failure is cached, not retried on every render.
+    expect(api.readFileOnBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it('a landed read is not a failure, and an unasked one is neither', async () => {
+    const { result, rerender } = renderHook(({ path }) => useFileOnBranchRead('main', path), {
+      initialProps: { path: null as string | null },
+    });
+    expect(result.current).toEqual({ content: null, failed: false });
+
+    rerender({ path: 'skill/SKILL.md' });
+    await waitFor(() =>
+      expect(result.current).toEqual({ content: 'content of skill/SKILL.md', failed: false }),
+    );
+  });
+
+  it('keys the failure to its own path — a sibling read is unaffected', async () => {
+    api.readFileOnBranch.mockImplementation(async (_branch: string, path: string) => {
+      if (path === 'Ops/gone.yaml') throw new Error('404');
+      return `content of ${path}`;
+    });
+    const { result, rerender } = renderHook(({ path }) => useFileOnBranchRead('main', path), {
+      initialProps: { path: 'Ops/gone.yaml' },
+    });
+    await waitFor(() => expect(result.current.failed).toBe(true));
+
+    rerender({ path: 'Ops/here.yaml' });
+    await waitFor(() => expect(result.current.content).toBe('content of Ops/here.yaml'));
+    expect(result.current.failed).toBe(false);
+
+    rerender({ path: 'Ops/gone.yaml' });
+    expect(result.current).toEqual({ content: null, failed: true });
   });
 });

--- a/packages/core-frontend/src/modules/change-requests/components/ChangeRequestDialog.tsx
+++ b/packages/core-frontend/src/modules/change-requests/components/ChangeRequestDialog.tsx
@@ -17,7 +17,7 @@ import { readFileOnBranch } from '../services/change-requests.api';
 import { changeAuthorName } from '../utils/author';
 import { conflictResolutionPrompt } from '../utils/conflict';
 import { ConflictHelp } from './ConflictHelp';
-import { useDefaultBranchFile } from '../hooks/useFileOnBranch';
+import { useDefaultBranchFileRead } from '../hooks/useFileOnBranch';
 import { diffLines, type DiffLine } from '../utils/diff';
 import { isBinaryFile } from '../../workspace/components/renderers';
 import { MarkdownDiffViewer } from '../../review/components/MarkdownDiffViewer';
@@ -178,13 +178,60 @@ export function ChangeRequestDialog({
   }, [selected, selectedIsBinary, cr.branch]);
 
   const isAdded = addedFiles.includes(selected);
+
+  /**
+   * A MOVED file's other side lives under its OLD name.
+   *
+   * The selection is the path on the change request's branch. For a rename
+   * that is a path the default branch has never had, so reading it there 404s
+   * — and the pane, which could only tell a failed read from a slow one by
+   * waiting, sat on "Loading…" for as long as anyone cared to watch. The
+   * before-side of a move is the file at `previousPath`; diffing that against
+   * the new path is what makes a rename-with-edits read as the edit it is,
+   * and a pure move read as no change at all.
+   */
+  const move = useMemo(() => {
+    const f = (detail?.files ?? []).find((x) => x.path === selected);
+    if (f?.status !== 'renamed') return null;
+    // `previousPath` is what GitHub populates for a rename; a rename that
+    // arrives without one is a move whose before-side we simply cannot name.
+    return { from: f.previousPath && f.previousPath !== f.path ? f.previousPath : null };
+  }, [detail, selected]);
+  const movedFrom = move?.from ?? null;
+  /** A rename described without a `previousPath` — no before-side to read. */
+  const renameWithoutOldPath = move !== null && move.from === null;
+
   // Raw-vs-raw: the skills API hands back SKILL.md's PARSED body (frontmatter
   // stripped), and diffing that against a raw branch read renders the
   // frontmatter as a deletion and the whole file as changed.
-  const mainRaw = useDefaultBranchFile(
-    isAdded || !selected || selectedIsBinary ? null : selected,
+  const mainRead = useDefaultBranchFileRead(
+    isAdded || renameWithoutOldPath || !selected || selectedIsBinary
+      ? null
+      : (movedFrom ?? selected),
   );
+  const mainRaw = mainRead.content;
   const branchRaw = branchContents[selected] ?? null;
+
+  /**
+   * The default-branch side is definitively gone — the read settled as an
+   * error, or a rename arrived with no old path to read at all.
+   *
+   * Gated on `detail`, because until it lands we do not yet know whether the
+   * selection is an ADDED file (whose absence from the default branch is
+   * expected and correct) or a moved one (whose old path we would then read
+   * instead). Announcing a failure inside that window would flash a wrong
+   * sentence at every reader of every new file.
+   */
+  const mainMissing = detail !== null && (renameWithoutOldPath || mainRead.failed);
+  const isRename = move !== null;
+  /**
+   * A move we cannot show the before-side of. Review does not stop for it: the
+   * pane says the old path could not be read and shows the file's NEW content,
+   * unmarked and labelled as such, which is still the thing being proposed.
+   */
+  const oldPathUnreadable = isRename && mainMissing;
+  /** Any other file whose default-branch copy could not be read. */
+  const baseUnreadable = !isRename && mainMissing;
 
   /**
    * BOTH sides or nothing.
@@ -221,6 +268,17 @@ export function ChangeRequestDialog({
     [selectedIsMarkdown, bothSidesIn, selected, isAdded, mainRaw, branchRaw],
   );
   const touchesSelected = changedFiles.has(selected);
+
+  /**
+   * The unmarked reading — the file itself, when there is no honest diff.
+   *
+   * Two cases reach it: a file this request doesn't touch (nothing to mark),
+   * and a move whose before-side could not be read (nothing to mark it
+   * AGAINST, but the proposed content is still worth reading). Anything else
+   * gets `null` and falls through to the diff.
+   */
+  const readsUnmarked = !selectedIsMarkdown && detail !== null && !touchesSelected;
+  const rawFallback = oldPathUnreadable ? branchRaw : readsUnmarked ? (mainRaw ?? branchRaw) : null;
 
   /** Per-file approval verdicts, straight from the detail. */
   const approvalByPath = useMemo(
@@ -519,6 +577,22 @@ export function ChangeRequestDialog({
                     : ' · not touched by this request'}
               </span>
             </div>
+            {/* The move, named. A rename's diff is otherwise unexplainable —
+                either it reads as an ordinary edit to a file that isn't there
+                under that name, or (a pure move) as no change at all. Sits
+                above the pane so it covers the rendered-markdown reading and
+                the marked-source one alike. */}
+            {movedFrom && (
+              <p className="truncate pb-1 font-mono text-meta text-ink-faint">
+                Moved: {movedFrom} → {selected}
+              </p>
+            )}
+            {oldPathUnreadable && (
+              <p className="pb-1 text-meta text-ink-faint">
+                The old path couldn't be read, so there is nothing to mark this against —
+                showing the file's new content as it stands on the change request.
+              </p>
+            )}
             {verbError && (
               <Banner tone="danger" role="alert" className="mb-2">
                 {verbError}
@@ -557,12 +631,17 @@ export function ChangeRequestDialog({
               ) : (
               <MarkedFile
                 diff={diff}
-                raw={
-                  !selectedIsMarkdown && detail !== null && !touchesSelected
-                    ? (mainRaw ?? branchRaw)
-                    : null
+                raw={rawFallback}
+                unreadable={
+                  // A failure only gets the last word when there is nothing
+                  // left to show: a file this request doesn't touch reads
+                  // fine from whichever copy arrived.
+                  unreadable.has(selected)
+                    ? 'branch'
+                    : baseUnreadable && !readsUnmarked
+                      ? 'base'
+                      : undefined
                 }
-                unreadable={unreadable.has(selected)}
               />
               )}
             </div>
@@ -673,13 +752,14 @@ function MarkedFile({
 }: {
   diff: DiffLine[] | null;
   raw: string | null;
-  unreadable?: boolean;
+  /** Which side failed to read — the change request's copy, or the default branch's. */
+  unreadable?: 'branch' | 'base';
 }) {
   if (unreadable) {
     return (
       <p className="py-6 text-center text-detail text-ink-faint">
-        This file's copy on the change request couldn't be read, so there is no honest before and
-        after to show.
+        This file's copy on {unreadable === 'branch' ? 'the change request' : 'the current text'}{' '}
+        couldn't be read, so there is no honest before and after to show.
       </p>
     );
   }

--- a/packages/core-frontend/src/modules/change-requests/hooks/useFileOnBranch.ts
+++ b/packages/core-frontend/src/modules/change-requests/hooks/useFileOnBranch.ts
@@ -3,6 +3,26 @@ import { DEFAULT_BRANCH } from '@bevel-software/platform-shared';
 import { readFileOnBranch } from '../services/change-requests.api';
 
 /**
+ * A read that has landed, or the fact that it hasn't.
+ *
+ * `content: null` on its own conflates two different truths — "still in
+ * flight" and "this read is never going to succeed" — and a caller holding
+ * only that can render exactly one thing for both: "Loading…", forever. A
+ * file the default branch simply does not have (the OLD half of a rename, a
+ * path outside the caller's access) is the second case, and it deserves a
+ * sentence rather than a spinner.
+ */
+export interface BranchFileRead {
+  /** The file's raw text once it lands; `null` while pending AND on failure. */
+  content: string | null;
+  /** True once the read SETTLED as an error — a definitive "no", not a wait. */
+  failed: boolean;
+}
+
+const PENDING: BranchFileRead = { content: null, failed: false };
+const FAILED: BranchFileRead = { content: null, failed: true };
+
+/**
  * The file's RAW text on the default branch.
  *
  * Not `skill.body`, which is what the skills API returns for SKILL.md: that has
@@ -24,6 +44,14 @@ export function useDefaultBranchFile(
   return useFileOnBranch(DEFAULT_BRANCH, repoRelativePath, revision);
 }
 
+/** The same default-branch read, with a failure distinguishable from a wait. */
+export function useDefaultBranchFileRead(
+  repoRelativePath: string | null,
+  revision = 0,
+): BranchFileRead {
+  return useFileOnBranchRead(DEFAULT_BRANCH, repoRelativePath, revision);
+}
+
 /**
  * The same read against ANY branch — `null` branch means "don't fetch". The
  * skill page uses it to seed an incremental proposal: when the caller already
@@ -36,6 +64,19 @@ export function useFileOnBranch(
   repoRelativePath: string | null,
   revision = 0,
 ): string | null {
+  return useFileOnBranchRead(branch, repoRelativePath, revision).content;
+}
+
+/**
+ * The read itself. Callers that can say something useful about a failure take
+ * this; callers that only ever want the text take the `string | null` wrappers
+ * above.
+ */
+export function useFileOnBranchRead(
+  branch: string | null,
+  repoRelativePath: string | null,
+  revision = 0,
+): BranchFileRead {
   /**
    * Answers are cached PER KEY, not as "the last one". The skill page's tabs
    * make the path oscillate (SKILL.md → a bundled file → SKILL.md), and with a
@@ -44,8 +85,12 @@ export function useFileOnBranch(
    * null forever and the pane sat on "Loading…". A map keeps every settled
    * answer addressable for as long as the page is mounted (bounded: one entry
    * per file per revision).
+   *
+   * A FAILURE is cached under its key too, for the same reason the successes
+   * are: it is an answer. Storing nothing left the key indistinguishable from
+   * one still in flight.
    */
-  const cache = useRef<Map<string, string>>(new Map());
+  const cache = useRef<Map<string, BranchFileRead>>(new Map());
   const asked = useRef<Set<string>>(new Set());
   const [, arrived] = useState(0);
   const key = `${branch ?? ''}::${repoRelativePath ?? ''}::${revision}`;
@@ -67,14 +112,19 @@ export function useFileOnBranch(
     asked.current.add(key);
     readFileOnBranch(branch, repoRelativePath)
       .then((content) => {
-        cache.current.set(key, content);
+        cache.current.set(key, { content, failed: false });
         arrived((n) => n + 1);
       })
       .catch(() => {
-        // Leave it unset rather than storing '': an empty string would diff as
-        // "the whole file was deleted".
+        // NOT `{ content: '' }`: an empty string would diff as "the whole file
+        // was deleted". The failure is recorded as a failure so the caller can
+        // say so.
+        cache.current.set(key, FAILED);
+        arrived((n) => n + 1);
       });
   }, [branch, repoRelativePath, key]);
 
-  return cache.current.get(key) ?? null;
+  // No path (or no branch) is not a failure — it is "nothing was asked for".
+  if (!branch || !repoRelativePath) return PENDING;
+  return cache.current.get(key) ?? PENDING;
 }


### PR DESCRIPTION
Implements `Data/Engineering/Knowledge/Hexis/Tickets/CR-Moved-File-View.md`.

## Summary
The change-request diff pane could get stuck on "Loading…" for renamed files, because the old-path content on the default branch was never resolved (or its failure was never surfaced). This fixes the fetch/resolution logic so renamed files reliably show a diff, and any failed default-branch read resolves to an honest "couldn't be read" state instead of hanging.

## Behavior
- Rename with content changes: shows the standard diff (old-path content on the default branch vs new-path content on the change branch), with a line naming the move (old path → new path).
- Pure rename (byte-identical content): shows the move note and the file's content with no added/removed marks.
- Rename where the old path can't be read (missing `previousPath`, or the read fails): pane says the old path couldn't be read and shows the new content, labeled as such.
- Any file whose default-branch read fails resolves to the pane's "couldn't be read" state instead of staying on "Loading…".
- Non-renamed files (added/modified/deleted/binary) are unaffected.

## Files changed
- `packages/core-frontend/src/modules/change-requests/hooks/useFileOnBranch.ts`
- `.../ChangeRequestDialog.tsx`
- `__tests__/useFileOnBranch.test.tsx`
- `__tests__/ChangeRequestDialog.moved.test.tsx`

## Testing
- `NODE_ENV=test` core-frontend: `tsc --noEmit` clean, `vitest` 1717/1717 passed across 137 files (6 new dialog tests + 3 new hook tests already existing test additions, 8 new `useFileOnBranch` cases in total).
- Verified 5/6 new tests fail against pre-change source (regression-proven).
- Booted the full app from source via `deployment/docker-compose.build.yml` against a scratch repo with rename+edit, pure-move, modified, added, deleted, and binary files, and confirmed all 6 acceptance criteria through the real UI, including that the default-branch fetch for a renamed file goes to the OLD path.
- Non-renamed files (added/modified/deleted/binary) render exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the change-request diff pane so a renamed file shows its change instead of an eternal "Loading…". The pane previously read the selected (new) path on the default branch, which 404s for a rename; a failed read was stored as nothing at all, indistinguishable from one still in flight.

**Bug Fixes**
- Reads a rename's before-side from `previousPath`, so rename-with-edits diffs as the edit and a pure move shows the content unmarked, both with a line naming the move (old path → new path).
- Settled default-branch read failures now land on the pane's "couldn't be read" state instead of a spinner; a rename whose old path can't be read shows the new content, labelled as such.
- Non-renamed files (added, modified, deleted, binary) render exactly as before.

<sup>Written for commit 331501996f38616d5d42cad07aff66555ebe0536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

