### PR TITLE
copy(keys): say "Revoke"/"Revoked" for API keys instead of "Disconnec…

### DIFF
--- a/packages/core-backend/src/modules/mcp/mcp.routes.ts
+++ b/packages/core-backend/src/modules/mcp/mcp.routes.ts
@@ -334,7 +334,7 @@ export function createMcpRoutes(
     }
   });
 
-  // Hard-delete: permanently remove a *disconnected* key and its audit row.
+  // Hard-delete: permanently remove a *revoked* key and its audit row.
   // Separate path from revoke so the two lifecycle steps can't be conflated;
   // the service refuses to delete a still-active key (409).
   router.delete('/mcp/external-api-keys/:id/permanent', jwtAuthMiddleware, async (req, res) => {

--- a/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
+++ b/packages/core-backend/src/modules/tool-auth/__tests__/external-api-key.service.test.ts
@@ -450,7 +450,7 @@ describe('ExternalApiKeyService', () => {
       expect((db as any).delete).toHaveBeenCalledWith(externalApiKeys);
     });
 
-    it('throws TokenStillActiveError when the token exists but was never disconnected', async () => {
+    it('throws TokenStillActiveError when the token exists but was never revoked', async () => {
       // SELECT finds the row with a null revokedAt → still active; no delete.
       const { db } = makeFakeDb([[{ revokedAt: null }]]);
       const service = new ExternalApiKeyService(db, 'bevel_');

--- a/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
+++ b/packages/core-backend/src/modules/tool-auth/connection-keys-admin.routes.ts
@@ -40,7 +40,7 @@ export function createConnectionKeysAdminRoutes(
     }
   });
 
-  // DELETE /api/admin/connection-keys/:id — revoke (disconnect) a key
+  // DELETE /api/admin/connection-keys/:id — revoke a key
   // belonging to ANY account. Idempotent on an already-revoked key; 404 when
   // no such key exists. Revoked rows are kept so `last_used_at` stays
   // auditable after a leak — there is deliberately no admin hard-delete.

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.errors.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.errors.ts
@@ -18,7 +18,7 @@ export class TokenNotFoundError extends Error {
 }
 
 export class TokenStillActiveError extends Error {
-  constructor(message = 'Disconnect this key before deleting it') {
+  constructor(message = 'Revoke this key before deleting it') {
     super(message);
     this.name = 'TokenStillActiveError';
   }

--- a/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
+++ b/packages/core-backend/src/modules/tool-auth/external-api-key.interface.ts
@@ -152,7 +152,7 @@ export interface IExternalApiKeyService {
 
   /**
    * Permanently delete a token row, dropping its audit trail. Only permitted
-   * on an already-revoked token — an active key must be disconnected first,
+   * on an already-revoked token — an active key must be revoked first,
    * so a live agent's access is never yanked by a single click. Throws
    * TokenNotFoundError if the token doesn't belong to the user, and
    * TokenStillActiveError if it hasn't been revoked yet.

--- a/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
+++ b/packages/core-frontend/src/modules/admin/__tests__/ConnectionKeysPage.test.tsx
@@ -107,7 +107,7 @@ describe('ConnectionKeysPage', () => {
     expect(listConnectionKeys).not.toHaveBeenCalled();
   });
 
-  it('lists live keys per account with created / last used, hiding disconnected ones by default', async () => {
+  it('lists live keys per account with created / last used, hiding revoked ones by default', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
 
@@ -125,18 +125,18 @@ describe('ConnectionKeysPage', () => {
     expect(within(bob).getByText('Claude link')).toBeInTheDocument();
     expect(within(bob).queryByText('Old script')).not.toBeInTheDocument();
 
-    expect(screen.getByText(/3 live keys · 1 disconnected/)).toBeInTheDocument();
+    expect(screen.getByText(/3 live keys · 1 revoked/)).toBeInTheDocument();
   });
 
-  it('reveals disconnected keys, without a revoke button, when toggled', async () => {
+  it('reveals revoked keys, without a revoke button, when toggled', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
 
-    await userEvent.click(screen.getByRole('checkbox', { name: 'Show disconnected keys' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Show revoked keys' }));
 
     const bob = screen.getByRole('region', { name: 'Keys for bob@example.com' });
     expect(within(bob).getByText('Old script')).toBeInTheDocument();
-    expect(within(bob).getByText(/Disconnected 2w ago/)).toBeInTheDocument();
+    expect(within(bob).getByText(/Revoked 2w ago/)).toBeInTheDocument();
     expect(
       within(bob).queryByRole('button', { name: 'Revoke Old script for bob@example.com' }),
     ).not.toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('ConnectionKeysPage', () => {
     expect(screen.getByText('CI pipeline')).toBeInTheDocument();
   });
 
-  it('keeps a revoked key disconnected when the reload after revoking fails', async () => {
+  it('keeps a revoked key revoked when the reload after revoking fails', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByText('CI pipeline')).toBeInTheDocument());
     vi.mocked(listConnectionKeys).mockRejectedValueOnce(new Error('Could not load connection keys'));
@@ -202,14 +202,14 @@ describe('ConnectionKeysPage', () => {
     );
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Could not load connection keys');
-    // The server said yes, so the row is disconnected regardless of the reload:
-    // hidden with the other disconnected keys, and never offering Revoke again.
+    // The server said yes, so the row is revoked regardless of the reload:
+    // hidden with the other revoked keys, and never offering Revoke again.
     expect(
       screen.queryByRole('button', { name: 'Revoke CI pipeline for alice@example.com' }),
     ).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole('checkbox', { name: 'Show disconnected keys' }));
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Show revoked keys' }));
     expect(screen.getByText('CI pipeline')).toBeInTheDocument();
-    expect(screen.getByText(/2 live keys · 2 disconnected/)).toBeInTheDocument();
+    expect(screen.getByText(/2 live keys · 2 revoked/)).toBeInTheDocument();
   });
 
   it('ignores a stale list response that lands after a newer one', async () => {
@@ -242,12 +242,12 @@ describe('ConnectionKeysPage', () => {
 
     const ciRevoked = { ...ALICE_CI, revokedAt: NOW };
     second.resolve([ciRevoked, { ...ALICE_LAPTOP, revokedAt: NOW }]);
-    await waitFor(() => expect(screen.getByText(/0 live keys · 2 disconnected/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/0 live keys · 2 revoked/)).toBeInTheDocument());
 
     // The stale reload: taken at face value, Laptop would come back to life.
     first.resolve([ciRevoked, ALICE_LAPTOP]);
     await new Promise((r) => setTimeout(r, 0));
-    expect(screen.getByText(/0 live keys · 2 disconnected/)).toBeInTheDocument();
+    expect(screen.getByText(/0 live keys · 2 revoked/)).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Revoke Laptop for alice@example.com' }),
     ).not.toBeInTheDocument();

--- a/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
+++ b/packages/core-frontend/src/modules/admin/components/ConnectionKeysPage.tsx
@@ -29,9 +29,9 @@ function formatAbsolute(ts: number | null): string | undefined {
  * connection key on the deployment, grouped per account, with when it was
  * created, when it was last used, and a revoke. It exists so a leaked or
  * forgotten key can be cut off without signing in as its owner. Revoking
- * keeps the row (dimmed, "Disconnected") so its last use stays visible;
+ * keeps the row (dimmed, "Revoked") so its last use stays visible;
  * only the owner can delete it for good, from their own External agent
- * access page. Disconnected keys are hidden by default — on a busy
+ * access page. Revoked keys are hidden by default — on a busy
  * deployment they outnumber the live ones — and a toggle brings them back.
  */
 export function ConnectionKeysPage() {
@@ -114,7 +114,7 @@ export function ConnectionKeysPage() {
         <div className="space-y-4">
           <p className="text-xs text-ink-muted leading-snug">
             Every connection key on this deployment, per account. Revoking a key cuts off the
-            external agent using it immediately; the key stays listed as disconnected so you can
+            external agent using it immediately; the key stays listed as revoked so you can
             still see when it was last used. Only its owner can delete it for good.
           </p>
 
@@ -131,7 +131,7 @@ export function ConnectionKeysPage() {
             <div className="flex items-center justify-between gap-3 text-xs text-ink-muted">
               <span>
                 {liveCount} live {liveCount === 1 ? 'key' : 'keys'}
-                {revokedCount > 0 && ` · ${revokedCount} disconnected`}
+                {revokedCount > 0 && ` · ${revokedCount} revoked`}
               </span>
               {revokedCount > 0 && (
                 <label className="flex items-center gap-1.5 cursor-pointer select-none">
@@ -140,7 +140,7 @@ export function ConnectionKeysPage() {
                     checked={showRevoked}
                     onChange={(e) => setShowRevoked(e.target.checked)}
                   />
-                  Show disconnected keys
+                  Show revoked keys
                 </label>
               )}
             </div>
@@ -196,7 +196,7 @@ export function ConnectionKeysPage() {
                                   <>
                                     {' · '}
                                     <span title={formatAbsolute(k.revokedAt)}>
-                                      Disconnected {formatRelative(k.revokedAt)}
+                                      Revoked {formatRelative(k.revokedAt)}
                                     </span>
                                   </>
                                 )}
@@ -254,7 +254,7 @@ export function ConnectionKeysPage() {
           <span className="font-medium">
             {pendingRevoke?.user.name} ({pendingRevoke?.user.email})
           </span>
-          ? Whatever is using it loses access immediately. The key stays listed as disconnected
+          ? Whatever is using it loses access immediately. The key stays listed as revoked
           so its last use remains visible; its owner can delete it for good from their External
           agent access page.
         </p>

--- a/packages/core-frontend/src/modules/admin/services/connection-keys.api.ts
+++ b/packages/core-frontend/src/modules/admin/services/connection-keys.api.ts
@@ -34,7 +34,7 @@ export async function listConnectionKeys(): Promise<AdminConnectionKey[]> {
 }
 
 /**
- * Revoke (disconnect) any account's key. The row is kept so its last-used
+ * Revoke any account's key. The row is kept so its last-used
  * time stays auditable; the agent holding the key loses access at once.
  */
 export async function revokeConnectionKey(id: string): Promise<void> {

--- a/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
+++ b/packages/core-frontend/src/modules/toolbar/components/ExternalAgentAccessPage.tsx
@@ -54,12 +54,13 @@ function formatRelative(ts: number | null): string {
  *    for what they may read. Their Claude links are listed here.
  *  - "Autonomous agents" — the external-API-key surface for pipelines/CI
  *    that can't open a browser: lists existing keys, mints new ones,
- *    disconnects revoked ones, permanently deletes disconnected ones. The
+ *    revokes live ones, permanently deletes revoked ones. The
  *    plaintext of a minted key is only shown once — there is no read-it-back
  *    endpoint.
  *
- * Glossary terms used in copy: "External API key", "Disconnect" (= revoke),
- * "External agent" (= MCP client). See docs/glossary.md.
+ * Glossary terms used in copy: "External API key", "Revoke" (a revoked key is
+ * gone for good — "Disconnect" is reserved for a Claude link, which can be
+ * connected again), "External agent" (= MCP client).
  */
 export function ExternalAgentAccessPage() {
   const labelInputId = useId();
@@ -100,7 +101,7 @@ export function ExternalAgentAccessPage() {
   const [reveal, setReveal] = useState<MintedExternalApiKey | null>(null);
   const { copied, copy } = useCopyFeedback();
 
-  // The disconnected key awaiting a permanent-delete confirmation. Non-null
+  // The revoked key awaiting a permanent-delete confirmation. Non-null
   // drives the themed confirm Dialog below; `deleting` keeps the request in
   // flight so the confirm can't be dismissed mid-delete.
   const [pendingDelete, setPendingDelete] = useState<{ id: string; label: string } | null>(null);
@@ -146,7 +147,7 @@ export function ExternalAgentAccessPage() {
       await disconnectExternalApiKey(id);
       await refresh();
     } catch (err) {
-      setLoadError(err instanceof Error ? err.message : "Couldn't disconnect this key.");
+      setLoadError(err instanceof Error ? err.message : "Couldn't revoke this key.");
     }
   }
 
@@ -169,13 +170,13 @@ export function ExternalAgentAccessPage() {
   const canSubmit = trimmed.length > 0 && trimmed.length <= MAX_LABEL_LEN && !creating;
 
   // Surface the keys that matter: active keys first (most-recently-used at the
-  // top, never-used ones last among the active), with disconnected keys sunk
+  // top, never-used ones last among the active), with revoked keys sunk
   // to the bottom. Non-destructive — nothing is hidden or deleted, just ordered
   // so a long list of stale/test keys doesn't bury the ones in use.
   // ONE list from the server, two views of it: live Claude links belong to
   // the Marketplaces tab (they were minted by a connection, not created
   // here), everything else — hand-made keys, and Claude links once
-  // disconnected, so they can be deleted — to the autonomous tab. Told
+  // revoked, so they can be deleted — to the autonomous tab. Told
   // apart by the stored kind, never the label.
   const isClaudeLink = (k: ExternalApiKeySummary) => k.kind === GITHUB_LINK_KIND;
   const claudeLinks = keys.filter((k) => isClaudeLink(k) && k.revokedAt === null);
@@ -517,7 +518,7 @@ export function ExternalAgentAccessPage() {
                           <div className="font-medium truncate">{k.label}</div>
                           <div className="text-[11px] text-ink-muted">
                             Created {formatRelative(k.createdAt)} · Last used {formatRelative(k.lastUsedAt)}
-                            {revoked && ' · Disconnected'}
+                            {revoked && ' · Revoked'}
                           </div>
                           {usage && (
                             <div className="mt-1 max-w-xs">
@@ -544,7 +545,7 @@ export function ExternalAgentAccessPage() {
                           <button
                             onClick={() => setPendingDelete({ id: k.id, label: k.label })}
                             className="text-xs px-2 py-1 rounded text-red-600 hover:bg-red-50 border border-line"
-                            title="Permanently delete this disconnected key and its usage history."
+                            title="Permanently delete this revoked key and its usage history."
                           >
                             Delete
                           </button>
@@ -552,9 +553,9 @@ export function ExternalAgentAccessPage() {
                           <button
                             onClick={() => handleDisconnect(k.id)}
                             className="text-xs px-2 py-1 rounded text-ink hover:bg-hover border border-line"
-                            title="Disconnect this external API key. The external agent using it will lose access."
+                            title="Revoke this external API key. The external agent using it will lose access."
                           >
-                            Disconnect
+                            Revoke
                           </button>
                         )}
                       </li>
@@ -614,7 +615,7 @@ export function ExternalAgentAccessPage() {
             </div>
             <div className="px-4 py-3 space-y-3">
               <p className="text-xs text-ink leading-snug">
-                This is the only time you'll see the full key. If you lose it, disconnect it and create a new one.
+                This is the only time you'll see the full key. If you lose it, revoke it and create a new one.
               </p>
               <div className="relative">
                 <textarea

--- a/packages/core-frontend/src/modules/toolbar/services/external-api-keys.api.ts
+++ b/packages/core-frontend/src/modules/toolbar/services/external-api-keys.api.ts
@@ -50,13 +50,13 @@ export async function disconnectExternalApiKey(id: string): Promise<void> {
   const res = await authFetch(`/api/mcp/external-api-keys/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
-  if (!res.ok) await unwrap(res, "Couldn't disconnect this key.");
+  if (!res.ok) await unwrap(res, "Couldn't revoke this key.");
 }
 
 /**
- * Permanently delete a disconnected key (drops its audit row). The backend
+ * Permanently delete a revoked key (drops its audit row). The backend
  * refuses to delete a still-active key, so callers should only offer this on
- * rows that are already disconnected.
+ * rows that are already revoked.
  */
 export async function deleteExternalApiKey(id: string): Promise<void> {
   const res = await authFetch(


### PR DESCRIPTION
…t"/"Disconnected"

"Disconnected" read as something a person could reconnect, and they tried. A revoked key is gone for good; "Disconnect" now names only a Claude link, which really can be connected again. Applied on the owner's External agent access page, the admin Connection keys page, the API clients' error copy and the backend's still-active error; tests follow the new wording.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the API key lifecycle copy from "Disconnect"/"Disconnected" to "Revoke"/"Revoked" across the owner's External agent access page, the admin Connection keys page, API client error messages, and backend errors. The old wording implied a key could be reconnected; a revoked key is gone for good. "Disconnect" now refers only to Claude links, which can genuinely be reconnected.

<sup>Written for commit 1b521c425a608d790c061f4cebbf494917ed86ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

