### PR TITLE
implemented admin view on external key connections

### DIFF
--- a/packages/core-backend/src/core/create-core-server.ts
+++ b/packages/core-backend/src/core/create-core-server.ts
@@ -32,6 +32,7 @@ import { createAdminAccessRoutes } from '../modules/admin/admin-access.routes.js
 import { createGroupsAdminRoutes } from '../modules/access/groups-admin.routes.js';
 import { createUpdateCheckRoutes } from '../modules/update-check/update-check.routes.js';
 import { createAccountRoutes } from '../modules/auth/account.routes.js';
+import { createConnectionKeysAdminRoutes } from '../modules/tool-auth/connection-keys-admin.routes.js';
 import { createSetupRoutes } from '../modules/settings/setup.routes.js';
 import {
   createKbSyncRoutes,
@@ -572,6 +573,13 @@ export async function createCoreServer(
     core.adminAccess,
     core.accountErasureService,
   ));
+  // Connection keys across the deployment (list per account, revoke any) —
+  // admin-gated inside. The per-user key surface stays on /api/mcp/…
+  app.use(
+    '/api',
+    core.authMiddleware,
+    createConnectionKeysAdminRoutes(core.externalApiKeyService, core.adminAccess),
+  );
   // First-run setup. Mounted with the other authed routes but touching NO
   // workspace — it has to work on a deployment that has no knowledge base yet,
   // which is the whole reason it exists. The startup runner rides along for

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -49,6 +49,7 @@ export {
 export type {
   IExternalApiKeyService,
   ExternalApiKeySummary,
+  AdminExternalApiKeySummary,
 } from './modules/tool-auth/external-api-key.interface.js';
 
 // Key port/seam types an overlay implements.

--- a/packages/core-backend/src/modules/tool-auth/__tests__/connection-keys-admin.routes.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/connection-keys-admin.routes.test.ts
@@ -6,8 +6,11 @@ import { TokenNotFoundError } from '../external-api-key.errors.js';
 import type { AdminExternalApiKeySummary } from '../external-api-key.interface.js';
 import type { IAdminAccessService } from '../../admin/admin.interface.js';
 
+const TOK = '0f1e2d3c-4b5a-4697-8877-665544332211';
+const GHOST = '00000000-0000-4000-8000-000000000000';
+
 const ALICE_KEY: AdminExternalApiKeySummary = {
-  id: 'tok-1',
+  id: TOK,
   label: 'CI pipeline',
   kind: 'key',
   createdAt: Date.UTC(2026, 0, 1),
@@ -59,7 +62,7 @@ describe('connection-keys admin routes', () => {
     const base = await listen(makeApp({ admin: false }));
     expect((await fetch(`${base}/api/admin/connection-keys`)).status).toBe(403);
     expect(
-      (await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' })).status,
+      (await fetch(`${base}/api/admin/connection-keys/${TOK}`, { method: 'DELETE' })).status,
     ).toBe(403);
     expect(keys.listForDeployment).not.toHaveBeenCalled();
     expect(keys.revokeAny).not.toHaveBeenCalled();
@@ -75,21 +78,31 @@ describe('connection-keys admin routes', () => {
 
   it('revokes any key by id for admins (not scoped to the caller)', async () => {
     const base = await listen(makeApp({ admin: true }));
-    const res = await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' });
+    const res = await fetch(`${base}/api/admin/connection-keys/${TOK}`, { method: 'DELETE' });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: 'revoked' });
-    expect(keys.revokeAny).toHaveBeenCalledWith('tok-1');
+    expect(keys.revokeAny).toHaveBeenCalledWith(TOK);
+  });
+
+  it('404s a malformed id without reaching the database (a uuid column would 500 on it)', async () => {
+    const base = await listen(makeApp({ admin: true }));
+    for (const bad of ['not-a-uuid', '123', '0f1e2d3c-4b5a-4697-8877-66554433221']) {
+      const res = await fetch(`${base}/api/admin/connection-keys/${bad}`, { method: 'DELETE' });
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as { error: string }).error).toBe('Token not found');
+    }
+    expect(keys.revokeAny).not.toHaveBeenCalled();
   });
 
   it('404s an unknown key and 500s with a generic body on other failures', async () => {
     const base = await listen(makeApp({ admin: true }));
     keys.revokeAny.mockRejectedValueOnce(new TokenNotFoundError());
     expect(
-      (await fetch(`${base}/api/admin/connection-keys/ghost`, { method: 'DELETE' })).status,
+      (await fetch(`${base}/api/admin/connection-keys/${GHOST}`, { method: 'DELETE' })).status,
     ).toBe(404);
 
     keys.revokeAny.mockRejectedValueOnce(new Error('relation "api_tokens" does not exist'));
-    const res = await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' });
+    const res = await fetch(`${base}/api/admin/connection-keys/${TOK}`, { method: 'DELETE' });
     expect(res.status).toBe(500);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('Failed to revoke this key');

--- a/packages/core-backend/src/modules/tool-auth/__tests__/connection-keys-admin.routes.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/connection-keys-admin.routes.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import type { Server } from 'node:http';
+import { createConnectionKeysAdminRoutes } from '../connection-keys-admin.routes.js';
+import { TokenNotFoundError } from '../external-api-key.errors.js';
+import type { AdminExternalApiKeySummary } from '../external-api-key.interface.js';
+import type { IAdminAccessService } from '../../admin/admin.interface.js';
+
+const ALICE_KEY: AdminExternalApiKeySummary = {
+  id: 'tok-1',
+  label: 'CI pipeline',
+  kind: 'key',
+  createdAt: Date.UTC(2026, 0, 1),
+  lastUsedAt: Date.UTC(2026, 0, 2),
+  revokedAt: null,
+  user: { id: 'u-alice', email: 'alice@example.com', name: 'Alice' },
+};
+
+const keys = {
+  listForDeployment: vi.fn(async () => [ALICE_KEY]),
+  revokeAny: vi.fn<(id: string) => Promise<void>>(async () => {}),
+};
+
+function makeApp(opts: { admin: boolean }) {
+  const adminAccess: IAdminAccessService = {
+    isAdmin: vi.fn(async () => opts.admin),
+  };
+  const app = express();
+  app.use(express.json());
+  // Stand-in auth middleware: stamps the caller identity the way the real JWT
+  // middleware does.
+  app.use((req, _res, next) => {
+    req.userId = 'u-admin';
+    req.userEmail = 'admin@example.com';
+    next();
+  });
+  app.use('/api', createConnectionKeysAdminRoutes(keys, adminAccess));
+  return app;
+}
+
+let server: Server;
+afterEach(() => {
+  server?.close();
+  keys.listForDeployment.mockClear().mockResolvedValue([ALICE_KEY]);
+  keys.revokeAny.mockClear().mockResolvedValue(undefined);
+});
+
+async function listen(app: express.Express): Promise<string> {
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+  const address = server.address();
+  if (typeof address === 'string' || !address) throw new Error('no port');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe('connection-keys admin routes', () => {
+  it('refuses non-admins on both endpoints without touching the service', async () => {
+    const base = await listen(makeApp({ admin: false }));
+    expect((await fetch(`${base}/api/admin/connection-keys`)).status).toBe(403);
+    expect(
+      (await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' })).status,
+    ).toBe(403);
+    expect(keys.listForDeployment).not.toHaveBeenCalled();
+    expect(keys.revokeAny).not.toHaveBeenCalled();
+  });
+
+  it('lists every key with its owner for admins', async () => {
+    const base = await listen(makeApp({ admin: true }));
+    const res = await fetch(`${base}/api/admin/connection-keys`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { keys: AdminExternalApiKeySummary[] };
+    expect(body.keys).toEqual([ALICE_KEY]);
+  });
+
+  it('revokes any key by id for admins (not scoped to the caller)', async () => {
+    const base = await listen(makeApp({ admin: true }));
+    const res = await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'revoked' });
+    expect(keys.revokeAny).toHaveBeenCalledWith('tok-1');
+  });
+
+  it('404s an unknown key and 500s with a generic body on other failures', async () => {
+    const base = await listen(makeApp({ admin: true }));
+    keys.revokeAny.mockRejectedValueOnce(new TokenNotFoundError());
+    expect(
+      (await fetch(`${base}/api/admin/connection-keys/ghost`, { method: 'DELETE' })).status,
+    ).toBe(404);
+
+    keys.revokeAny.mockRejectedValueOnce(new Error('relation "api_tokens" does not exist'));
+    const res = await fetch(`${base}/api/admin/connection-keys/tok-1`, { method: 'DELETE' });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Failed to revoke this key');
+    expect(JSON.stringify(body)).not.toContain('relation');
+
+    keys.listForDeployment.mockRejectedValueOnce(new Error('boom'));
+    const list = await fetch(`${base}/api/admin/connection-keys`);
+    expect(list.status).toBe(500);
+    expect(((await list.json()) as { error: string }).error).toBe('Failed to load connection keys');
+  });
+});

--- a/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createHash } from 'node:crypto';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { ExternalApiKeyService } from '../external-api-key.service.js';
 import {
   InvalidTokenLabelError,
@@ -99,6 +101,15 @@ function makeRow(overrides: Partial<{
     lastUsedAt: overrides.lastUsedAt ?? null,
     revokedAt: overrides.revokedAt ?? null,
   };
+}
+
+/**
+ * Render a drizzle predicate to SQL text + params, so a test can assert on
+ * WHAT was asked of the database even though the fake never evaluates it.
+ */
+function renderSql(fragment: SQL): { sql: string; params: unknown[] } {
+  const q = new PgDialect().sqlToQuery(fragment);
+  return { sql: q.sql, params: q.params };
 }
 
 function sha256Hex(s: string): string {
@@ -346,6 +357,26 @@ describe('ExternalApiKeyService', () => {
 
       expect(calls.set[0][0].revokedAt).toBeInstanceOf(Date);
       expect((db as any).select).not.toHaveBeenCalled();
+      // The fake DB ignores predicates, so render the one the UPDATE was
+      // given: it must pin the id and the not-yet-revoked state, and must NOT
+      // carry a user_id — that scope is what makes this the admin path. The
+      // owner path (`revoke`) is checked for the opposite below.
+      const where = renderSql(calls.where[0][0]);
+      expect(where.sql).toContain('"id" = ');
+      expect(where.sql).toContain('"revoked_at" is null');
+      expect(where.sql).not.toContain('user_id');
+      expect(where.params).toEqual(['tok-1']);
+    });
+
+    it('owner-scoped revoke, by contrast, does carry the user_id predicate', async () => {
+      const { db, calls } = makeFakeDb([[{ id: 'tok-1' }]]);
+      const service = new ExternalApiKeyService(db, 'bevel_');
+
+      await service.revoke('tok-1', 'user-1');
+
+      const where = renderSql(calls.where[0][0]);
+      expect(where.sql).toContain('"user_id" = ');
+      expect(where.params).toEqual(['tok-1', 'user-1']);
     });
 
     it('is idempotent on an already-revoked token', async () => {

--- a/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
@@ -295,6 +295,74 @@ describe('ExternalApiKeyService', () => {
     });
   });
 
+  describe('listForDeployment', () => {
+    it('joins the owner onto every key and keeps the row order the DB returned', async () => {
+      const aliceKey = makeRow({ id: 'a', userId: 'u-alice', lastUsedAt: new Date('2026-03-02T00:00:00Z') });
+      const bobKey = makeRow({ id: 'b', userId: 'u-bob', revokedAt: new Date('2026-02-15T00:00:00Z') });
+      const rows = [
+        { key: aliceKey, userId: 'u-alice', email: 'alice@example.com', name: 'Alice' },
+        { key: bobKey, userId: 'u-bob', email: 'bob@example.com', name: 'Bob' },
+      ];
+      const { db, calls } = makeFakeDb([rows]);
+      const service = new ExternalApiKeyService(db, 'bevel_');
+
+      const summaries = await service.listForDeployment();
+
+      expect(summaries).toEqual([
+        {
+          id: 'a',
+          label: aliceKey.label,
+          kind: aliceKey.kind,
+          createdAt: aliceKey.createdAt.getTime(),
+          lastUsedAt: aliceKey.lastUsedAt!.getTime(),
+          revokedAt: null,
+          user: { id: 'u-alice', email: 'alice@example.com', name: 'Alice' },
+        },
+        {
+          id: 'b',
+          label: bobKey.label,
+          kind: bobKey.kind,
+          createdAt: bobKey.createdAt.getTime(),
+          lastUsedAt: null,
+          revokedAt: bobKey.revokedAt!.getTime(),
+          user: { id: 'u-bob', email: 'bob@example.com', name: 'Bob' },
+        },
+      ]);
+      // One join to users, one ordering clause — the grouping order is the
+      // DB's job, not a re-sort here.
+      expect(calls.innerJoin).toHaveLength(1);
+      expect(calls.orderBy).toHaveLength(1);
+      // The hash never leaves the service, even for admins.
+      expect(JSON.stringify(summaries)).not.toContain('hash-1');
+    });
+  });
+
+  describe('revokeAny', () => {
+    it('revokes without an owner scope when the token was active', async () => {
+      const { db, calls } = makeFakeDb([[{ id: 'tok-1' }]]);
+      const service = new ExternalApiKeyService(db, 'bevel_');
+
+      await service.revokeAny('tok-1');
+
+      expect(calls.set[0][0].revokedAt).toBeInstanceOf(Date);
+      expect((db as any).select).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent on an already-revoked token', async () => {
+      const { db } = makeFakeDb([[], [{ id: 'tok-1' }]]);
+      const service = new ExternalApiKeyService(db, 'bevel_');
+
+      await expect(service.revokeAny('tok-1')).resolves.toBeUndefined();
+    });
+
+    it('throws TokenNotFoundError when no such token exists on the deployment', async () => {
+      const { db } = makeFakeDb([[], []]);
+      const service = new ExternalApiKeyService(db, 'bevel_');
+
+      await expect(service.revokeAny('tok-x')).rejects.toBeInstanceOf(TokenNotFoundError);
+    });
+  });
+
   describe('revoke', () => {
     it('updates the row and returns silently when the token belongs to the user and was active', async () => {
       // First op: UPDATE returns 1 row.

--- a/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
+++ b/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
@@ -1,0 +1,66 @@
+import express from 'express';
+import type { IAdminAccessService } from '../admin/admin.interface.js';
+import { TokenNotFoundError } from './external-api-key.errors.js';
+import type { IExternalApiKeyService } from './external-api-key.interface.js';
+import '../auth/auth.middleware.js'; // Express Request augmentation
+
+/**
+ * Admin overview of connection keys across the deployment (the core
+ * "Connection keys" admin page): every key on every account — owner, label,
+ * created, last used, whether it is still live — and a revoke that is not
+ * scoped to the caller. The per-user surface stays in mcp.routes.ts; this
+ * router exists so an admin can cut off a leaked or forgotten key without
+ * signing in as its owner. Gated per request by {@link IAdminAccessService}.
+ */
+export function createConnectionKeysAdminRoutes(
+  externalApiKeyService: Pick<IExternalApiKeyService, 'listForDeployment' | 'revokeAny'>,
+  adminAccess: IAdminAccessService,
+): express.Router {
+  const router = express.Router();
+
+  const requireAdmin: express.RequestHandler = async (req, res, next) => {
+    if (!(await adminAccess.isAdmin(req.userEmail))) {
+      res.status(403).json({ error: 'Admins only' });
+      return;
+    }
+    next();
+  };
+
+  // GET /api/admin/connection-keys — every key with its owner, ordered by
+  // owner email then newest-first. Never carries a plaintext or a hash.
+  router.get('/admin/connection-keys', requireAdmin, async (_req, res) => {
+    try {
+      res.json({ keys: await externalApiKeyService.listForDeployment() });
+    } catch (err) {
+      console.error('[connection-keys] admin list failed:', err);
+      res.status(500).json({ error: 'Failed to load connection keys' });
+    }
+  });
+
+  // DELETE /api/admin/connection-keys/:id — revoke (disconnect) a key
+  // belonging to ANY account. Idempotent on an already-revoked key; 404 when
+  // no such key exists. Revoked rows are kept so `last_used_at` stays
+  // auditable after a leak — there is deliberately no admin hard-delete.
+  router.delete('/admin/connection-keys/:id', requireAdmin, async (req, res) => {
+    const id = String(req.params.id);
+    try {
+      await externalApiKeyService.revokeAny(id);
+      // Accountability record: WHO revoked WHICH key. Ids only — the key's
+      // label is the owner's free text and does not belong in logs.
+      console.log(
+        '[connection-keys] revoke audit:',
+        JSON.stringify({ action: 'admin-revoke-key', actorUserId: req.userId, tokenId: id }),
+      );
+      res.json({ status: 'revoked' });
+    } catch (err) {
+      if (err instanceof TokenNotFoundError) {
+        res.status(404).json({ error: err.message });
+        return;
+      }
+      console.error('[connection-keys] admin revoke failed:', err);
+      res.status(500).json({ error: 'Failed to revoke this key' });
+    }
+  });
+
+  return router;
+}

--- a/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
+++ b/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
@@ -4,6 +4,9 @@ import { TokenNotFoundError } from './external-api-key.errors.js';
 import type { IExternalApiKeyService } from './external-api-key.interface.js';
 import '../auth/auth.middleware.js'; // Express Request augmentation
 
+/** Shape of the `api_tokens.id` column (any uuid version; case-insensitive). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Admin overview of connection keys across the deployment (the core
  * "Connection keys" admin page): every key on every account — owner, label,
@@ -43,6 +46,13 @@ export function createConnectionKeysAdminRoutes(
   // auditable after a leak — there is deliberately no admin hard-delete.
   router.delete('/admin/connection-keys/:id', requireAdmin, async (req, res) => {
     const id = String(req.params.id);
+    // The id column is a uuid: anything else makes Postgres raise a cast
+    // error before the WHERE is even evaluated, which would surface as a 500.
+    // A malformed id names no key, so it is a not-found, same as an unknown one.
+    if (!UUID_RE.test(id)) {
+      res.status(404).json({ error: 'Token not found' });
+      return;
+    }
     try {
       await externalApiKeyService.revokeAny(id);
       // Accountability record: WHO revoked WHICH key. Ids only — the key's

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
@@ -43,6 +43,19 @@ export interface MintedExternalApiKey {
   summary: ExternalApiKeySummary;
 }
 
+/**
+ * One row of the admin "Connection keys" overview: a key summary plus the
+ * account it belongs to. Deployment-wide, so unlike {@link ExternalApiKeySummary}
+ * the owner is not implied by the caller.
+ */
+export interface AdminExternalApiKeySummary extends ExternalApiKeySummary {
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+}
+
 /** The kind of a key a person creates by hand. */
 export const DEFAULT_KEY_KIND = 'key';
 
@@ -121,6 +134,21 @@ export interface IExternalApiKeyService {
    * TokenNotFoundError if the token doesn't belong to the user.
    */
   revoke(id: string, userId: string): Promise<void>;
+
+  /**
+   * Every token on the deployment, active and revoked, with its owner —
+   * the admin overview. Ordered by owner email, then newest-first, so the
+   * caller can group per account without re-sorting.
+   */
+  listForDeployment(): Promise<AdminExternalApiKeySummary[]>;
+
+  /**
+   * Admin revoke: mark a token revoked WITHOUT scoping by owner. Same
+   * idempotency as {@link revoke}; throws TokenNotFoundError when no such
+   * token exists. Only reachable through an admin-gated route — the
+   * per-user route must keep using {@link revoke}.
+   */
+  revokeAny(id: string): Promise<void>;
 
   /**
    * Permanently delete a token row, dropping its audit trail. Only permitted

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.service.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.service.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
+import { and, asc, desc, eq, isNotNull, isNull, type SQL } from 'drizzle-orm';
 import type { AuthUser } from '@bevel-software/platform-shared';
 import type { Database } from '../database/connection.js';
 import { externalApiKeys, users } from '../database/schema.js';
@@ -10,6 +10,7 @@ import {
 } from './external-api-key.errors.js';
 import {
   DEFAULT_KEY_KIND,
+  type AdminExternalApiKeySummary,
   type ExternalApiKeySummary,
   type IExternalApiKeyService,
   type KeyKindSpec,
@@ -147,31 +148,60 @@ export class ExternalApiKeyService implements IExternalApiKeyService {
     return rows.map(toSummary);
   }
 
+  async listForDeployment(): Promise<AdminExternalApiKeySummary[]> {
+    // Owner joined in so the admin overview is one round-trip; ordered by
+    // owner email so per-account grouping is a linear pass, newest key
+    // first within an account (same order the owner sees on their own page).
+    const rows = await this.db
+      .select({
+        key: externalApiKeys,
+        userId: users.id,
+        email: users.email,
+        name: users.name,
+      })
+      .from(externalApiKeys)
+      .innerJoin(users, eq(externalApiKeys.userId, users.id))
+      .orderBy(asc(users.email), desc(externalApiKeys.createdAt));
+    return rows.map((row) => ({
+      ...toSummary(row.key),
+      user: { id: row.userId, email: row.email, name: row.name },
+    }));
+  }
+
   async revoke(id: string, userId: string): Promise<void> {
-    // Scope the WHERE by userId so a user can never revoke another user's
-    // token even if they learn the id. Idempotent on already-revoked rows
-    // because we only set `revokedAt` when it's currently null — re-revoking
-    // returns 0 rows changed but no error.
+    // Scope by userId so a user can never revoke another user's token even
+    // if they learn the id.
+    await this.markRevoked(and(eq(externalApiKeys.id, id), eq(externalApiKeys.userId, userId))!);
+  }
+
+  async revokeAny(id: string): Promise<void> {
+    // No owner scope: the caller is an admin acting across the deployment.
+    // The route that exposes this is admin-gated; nothing user-facing may
+    // reach it.
+    await this.markRevoked(eq(externalApiKeys.id, id));
+  }
+
+  /**
+   * Set `revokedAt` on the rows matching `scope`. Idempotent on
+   * already-revoked rows because we only set `revokedAt` when it's currently
+   * null — re-revoking returns 0 rows changed but no error. Throws
+   * TokenNotFoundError when `scope` matches nothing at all.
+   */
+  private async markRevoked(scope: SQL): Promise<void> {
     const result = await this.db
       .update(externalApiKeys)
       .set({ revokedAt: new Date() })
-      .where(
-        and(
-          eq(externalApiKeys.id, id),
-          eq(externalApiKeys.userId, userId),
-          isNull(externalApiKeys.revokedAt),
-        ),
-      )
+      .where(and(scope, isNull(externalApiKeys.revokedAt)))
       .returning({ id: externalApiKeys.id });
 
     if (result.length === 0) {
-      // Distinguish "doesn't exist / not yours" from "already revoked".
+      // Distinguish "doesn't exist / out of scope" from "already revoked".
       // The latter must stay idempotent (return success); only the former
       // throws.
       const [existing] = await this.db
         .select({ id: externalApiKeys.id })
         .from(externalApiKeys)
-        .where(and(eq(externalApiKeys.id, id), eq(externalApiKeys.userId, userId)))
+        .where(scope)
         .limit(1);
       if (!existing) {
         throw new TokenNotFoundError();

--- a/packages/core-frontend/src/core/CoreAppShell.tsx
+++ b/packages/core-frontend/src/core/CoreAppShell.tsx
@@ -45,6 +45,7 @@ import { ExternalAgentAccessPage } from '../modules/toolbar/components/ExternalA
 import { AdminRolesPage } from '../modules/admin/components/AdminRolesPage';
 import { UserAccountsPage } from '../modules/admin/components/UserAccountsPage';
 import { DirectoryGroupsPage } from '../modules/admin/components/DirectoryGroupsPage';
+import { ConnectionKeysPage } from '../modules/admin/components/ConnectionKeysPage';
 import { ToolsExplorerPage } from '../modules/tools/ToolsExplorerPage';
 import { LibraryRoutes } from '../modules/library/routes/LibraryRoutes';
 import { RootLanding } from '../modules/onboarding/components/RootLanding';
@@ -411,6 +412,7 @@ export function ShellRoutes({ apps }: { apps: AppDef[] }) {
         <Route path="/deployment" element={<DeploymentPage />} />
         <Route path="/user-accounts" element={<UserAccountsPage />} />
         <Route path="/directory-groups" element={<DirectoryGroupsPage />} />
+        <Route path="/connection-keys" element={<ConnectionKeysPage />} />
         <Route path="/tools" element={<ToolsExplorerPage />} />
       </Route>
       {/* `/` consults the onboarding: a brand-new account's FIRST visit lands

--- a/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
@@ -189,6 +189,70 @@ describe('ConnectionKeysPage', () => {
     expect(screen.getByText('CI pipeline')).toBeInTheDocument();
   });
 
+  it('keeps a revoked key disconnected when the reload after revoking fails', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+    vi.mocked(listConnectionKeys).mockRejectedValueOnce(new Error('Could not load connection keys'));
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    );
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', { name: 'Revoke key' }),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load connection keys');
+    // The server said yes, so the row is disconnected regardless of the reload:
+    // hidden with the other disconnected keys, and never offering Revoke again.
+    expect(
+      screen.queryByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Show disconnected keys' }));
+    expect(screen.getByText('CI pipeline')).toBeInTheDocument();
+    expect(screen.getByText(/2 live keys · 2 disconnected/)).toBeInTheDocument();
+  });
+
+  it('ignores a stale list response that lands after a newer one', async () => {
+    // Two revokes back to back: the reload from the FIRST resolves last, still
+    // showing the second key as live. It must not win over the newer reload.
+    const deferred = () => {
+      let resolve!: (rows: AdminConnectionKey[]) => void;
+      const promise = new Promise<AdminConnectionKey[]>((r) => (resolve = r));
+      return { promise, resolve };
+    };
+    const first = deferred();
+    const second = deferred();
+    vi.mocked(listConnectionKeys)
+      .mockReset()
+      .mockResolvedValueOnce([ALICE_CI, ALICE_LAPTOP])
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+
+    const revoke = async (name: string) => {
+      await userEvent.click(screen.getByRole('button', { name }));
+      await userEvent.click(
+        within(await screen.findByRole('dialog')).getByRole('button', { name: 'Revoke key' }),
+      );
+    };
+    await revoke('Revoke CI pipeline for alice@example.com');
+    await revoke('Revoke Laptop for alice@example.com');
+    await waitFor(() => expect(listConnectionKeys).toHaveBeenCalledTimes(3));
+
+    const ciRevoked = { ...ALICE_CI, revokedAt: NOW };
+    second.resolve([ciRevoked, { ...ALICE_LAPTOP, revokedAt: NOW }]);
+    await waitFor(() => expect(screen.getByText(/0 live keys · 2 disconnected/)).toBeInTheDocument());
+
+    // The stale reload: taken at face value, Laptop would come back to life.
+    first.resolve([ciRevoked, ALICE_LAPTOP]);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText(/0 live keys · 2 disconnected/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Revoke Laptop for alice@example.com' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('shows the load error and no empty state when the first load fails', async () => {
     vi.mocked(listConnectionKeys).mockRejectedValueOnce(new Error('Could not load connection keys'));
     renderPage();

--- a/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConnectionKeysPage } from '../components/ConnectionKeysPage';
+import { groupByAccount } from '../components/connection-keys-grouping';
+import { AdminContext } from '../state/admin.context';
+import {
+  listConnectionKeys,
+  revokeConnectionKey,
+  type AdminConnectionKey,
+} from '../services/connection-keys.api';
+
+vi.mock('../services/connection-keys.api', () => ({
+  listConnectionKeys: vi.fn(),
+  revokeConnectionKey: vi.fn(),
+}));
+
+const ALICE = { id: 'u-alice', email: 'alice@example.com', name: 'Alice' };
+const BOB = { id: 'u-bob', email: 'bob@example.com', name: 'Bob' };
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.now();
+
+const ALICE_CI: AdminConnectionKey = {
+  id: 'k-ci',
+  label: 'CI pipeline',
+  kind: 'key',
+  createdAt: NOW - 10 * DAY,
+  lastUsedAt: NOW - 2 * 60 * 60 * 1000,
+  revokedAt: null,
+  user: ALICE,
+};
+const ALICE_LAPTOP: AdminConnectionKey = {
+  id: 'k-laptop',
+  label: 'Laptop',
+  kind: 'key',
+  createdAt: NOW - 3 * DAY,
+  lastUsedAt: null,
+  revokedAt: null,
+  user: ALICE,
+};
+const BOB_OLD: AdminConnectionKey = {
+  id: 'k-old',
+  label: 'Old script',
+  kind: 'key',
+  createdAt: NOW - 40 * DAY,
+  lastUsedAt: NOW - 30 * DAY,
+  revokedAt: NOW - 20 * DAY,
+  user: BOB,
+};
+const BOB_LINK: AdminConnectionKey = {
+  id: 'k-link',
+  label: 'Claude',
+  kind: 'github-link',
+  createdAt: NOW - 1 * DAY,
+  lastUsedAt: NOW - 60 * 1000,
+  revokedAt: null,
+  user: BOB,
+};
+
+function renderPage(opts: { isAdmin?: boolean } = {}) {
+  return render(
+    <AdminContext.Provider
+      value={{
+        isAdmin: opts.isAdmin ?? true,
+        unreadCount: 0,
+        lastSeen: null,
+        markSeen: () => {},
+        refresh: () => {},
+        rolesConfigCorrupted: false,
+        rolesConfigErrors: [],
+        runRolesRecovery: async () => {},
+      }}
+    >
+      <ConnectionKeysPage />
+    </AdminContext.Provider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(listConnectionKeys)
+    .mockReset()
+    .mockResolvedValue([ALICE_LAPTOP, ALICE_CI, BOB_OLD, BOB_LINK]);
+  vi.mocked(revokeConnectionKey).mockReset().mockResolvedValue(undefined);
+});
+
+describe('groupByAccount', () => {
+  it('groups in server order, live keys first, most recently used at the top', () => {
+    const groups = groupByAccount([ALICE_LAPTOP, ALICE_CI, BOB_OLD, BOB_LINK], true);
+    expect(groups.map((g) => g.user.id)).toEqual(['u-alice', 'u-bob']);
+    // Alice: CI was used, Laptop never → CI first despite Laptop being newer.
+    expect(groups[0].keys.map((k) => k.id)).toEqual(['k-ci', 'k-laptop']);
+    // Bob: the live link outranks the revoked key.
+    expect(groups[1].keys.map((k) => k.id)).toEqual(['k-link', 'k-old']);
+  });
+
+  it('drops revoked keys (and accounts left empty) when they are hidden', () => {
+    const groups = groupByAccount([BOB_OLD, ALICE_CI], false);
+    expect(groups.map((g) => g.user.id)).toEqual(['u-alice']);
+  });
+});
+
+describe('ConnectionKeysPage', () => {
+  it('shows the admins-only state (and never loads) for non-admins', () => {
+    renderPage({ isAdmin: false });
+    expect(screen.getByText(/Admins only/)).toBeInTheDocument();
+    expect(listConnectionKeys).not.toHaveBeenCalled();
+  });
+
+  it('lists live keys per account with created / last used, hiding disconnected ones by default', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+
+    const alice = screen.getByRole('region', { name: 'Keys for alice@example.com' });
+    expect(within(alice).getByText('Alice')).toBeInTheDocument();
+    expect(within(alice).getByText('Created 1w ago')).toBeInTheDocument();
+    expect(within(alice).getByText('Last used 2h ago')).toBeInTheDocument();
+    expect(within(alice).getByText('Created 3d ago')).toBeInTheDocument();
+    expect(within(alice).getByText('Last used never')).toBeInTheDocument();
+    expect(
+      within(alice).getByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    ).toBeInTheDocument();
+
+    const bob = screen.getByRole('region', { name: 'Keys for bob@example.com' });
+    expect(within(bob).getByText('Claude link')).toBeInTheDocument();
+    expect(within(bob).queryByText('Old script')).not.toBeInTheDocument();
+
+    expect(screen.getByText(/3 live keys · 1 disconnected/)).toBeInTheDocument();
+  });
+
+  it('reveals disconnected keys, without a revoke button, when toggled', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Show disconnected keys' }));
+
+    const bob = screen.getByRole('region', { name: 'Keys for bob@example.com' });
+    expect(within(bob).getByText('Old script')).toBeInTheDocument();
+    expect(within(bob).getByText(/Disconnected 2w ago/)).toBeInTheDocument();
+    expect(
+      within(bob).queryByRole('button', { name: 'Revoke Old script for bob@example.com' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('revokes after confirmation and reloads the list', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    );
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Alice \(alice@example.com\)/)).toBeInTheDocument();
+    expect(revokeConnectionKey).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Revoke key' }));
+
+    await waitFor(() => expect(revokeConnectionKey).toHaveBeenCalledWith('k-ci'));
+    await waitFor(() => expect(listConnectionKeys).toHaveBeenCalledTimes(2));
+  });
+
+  it('cancelling the confirm revokes nothing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    );
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    expect(revokeConnectionKey).not.toHaveBeenCalled();
+    expect(listConnectionKeys).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a failed revoke inline and keeps the rows it had', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
+    vi.mocked(revokeConnectionKey).mockRejectedValueOnce(new Error('Token not found'));
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
+    );
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', { name: 'Revoke key' }),
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Token not found');
+    expect(screen.getByText('CI pipeline')).toBeInTheDocument();
+  });
+
+  it('shows the load error and no empty state when the first load fails', async () => {
+    vi.mocked(listConnectionKeys).mockRejectedValueOnce(new Error('Could not load connection keys'));
+    renderPage();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load connection keys');
+    expect(screen.queryByText(/No connection keys/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PageShell } from '../../../shared/components/PageShell';
 import { Dialog } from '../../../shared/components/Dialog';
 import { formatRelativeTime } from '../../../lib/utils';
@@ -44,13 +44,20 @@ export function ConnectionKeysPage() {
   const [pendingRevoke, setPendingRevoke] = useState<AdminConnectionKey | null>(null);
   const [revoking, setRevoking] = useState(false);
 
+  // Generation of the newest load. Two revokes in quick succession start two
+  // reloads, and the older one can land last — carrying a key the newer one
+  // already saw revoked. Only the latest load may write `keys`.
+  const loadGen = useRef(0);
   const refresh = useCallback(() => {
+    const gen = ++loadGen.current;
     listConnectionKeys()
       .then((rows) => {
+        if (gen !== loadGen.current) return;
         setKeys(rows);
         setError(null);
       })
       .catch((err) => {
+        if (gen !== loadGen.current) return;
         setError(err instanceof Error ? err.message : "Couldn't load connection keys.");
         // `keys` is deliberately left alone: a reload that fails keeps the
         // rows it had, and a first load that fails stays `null` rather than
@@ -71,7 +78,16 @@ export function ConnectionKeysPage() {
     setRevoking(true);
     setError(null);
     try {
-      await revokeConnectionKey(pendingRevoke.id);
+      const { id } = pendingRevoke;
+      await revokeConnectionKey(id);
+      // The server has revoked it; say so at once rather than waiting on the
+      // reload. If that reload fails, the row must not sit there looking live
+      // with a Revoke button — the agent holding this key is already cut off.
+      setKeys((prev) =>
+        prev
+          ? prev.map((k) => (k.id === id && k.revokedAt === null ? { ...k, revokedAt: Date.now() } : k))
+          : prev,
+      );
       setPendingRevoke(null);
       refresh();
     } catch (err) {

--- a/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PageShell } from '../../../shared/components/PageShell';
+import { Dialog } from '../../../shared/components/Dialog';
+import { formatRelativeTime } from '../../../lib/utils';
+import { GITHUB_LINK_KIND } from '../../../shared/marketplace-url';
+import { useAdmin } from '../state/admin.context';
+import {
+  listConnectionKeys,
+  revokeConnectionKey,
+  type AdminConnectionKey,
+} from '../services/connection-keys.api';
+import { groupByAccount } from './connection-keys-grouping';
+
+/**
+ * The shared formatter, plus the one word it deliberately leaves to the caller:
+ * a key that has never been used has no instant to describe.
+ */
+function formatRelative(ts: number | null): string {
+  return formatRelativeTime(ts) || 'never';
+}
+
+/** The exact instant, for a hover — the row shows the relative form. */
+function formatAbsolute(ts: number | null): string | undefined {
+  return ts === null ? undefined : new Date(ts).toLocaleString();
+}
+
+/**
+ * The Connection keys page (`/connection-keys`, admins only): every
+ * connection key on the deployment, grouped per account, with when it was
+ * created, when it was last used, and a revoke. It exists so a leaked or
+ * forgotten key can be cut off without signing in as its owner. Revoking
+ * keeps the row (dimmed, "Disconnected") so its last use stays visible;
+ * only the owner can delete it for good, from their own External agent
+ * access page. Disconnected keys are hidden by default — on a busy
+ * deployment they outnumber the live ones — and a toggle brings them back.
+ */
+export function ConnectionKeysPage() {
+  const { isAdmin } = useAdmin();
+  const [keys, setKeys] = useState<AdminConnectionKey[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showRevoked, setShowRevoked] = useState(false);
+  // The key awaiting revoke confirmation; non-null drives the confirm
+  // Dialog. `revoking` keeps the confirm open while the request is in flight.
+  const [pendingRevoke, setPendingRevoke] = useState<AdminConnectionKey | null>(null);
+  const [revoking, setRevoking] = useState(false);
+
+  const refresh = useCallback(() => {
+    listConnectionKeys()
+      .then((rows) => {
+        setKeys(rows);
+        setError(null);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Couldn't load connection keys.");
+        // `keys` is deliberately left alone: a reload that fails keeps the
+        // rows it had, and a first load that fails stays `null` rather than
+        // rendering "No connection keys" for a deployment we cannot reach.
+      });
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) refresh();
+  }, [isAdmin, refresh]);
+
+  const groups = useMemo(() => (keys ? groupByAccount(keys, showRevoked) : []), [keys, showRevoked]);
+  const liveCount = keys?.filter((k) => k.revokedAt === null).length ?? 0;
+  const revokedCount = (keys?.length ?? 0) - liveCount;
+
+  async function confirmRevoke() {
+    if (!pendingRevoke || revoking) return;
+    setRevoking(true);
+    setError(null);
+    try {
+      await revokeConnectionKey(pendingRevoke.id);
+      setPendingRevoke(null);
+      refresh();
+    } catch (err) {
+      setPendingRevoke(null);
+      setError(err instanceof Error ? err.message : "Couldn't revoke this key.");
+    } finally {
+      setRevoking(false);
+    }
+  }
+
+  if (!isAdmin) {
+    return (
+      <PageShell title="Connection keys">
+        <div className="text-sm text-ink-muted">
+          Admins only. Your own keys are on the External agent access page.
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <>
+      <PageShell title="Connection keys">
+        <div className="space-y-4">
+          <p className="text-xs text-ink-muted leading-snug">
+            Every connection key on this deployment, per account. Revoking a key cuts off the
+            external agent using it immediately; the key stays listed as disconnected so you can
+            still see when it was last used. Only its owner can delete it for good.
+          </p>
+
+          {error && (
+            <div
+              className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-sm px-2 py-1.5"
+              role="alert"
+            >
+              {error}
+            </div>
+          )}
+
+          {keys !== null && (
+            <div className="flex items-center justify-between gap-3 text-xs text-ink-muted">
+              <span>
+                {liveCount} live {liveCount === 1 ? 'key' : 'keys'}
+                {revokedCount > 0 && ` · ${revokedCount} disconnected`}
+              </span>
+              {revokedCount > 0 && (
+                <label className="flex items-center gap-1.5 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={showRevoked}
+                    onChange={(e) => setShowRevoked(e.target.checked)}
+                  />
+                  Show disconnected keys
+                </label>
+              )}
+            </div>
+          )}
+
+          {keys === null ? (
+            error ? null : <div className="text-xs text-ink-muted">Loading…</div>
+          ) : groups.length === 0 ? (
+            <div className="text-xs text-ink-muted">
+              {keys.length === 0 ? 'No connection keys on this deployment.' : 'No live connection keys.'}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {groups.map((group) => {
+                const live = group.keys.filter((k) => k.revokedAt === null).length;
+                return (
+                  <section key={group.user.id} aria-label={`Keys for ${group.user.email}`}>
+                    <div className="flex items-baseline gap-2 px-1 pb-1.5">
+                      <span className="text-sm font-medium truncate">{group.user.name}</span>
+                      <span className="text-meta text-ink-muted truncate">{group.user.email}</span>
+                      <span className="ml-auto text-meta text-ink-muted whitespace-nowrap">
+                        {live} live
+                      </span>
+                    </div>
+                    <ul className="divide-y divide-line border border-line rounded-sm">
+                      {group.keys.map((k) => {
+                        const revoked = k.revokedAt !== null;
+                        return (
+                          <li
+                            key={k.id}
+                            className={`flex items-center gap-3 px-3 py-2 text-sm ${
+                              revoked ? 'opacity-60' : ''
+                            }`}
+                          >
+                            <div className="flex-1 min-w-0">
+                              <div className="font-medium truncate">
+                                {k.label}
+                                {k.kind === GITHUB_LINK_KIND && (
+                                  <span className="ml-1.5 text-meta font-normal text-ink-muted">
+                                    Claude link
+                                  </span>
+                                )}
+                              </div>
+                              <div className="text-meta text-ink-muted">
+                                <span title={formatAbsolute(k.createdAt)}>
+                                  Created {formatRelative(k.createdAt)}
+                                </span>
+                                {' · '}
+                                <span title={formatAbsolute(k.lastUsedAt)}>
+                                  Last used {formatRelative(k.lastUsedAt)}
+                                </span>
+                                {revoked && (
+                                  <>
+                                    {' · '}
+                                    <span title={formatAbsolute(k.revokedAt)}>
+                                      Disconnected {formatRelative(k.revokedAt)}
+                                    </span>
+                                  </>
+                                )}
+                              </div>
+                            </div>
+                            {!revoked && (
+                              <button
+                                onClick={() => setPendingRevoke(k)}
+                                className="text-xs px-2 py-1 rounded-sm text-red-700 hover:bg-red-50 border border-red-200"
+                                title="Revoke this key. The external agent using it will lose access."
+                                aria-label={`Revoke ${k.label} for ${group.user.email}`}
+                              >
+                                Revoke
+                              </button>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </PageShell>
+
+      <Dialog
+        open={pendingRevoke !== null}
+        onClose={() => setPendingRevoke(null)}
+        title="Revoke connection key"
+        size="sm"
+        busy={revoking}
+        footer={
+          <>
+            <button
+              onClick={() => setPendingRevoke(null)}
+              disabled={revoking}
+              className="px-3 py-1.5 text-sm rounded-sm text-ink hover:bg-hover border border-line disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={confirmRevoke}
+              disabled={revoking}
+              className="px-3 py-1.5 text-sm rounded-sm bg-red-600 hover:bg-red-700 text-white disabled:opacity-50 disabled:hover:bg-red-600"
+            >
+              {revoking ? 'Revoking…' : 'Revoke key'}
+            </button>
+          </>
+        }
+      >
+        <p className="text-xs text-ink leading-snug">
+          Revoke <span className="font-medium">{pendingRevoke?.label}</span> belonging to{' '}
+          <span className="font-medium">
+            {pendingRevoke?.user.name} ({pendingRevoke?.user.email})
+          </span>
+          ? Whatever is using it loses access immediately. The key stays listed as disconnected
+          so its last use remains visible; its owner can delete it for good from their External
+          agent access page.
+        </p>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/core-frontend/src/modules/admin/components/connection-keys-grouping.ts
+++ b/packages/core-frontend/src/modules/admin/components/connection-keys-grouping.ts
@@ -1,0 +1,43 @@
+import type { AdminConnectionKey } from '../services/connection-keys.api';
+
+export interface AccountGroup {
+  user: AdminConnectionKey['user'];
+  keys: AdminConnectionKey[];
+}
+
+/**
+ * One list from the server, grouped per account in the order the server
+ * returned it (owner email). Within an account: live keys first, most
+ * recently used at the top, so the row an admin is hunting for — the key
+ * that is still being used — is never below the ones that are not.
+ *
+ * Lives beside {@link ConnectionKeysPage} rather than in it: a component
+ * file that also exports a plain function breaks fast refresh.
+ */
+export function groupByAccount(
+  keys: AdminConnectionKey[],
+  includeRevoked: boolean,
+): AccountGroup[] {
+  const groups: AccountGroup[] = [];
+  const byUser = new Map<string, AccountGroup>();
+  for (const key of keys) {
+    if (!includeRevoked && key.revokedAt !== null) continue;
+    let group = byUser.get(key.user.id);
+    if (!group) {
+      group = { user: key.user, keys: [] };
+      byUser.set(key.user.id, group);
+      groups.push(group);
+    }
+    group.keys.push(key);
+  }
+  for (const group of groups) {
+    group.keys.sort((a, b) => {
+      const aRevoked = a.revokedAt !== null;
+      const bRevoked = b.revokedAt !== null;
+      if (aRevoked !== bRevoked) return aRevoked ? 1 : -1;
+      const byUse = (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0);
+      return byUse !== 0 ? byUse : b.createdAt - a.createdAt;
+    });
+  }
+  return groups;
+}

--- a/packages/core-frontend/src/modules/admin/services/connection-keys.api.ts
+++ b/packages/core-frontend/src/modules/admin/services/connection-keys.api.ts
@@ -1,0 +1,45 @@
+import { authFetch } from '../../../lib/api';
+
+/**
+ * One row of the admin Connection keys overview
+ * (`GET /api/admin/connection-keys`): a key plus the account it belongs to.
+ * Never carries the plaintext — that was shown to the owner exactly once.
+ */
+export interface AdminConnectionKey {
+  id: string;
+  label: string;
+  /** `key` for a hand-made key; another kind for one a flow minted (a Claude link). */
+  kind: string;
+  createdAt: number;
+  lastUsedAt: number | null;
+  revokedAt: number | null;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+}
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  const body = await res.json().catch(() => ({}));
+  return (body as { error?: string }).error || fallback;
+}
+
+/** Every connection key on the deployment, ordered by owner email then newest-first. */
+export async function listConnectionKeys(): Promise<AdminConnectionKey[]> {
+  const res = await authFetch('/api/admin/connection-keys');
+  if (!res.ok) throw new Error(await readError(res, 'Could not load connection keys'));
+  const body = (await res.json()) as { keys: AdminConnectionKey[] };
+  return body.keys;
+}
+
+/**
+ * Revoke (disconnect) any account's key. The row is kept so its last-used
+ * time stays auditable; the agent holding the key loses access at once.
+ */
+export async function revokeConnectionKey(id: string): Promise<void> {
+  const res = await authFetch(`/api/admin/connection-keys/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error(await readError(res, 'Could not revoke this key'));
+}

--- a/packages/core-frontend/src/modules/settings/settings-nav-items.tsx
+++ b/packages/core-frontend/src/modules/settings/settings-nav-items.tsx
@@ -95,6 +95,14 @@ export const CORE_MENU_ITEMS: AdminMenuItem[] = [
     label: 'User accounts',
     path: '/user-accounts',
   },
+  {
+    id: 'connection-keys',
+    section: 'admin',
+    order: 25,
+    icon: <KeyRound size={15} />,
+    label: 'Connection keys',
+    path: '/connection-keys',
+  },
 ];
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an admins-only Connection keys page and deployment-wide API to inspect external keys across accounts and revoke any key. Revocation cuts off access immediately while retaining the disconnected row for audit; responses never expose plaintext keys or hashes.

**New Features**

- Groups keys by account with their label, type, creation time, last use, and disconnected status, with disconnected keys hidden by default.
- Keeps user-scoped revocation separate from the admin endpoint and adds confirmation, audit logging, safe errors, and 404s for malformed IDs.
- Marks revoked rows locally and ignores stale reloads so failed or out-of-order responses cannot restore a live row or its Revoke action.

<sup>Written for commit 9f36c32721c9c308fb92713eafe46ddc5d15eac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

