### PR TITLE
MCP-Session-Recovery — MCP tool calls survive a server restart

### DIFF
--- a/.changeset/mcp-session-recovery.md
+++ b/.changeset/mcp-session-recovery.md
@@ -1,0 +1,7 @@
+---
+'@bevel-software/platform-mcp-core': patch
+'@bevel-software/platform-core-backend': patch
+'@bevel-software/hexis-mcp': patch
+---
+
+MCP tool calls survive a server restart. A restarted server answers the next call on an old session with the spec's 404 / `Session not found`, and our clients used to hand that straight to the caller — a platform redeploy left every connected agent erroring until someone reconnected it by hand. The client now re-registers the affected manual and retries the call once, so the restart shows up as a single log line instead of a broken toolset. This covers third-party MCP servers the workspace proxies as well as the platform itself, and the local `hexis-mcp` server as well as the hosted endpoint. Only that one failure — the session miss, which the server decides before it dispatches to a tool — is retried: a tool error, an auth refusal, a timeout or a dropped connection surfaces exactly as before, so nothing that could have already run is ever run twice.

--- a/packages/core-backend/src/modules/mcp/mcp.service.ts
+++ b/packages/core-backend/src/modules/mcp/mcp.service.ts
@@ -28,6 +28,7 @@ import {
   dispatchMetaTool,
   dispatchToolCall,
   registerManual,
+  installSessionRecovery,
   flattenManualTool,
   toListedTool,
   toolError,
@@ -447,7 +448,24 @@ export class McpService {
       variables,
       load_variables_from: [bevelSecretsLoaderConfig(userId)],
     });
-    return CodeModeUtcpClient.create(process.cwd(), config);
+    const client = await CodeModeUtcpClient.create(process.cwd(), config);
+    /**
+     * SESSION RECOVERY. A proxied third-party MCP server that restarts (or
+     * expires a session) answers our next call with the spec's 404/`-32001`;
+     * without this the session's tools stay broken until the caller reconnects.
+     * Installed on the client, so the dispatch surface and `call_tool_chain`
+     * recover through the same mechanism. Re-registration re-uses the very
+     * template discovery registered with, resolved through the same variable
+     * tiers, so a healed manual is identical to a freshly discovered one.
+     *
+     * Deliberately clear of {@link ManualFailureMemo}: that memo is a circuit
+     * breaker for manuals whose REGISTRATION failed — which have no discovered
+     * tools to call in the first place — so a recovery neither consults it (a
+     * memoized failure must not block healing a manual that registered fine)
+     * nor records into it (an evicted session is not a broken credential).
+     */
+    const byName = new Map(manuals.map((m) => [String(m.name), m]));
+    return installSessionRecovery(client, { manualTemplate: (name) => byName.get(name) });
   }
 
   /**

--- a/packages/hexis-mcp/src/server.ts
+++ b/packages/hexis-mcp/src/server.ts
@@ -323,26 +323,61 @@ export async function createHexisMcpServer(
    * template from the repository BY NAME at call time, so re-registration is
    * invisible to it (verified against @utcp/sdk's dispatch).
    *
+   * SESSION RECOVERY SHARES THIS GATE. Recovery (below) re-registers a manual
+   * too, so both go through `withReregisterGate`: one at a time, never
+   * interleaved, and never each waiting on the other. That last part is why
+   * `callsParkedForReregister` exists — a call queued at the gate still holds
+   * an `inflightCalls` slot, and a swap draining for it would wait out the
+   * full deadline for a call that is itself waiting for that swap.
+   *
    * Key mode sets no `renewConnectionKey`, so renewal.ts never renews, this
-   * listener is never called, and the gate below never engages.
+   * listener is never called, and the swap below never engages.
    */
   let closed = false;
   let remoteManualRegistered = false;
   let inflightCalls = 0;
-  let swapInProgress: Promise<void> | null = null;
+  /** The one re-registration allowed at a time: a credential swap or a recovery. */
+  let reregisterInProgress: Promise<void> | null = null;
+  /** In-flight calls parked at that gate, waiting for their turn to recover. */
+  let callsParkedForReregister = 0;
   const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+  /**
+   * Run `body` as THE re-registration in flight. `parksACall` marks the waiter
+   * as a tool call whose own dispatch is blocked here, so a swap's drain does
+   * not count it. The published promise never rejects: it says "finished", not
+   * "succeeded".
+   */
+  const withReregisterGate = async <T>(body: () => Promise<T>, parksACall = false): Promise<T> => {
+    if (parksACall) callsParkedForReregister += 1;
+    try {
+      while (reregisterInProgress) await reregisterInProgress;
+    } finally {
+      if (parksACall) callsParkedForReregister -= 1;
+    }
+    // `body()` runs to its first await before the publish below, and nothing
+    // else can interleave in between — so anyone who observes this gate as
+    // free has genuinely not missed a re-registration that already began.
+    const run = body();
+    const published: Promise<void> = run.then(
+      () => {},
+      () => {},
+    ).finally(() => {
+      if (reregisterInProgress === published) reregisterInProgress = null;
+    });
+    reregisterInProgress = published;
+    return run;
+  };
   const swapRemoteCredential = async (token: string): Promise<void> => {
     // `client` (below) exists from the moment the manual is registered, so
     // the guard also keeps this closure off it before its declaration.
     if (closed || !remoteManualRegistered) return;
-    while (swapInProgress) await swapInProgress;
-    if (closed) return; // shutdown landed while awaiting the previous swap
-    const run = (async (): Promise<void> => {
+    await withReregisterGate(async (): Promise<void> => {
+      if (closed) return; // shutdown landed while awaiting the gate
       // Bounded drain: a wedged call must not hold the credential stale
       // forever — after the deadline the swap proceeds and the straggler
       // fails like any call racing a dying session would.
       const deadline = Date.now() + 15_000;
-      while (inflightCalls > 0 && Date.now() < deadline) await sleep(50);
+      while (inflightCalls - callsParkedForReregister > 0 && Date.now() < deadline) await sleep(50);
       try {
         // Closes the manual's MCP sessions and drops its repository entries.
         await client.deregisterManual(REMOTE_MANUAL_NAME);
@@ -361,11 +396,7 @@ export async function createHexisMcpServer(
       }
       await removeRemoteMetaTools(client);
       console.error('[hexis-mcp] remote manual re-registered with the renewed credential.');
-    })();
-    swapInProgress = run.finally(() => {
-      swapInProgress = null;
     });
-    await swapInProgress;
   };
   if (config.renewConnectionKey) {
     config.onConnectionKeyRenewed = swapRemoteCredential;
@@ -393,17 +424,19 @@ export async function createHexisMcpServer(
    * on one gets the spec's 404/`-32001`. Installed on the client, so the MCP
    * surface below and any `call_tool_chain` recover through the same mechanism.
    *
-   * The template is rebuilt HERE rather than captured, for two reasons: the
-   * remote manual must re-register with whatever connection key renewal has
-   * arrived at by now (a restart and a renewal often land together), and
-   * awaiting an in-flight credential swap first keeps the two re-registration
-   * paths off each other — a swap is already re-registering this manual, and
-   * its result is the session the retry should use.
+   * The template is rebuilt HERE rather than captured, so the remote manual
+   * re-registers with whatever connection key renewal has arrived at by now (a
+   * restart and a renewal often land together). Recovery runs under the SAME
+   * gate the credential swap uses, which is what keeps the two re-registration
+   * paths off each other, and it is `closed`-checked INSIDE that gate: once
+   * shutdown holds it, a recovery behind it registers nothing — and a recovery
+   * that got in first is awaited by `shutdown` before the client is closed, so
+   * a local manual can never be registered (spawning a child) after teardown.
    */
   const localByName = new Map(local.map((m) => [String(m.name), m]));
   installSessionRecovery(client, {
-    manualTemplate: async (name) => {
-      while (swapInProgress) await swapInProgress;
+    withReregister: (_name, run) => withReregisterGate(run, true),
+    manualTemplate: (name) => {
       if (closed) return undefined;
       return name === REMOTE_MANUAL_NAME
         ? remoteManualTemplate(mcpUrl, config.connectionKey)
@@ -433,13 +466,16 @@ export async function createHexisMcpServer(
     // starting after this point — a straggling 401-retry — is refused, not
     // merely de-fanged), the listener is unhooked (renewal.ts reads it at
     // notify time, so a renewal already in flight applies to nothing), and a
-    // swap that started before this point gets to finish before the client it
-    // operates on is closed out from under it.
+    // swap — or a session recovery — that started before this point gets to
+    // finish before the client it operates on is closed out from under it.
     closeRenewal(config);
     if (config.onConnectionKeyRenewed === swapRemoteCredential) {
       config.onConnectionKeyRenewed = undefined;
     }
-    if (swapInProgress) await swapInProgress.catch(() => {});
+    // One await, not a loop: whatever holds the gate finishes, and anything
+    // queued behind it now finds `closed` and registers nothing. The gate
+    // promise never rejects, so this cannot throw teardown off course.
+    if (reregisterInProgress) await reregisterInProgress;
     // The SDK server too, not only the client: embedding callers connect the
     // transport themselves, and this handle should fully tear down — closing
     // the server closes its transport (and with it any pending requests).
@@ -477,9 +513,10 @@ export async function createHexisMcpServer(
     server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: listedTools(tools) }));
 
     server.setRequestHandler(CallToolRequestSchema, async (request, extra): Promise<CallToolResult> => {
-      // Never start a call mid-swap — the remote manual may be between its
-      // deregister and re-register, where a repository lookup finds nothing.
-      while (swapInProgress) await swapInProgress;
+      // Never start a call mid-re-registration — a swap or a recovery may have
+      // the manual between its deregister and its register, where a repository
+      // lookup finds nothing.
+      while (reregisterInProgress) await reregisterInProgress;
       inflightCalls += 1;
       try {
         const name = request.params.name;

--- a/packages/hexis-mcp/src/server.ts
+++ b/packages/hexis-mcp/src/server.ts
@@ -25,6 +25,7 @@ import {
   dispatchMetaTool,
   dispatchToolCall,
   registerManual,
+  installSessionRecovery,
   flattenManualTool,
   toListedTool,
   toolError,
@@ -385,6 +386,38 @@ export async function createHexisMcpServer(
   const remote = remoteManualTemplate(mcpUrl, registeredKey);
 
   const { client, bindingId } = await buildClient(config, [remote, ...local], localOnly);
+
+  /**
+   * SESSION RECOVERY. A deployment redeploy — or a local `mcp.json` server
+   * restarting — throws away the sessions our manuals hold, and the next call
+   * on one gets the spec's 404/`-32001`. Installed on the client, so the MCP
+   * surface below and any `call_tool_chain` recover through the same mechanism.
+   *
+   * The template is rebuilt HERE rather than captured, for two reasons: the
+   * remote manual must re-register with whatever connection key renewal has
+   * arrived at by now (a restart and a renewal often land together), and
+   * awaiting an in-flight credential swap first keeps the two re-registration
+   * paths off each other — a swap is already re-registering this manual, and
+   * its result is the session the retry should use.
+   */
+  const localByName = new Map(local.map((m) => [String(m.name), m]));
+  installSessionRecovery(client, {
+    manualTemplate: async (name) => {
+      while (swapInProgress) await swapInProgress;
+      if (closed) return undefined;
+      return name === REMOTE_MANUAL_NAME
+        ? remoteManualTemplate(mcpUrl, config.connectionKey)
+        : localByName.get(name);
+    },
+    // Re-registering rediscovers the deployment's own copies of the code-mode
+    // meta-tools, which must not be callable from a chain here (see
+    // `discoverTools`) — the same purge first registration does.
+    afterReregister: async (name) => {
+      if (name === REMOTE_MANUAL_NAME) await removeRemoteMetaTools(client);
+    },
+    // No `log` override: the default writes to stderr, which is the only place
+    // this stdio server may write — stdout is the MCP transport itself.
+  });
 
   // Declared BEFORE the fallible phase below, so the failure path can run the
   // very same teardown: from the moment the client exists, registrations spawn

--- a/packages/hexis-mcp/src/server.ts
+++ b/packages/hexis-mcp/src/server.ts
@@ -26,6 +26,7 @@ import {
   dispatchToolCall,
   registerManual,
   installSessionRecovery,
+  noteManualReregistered,
   flattenManualTool,
   toListedTool,
   toolError,
@@ -395,6 +396,11 @@ export async function createHexisMcpServer(
         return;
       }
       await removeRemoteMetaTools(client);
+      // The manual now holds a session this swap created. A call that lost its
+      // own session around the swap — the two often land together, a redeploy
+      // being exactly when a 401-triggered renewal happens — retries against
+      // THIS one instead of deregistering it to dial an identical third.
+      noteManualReregistered(client, REMOTE_MANUAL_NAME);
       console.error('[hexis-mcp] remote manual re-registered with the renewed credential.');
     });
   };
@@ -517,6 +523,11 @@ export async function createHexisMcpServer(
       // the manual between its deregister and its register, where a repository
       // lookup finds nothing.
       while (reregisterInProgress) await reregisterInProgress;
+      // Shutdown can land while a call waits here, and `shutdown` waits only
+      // for the re-registration, not for callers parked behind it. Dispatching
+      // now would run against a client being torn down, so the caller gets the
+      // real reason rather than whatever a half-closed transport throws.
+      if (closed) throw new McpError(ErrorCode.ConnectionClosed, 'hexis-mcp is shutting down.');
       inflightCalls += 1;
       try {
         const name = request.params.name;

--- a/packages/mcp-core/src/__tests__/fake-mcp-server.ts
+++ b/packages/mcp-core/src/__tests__/fake-mcp-server.ts
@@ -1,0 +1,178 @@
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { AddressInfo } from 'node:net';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  isInitializeRequest,
+  type CallToolResult,
+} from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * A scriptable MCP server over real HTTP, used to drive session recovery
+ * against the failure shape a live server actually produces.
+ *
+ * The point of using a real server rather than a stubbed client: the whole
+ * safety argument for retrying rests on ONE error shape — HTTP 404 carrying
+ * JSON-RPC `-32001` — travelling intact from the wire, through the MCP SDK's
+ * transport, through `@utcp/mcp`, to our classifier. A hand-built `Error` would
+ * assert our belief about that shape instead of the shape itself, and the
+ * belief is the part most likely to be wrong (or to drift on a version bump).
+ *
+ * Session routing mirrors the platform's own (`mcp.routes.ts`): a live session
+ * id is forwarded, an `initialize` always starts a fresh session whatever stale
+ * id it carries, a session id we hold nothing for is the 404, and no session id
+ * at all is the 400.
+ */
+export interface FakeMcpServer {
+  url: string;
+  /** Throw away every session, as a restart does. The process stays up. */
+  restart(): Promise<void>;
+  /** Stop listening entirely — the "server is DOWN" case. */
+  stop(): Promise<void>;
+  /** `initialize` requests served; one per registration that reached the server. */
+  initializations(): number;
+  /** How many times each tool actually EXECUTED (the double-execution guard). */
+  executions(toolName: string): number;
+  /**
+   * Make every tool call fail from now on the way a genuinely broken tool does:
+   * the handler throws, the SDK turns that into a JSON-RPC error response, and
+   * the client rejects with an `McpError`. Nothing about it is session-shaped.
+   */
+  failToolCalls(reason: string | null): void;
+  /** Answer every request 401, as a server that has stopped accepting our key. */
+  failWithAuthError(on: boolean): void;
+}
+
+const TOOLS = [
+  {
+    name: 'echo',
+    description: 'Return the text it was given.',
+    inputSchema: { type: 'object' as const, properties: { text: { type: 'string' } } },
+  },
+  {
+    name: 'bump',
+    description: 'A MUTATING tool: increments a counter and returns its new value.',
+    inputSchema: { type: 'object' as const, properties: {} },
+  },
+];
+
+export async function startFakeMcpServer(name = 'fake'): Promise<FakeMcpServer> {
+  const sessions = new Map<string, { transport: StreamableHTTPServerTransport; server: Server }>();
+  const executions = new Map<string, number>();
+  let initializations = 0;
+  let counter = 0;
+  let toolFailure: string | null = null;
+  let authFailure = false;
+
+  function buildServer(): Server {
+    const server = new Server({ name, version: '0.0.0' }, { capabilities: { tools: {} } });
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+    server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+      const tool = request.params.name;
+      executions.set(tool, (executions.get(tool) ?? 0) + 1);
+      // Thrown, not returned as `isError`: a handler that throws is what
+      // reaches the caller as an exception, which is the only failure shape
+      // recovery could ever mistake for session loss.
+      if (toolFailure) throw new Error(toolFailure);
+      if (tool === 'bump') {
+        counter += 1;
+        return { content: [{ type: 'text', text: JSON.stringify({ counter }) }] };
+      }
+      const text = String((request.params.arguments as { text?: unknown } | undefined)?.text ?? '');
+      return { content: [{ type: 'text', text: JSON.stringify({ echoed: text }) }] };
+    });
+    return server;
+  }
+
+  function jsonRpcError(res: ServerResponse, status: number, code: number, message: string): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: null }));
+  }
+
+  async function readBody(req: IncomingMessage): Promise<unknown> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk as Buffer);
+    if (chunks.length === 0) return undefined;
+    try {
+      return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    } catch {
+      return undefined;
+    }
+  }
+
+  const http: HttpServer = createServer((req, res) => {
+    void (async () => {
+      if (authFailure) {
+        jsonRpcError(res, 401, -32000, 'Unauthorized');
+        return;
+      }
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      const body = req.method === 'POST' ? await readBody(req) : undefined;
+      const live = sessionId ? sessions.get(sessionId) : undefined;
+      if (live) {
+        await live.transport.handleRequest(req, res, body);
+        return;
+      }
+      if (req.method === 'POST' && isInitializeRequest(body)) {
+        initializations += 1;
+        const server = buildServer();
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          onsessioninitialized: (id: string): void => {
+            sessions.set(id, { transport, server });
+          },
+        });
+        transport.onclose = () => {
+          if (transport.sessionId) sessions.delete(transport.sessionId);
+        };
+        await server.connect(transport);
+        await transport.handleRequest(req, res, body);
+        return;
+      }
+      // The signal this whole feature keys on: a session id we hold nothing
+      // for. Anything without an id at all is the caller's own mistake.
+      if (sessionId) {
+        jsonRpcError(res, 404, -32001, 'Session not found');
+        return;
+      }
+      jsonRpcError(res, 400, -32000, 'Bad Request: Mcp-Session-Id header is required');
+    })().catch(() => {
+      if (!res.headersSent) jsonRpcError(res, 500, -32603, 'Internal error');
+      else res.end();
+    });
+  });
+
+  await new Promise<void>((resolve) => http.listen(0, '127.0.0.1', resolve));
+  const { port } = http.address() as AddressInfo;
+
+  async function dropSessions(): Promise<void> {
+    const live = [...sessions.values()];
+    sessions.clear();
+    // Closing after clearing: the transport's onclose would otherwise delete
+    // an entry a re-initialize may already have put back.
+    await Promise.all(live.map((s) => s.transport.close().catch(() => {})));
+  }
+
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    restart: dropSessions,
+    async stop() {
+      await dropSessions();
+      await new Promise<void>((resolve) => http.close(() => resolve()));
+      // A keep-alive socket the client still holds would let a request hang
+      // past close(); drop them so a call against a stopped server refuses.
+      http.closeAllConnections?.();
+    },
+    initializations: () => initializations,
+    executions: (toolName: string) => executions.get(toolName) ?? 0,
+    failToolCalls: (reason: string | null) => {
+      toolFailure = reason;
+    },
+    failWithAuthError: (on: boolean) => {
+      authFailure = on;
+    },
+  };
+}

--- a/packages/mcp-core/src/__tests__/session-recovery.test.ts
+++ b/packages/mcp-core/src/__tests__/session-recovery.test.ts
@@ -455,6 +455,48 @@ describe('session recovery — invariants that only a stubbed client can force',
     ]);
   });
 
+  it('reuses a session the surface re-registered while the template resolver waited', async () => {
+    const { client, calls } = losesSessionOnce();
+    let registrations = 0;
+    let deregistrations = 0;
+    Object.assign(client, {
+      registerManual: async () => {
+        registrations += 1;
+        return { success: true };
+      },
+      deregisterManual: async () => {
+        deregistrations += 1;
+        return true;
+      },
+    });
+    let releaseResolver = (): void => {};
+    const resolverParked = new Promise<void>((enteredResolver) => {
+      installSessionRecovery(client, {
+        // The documented use of an ASYNC resolver: a surface parks here to
+        // wait out a re-registration of its own. The generation can move
+        // across that await, and this is the window under test.
+        manualTemplate: async () => {
+          enteredResolver();
+          await new Promise<void>((release) => (releaseResolver = release));
+          return manualTemplate('platform', 'http://127.0.0.1:1/mcp');
+        },
+        log: () => {},
+      });
+    });
+
+    const call = client.callTool('platform.srv.echo', {});
+    await resolverParked;
+    noteManualReregistered(client, 'platform');
+    releaseResolver();
+
+    expect(await call).toBe('ok');
+    // The session the surface just made is live: recovery must not tear it
+    // down on the strength of a generation it read before it waited.
+    expect(registrations).toBe(0);
+    expect(deregistrations).toBe(0);
+    expect(calls()).toBe(2);
+  });
+
   it('ignores a re-registration reported for a client that has no recovery installed', () => {
     // The surface calls this unconditionally; a client without recovery (a
     // test double, an embedding host that never installed it) is not an error.

--- a/packages/mcp-core/src/__tests__/session-recovery.test.ts
+++ b/packages/mcp-core/src/__tests__/session-recovery.test.ts
@@ -4,7 +4,11 @@ import { CodeModeUtcpClient } from '@utcp/code-mode';
 import { CallTemplateSerializer, type CallTemplate } from '@utcp/sdk';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { installSessionRecovery, isSessionLoss } from '../session-recovery.js';
+import {
+  installSessionRecovery,
+  isSessionLoss,
+  noteManualReregistered,
+} from '../session-recovery.js';
 import { registerManual, dispatchToolCall } from '../dispatch.js';
 import { dispatchMetaTool } from '../meta-tools.js';
 import type { ProxiedTool } from '../proxied-tool.js';
@@ -412,6 +416,49 @@ describe('session recovery — invariants that only a stubbed client can force',
     // Nothing the surface has to serialize against — template resolution, the
     // deregister/register pair, the cleanup — may escape the gate.
     expect(order).toEqual(['gate:enter:platform', 'template', 'cleanup', 'gate:exit']);
+  });
+
+  it('reuses a session the surface re-registered while the recovery waited at its gate', async () => {
+    const { client, calls } = losesSessionOnce();
+    let registrations = 0;
+    let deregistrations = 0;
+    Object.assign(client, {
+      registerManual: async () => {
+        registrations += 1;
+        return { success: true };
+      },
+      deregisterManual: async () => {
+        deregistrations += 1;
+        return true;
+      },
+    });
+    const log: string[] = [];
+    installSessionRecovery(client, {
+      manualTemplate: () => manualTemplate('platform', 'http://127.0.0.1:1/mcp'),
+      // The surface's own re-registration — hexis-mcp's credential swap —
+      // completing while this recovery is queued behind it for the gate.
+      withReregister: async (_name, run) => {
+        noteManualReregistered(client, 'platform');
+        return run();
+      },
+      log: (m) => log.push(m),
+    });
+
+    expect(await client.callTool('platform.srv.echo', {})).toBe('ok');
+    // The swap's session is live and postdates the failure, so recovery must
+    // retry against it rather than tear it down to dial an identical third.
+    expect(registrations).toBe(0);
+    expect(deregistrations).toBe(0);
+    expect(calls()).toBe(2);
+    expect(log).toEqual([
+      `[mcp] session lost on 'platform' — re-registered by a concurrent call; retrying.`,
+    ]);
+  });
+
+  it('ignores a re-registration reported for a client that has no recovery installed', () => {
+    // The surface calls this unconditionally; a client without recovery (a
+    // test double, an embedding host that never installed it) is not an error.
+    expect(() => noteManualReregistered(stubClient({}), 'platform')).not.toThrow();
   });
 
   it('keeps one recovered call to one log line however much went sideways', async () => {

--- a/packages/mcp-core/src/__tests__/session-recovery.test.ts
+++ b/packages/mcp-core/src/__tests__/session-recovery.test.ts
@@ -338,4 +338,113 @@ describe('session recovery — invariants that only a stubbed client can force',
     expect(calls).toBe(2);
     expect(registrations).toBe(1);
   });
+
+  /** A stub whose `callTool` loses the session once, then answers 'ok'. */
+  function losesSessionOnce(): { client: CodeModeUtcpClient; calls: () => number } {
+    let calls = 0;
+    const client = stubClient({
+      async callTool() {
+        calls += 1;
+        if (calls === 1) throw sessionLost();
+        return 'ok';
+      },
+      callToolStreaming: () => {
+        throw new Error('not exercised by this test');
+      },
+    });
+    return { client, calls: () => calls };
+  }
+
+  it('surfaces the original session loss when the template resolver throws', async () => {
+    const { client, calls } = losesSessionOnce();
+    const log: string[] = [];
+    installSessionRecovery(client, {
+      manualTemplate: () => {
+        throw new Error('config store unreachable');
+      },
+      log: (m) => log.push(m),
+    });
+
+    // The caller's error is the one the CALL produced. A resolver blowing up
+    // means recovery did not happen — not that the failure changes shape.
+    await expect(client.callTool('platform.srv.echo', {})).rejects.toThrow(/Session not found/);
+    expect(calls()).toBe(1);
+    expect(log).toEqual([
+      `[mcp] session lost on 'platform' — not recovered (re-registration threw: config store unreachable); the original failure stands.`,
+    ]);
+  });
+
+  it('surfaces the original session loss when the surface gate throws', async () => {
+    const { client, calls } = losesSessionOnce();
+    installSessionRecovery(client, {
+      manualTemplate: () => manualTemplate('platform', 'http://127.0.0.1:1/mcp'),
+      withReregister: () => Promise.reject(new Error('shutting down')),
+      log: () => {},
+    });
+
+    await expect(client.callTool('platform.srv.echo', {})).rejects.toThrow(/Session not found/);
+    expect(calls()).toBe(1);
+  });
+
+  it('runs the whole re-registration inside the surface gate, once', async () => {
+    const { client } = losesSessionOnce();
+    const order: string[] = [];
+    installSessionRecovery(client, {
+      manualTemplate: () => {
+        order.push('template');
+        return manualTemplate('platform', 'http://127.0.0.1:1/mcp');
+      },
+      afterReregister: () => {
+        order.push('cleanup');
+      },
+      withReregister: async (name, run) => {
+        order.push(`gate:enter:${name}`);
+        try {
+          return await run();
+        } finally {
+          order.push('gate:exit');
+        }
+      },
+      log: () => {},
+    });
+
+    expect(await client.callTool('platform.srv.echo', {})).toBe('ok');
+    // Nothing the surface has to serialize against — template resolution, the
+    // deregister/register pair, the cleanup — may escape the gate.
+    expect(order).toEqual(['gate:enter:platform', 'template', 'cleanup', 'gate:exit']);
+  });
+
+  it('keeps one recovered call to one log line however much went sideways', async () => {
+    let calls = 0;
+    const client = stubClient({
+      deregisterManual: async () => {
+        throw new Error('manual already gone');
+      },
+      async callTool() {
+        calls += 1;
+        if (calls === 1) throw sessionLost();
+        return 'ok';
+      },
+      callToolStreaming: () => {
+        throw new Error('not exercised by this test');
+      },
+    });
+    const log: string[] = [];
+    installSessionRecovery(client, {
+      manualTemplate: () => manualTemplate('platform', 'http://127.0.0.1:1/mcp'),
+      afterReregister: () => {
+        throw new Error('purge failed');
+      },
+      log: (m) => log.push(m),
+    });
+
+    expect(await client.callTool('platform.srv.echo', {})).toBe('ok');
+    // One recovery is one event: the abnormalities ride in that line rather
+    // than arriving as lines of their own, which would read as three
+    // recoveries to anyone watching stderr.
+    expect(log).toEqual([
+      `[mcp] session lost on 'platform' — re-registered and retried. ` +
+        `(deregistering first failed: manual already gone; post-re-registration cleanup failed: purge failed)`,
+    ]);
+  });
 });

--- a/packages/mcp-core/src/__tests__/session-recovery.test.ts
+++ b/packages/mcp-core/src/__tests__/session-recovery.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '@utcp/mcp'; // side effect: registers the 'mcp' UTCP communication protocol
+import { CodeModeUtcpClient } from '@utcp/code-mode';
+import { CallTemplateSerializer, type CallTemplate } from '@utcp/sdk';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { installSessionRecovery, isSessionLoss } from '../session-recovery.js';
+import { registerManual, dispatchToolCall } from '../dispatch.js';
+import { dispatchMetaTool } from '../meta-tools.js';
+import type { ProxiedTool } from '../proxied-tool.js';
+import { startFakeMcpServer, type FakeMcpServer } from './fake-mcp-server.js';
+
+const serializer = new CallTemplateSerializer();
+
+/** The manual a surface registers a remote MCP server as. */
+function manualTemplate(name: string, url: string): CallTemplate {
+  return serializer.validateDict({
+    name,
+    call_template_type: 'mcp',
+    config: {
+      mcpServers: {
+        srv: { transport: 'http', url, timeout: 10, terminate_on_close: true },
+      },
+    },
+  });
+}
+
+function proxiedTool(manual: string, tool: string): ProxiedTool {
+  return {
+    utcpName: `${manual}.srv.${tool}`,
+    mcpName: tool,
+    description: `the ${tool} tool`,
+    inputSchema: { type: 'object', properties: {} },
+    manualName: manual,
+  };
+}
+
+/** Everything a test needs torn down, in reverse order of creation. */
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup().catch(() => {});
+  vi.restoreAllMocks();
+});
+
+async function startServer(name = 'fake'): Promise<FakeMcpServer> {
+  const server = await startFakeMcpServer(name);
+  cleanups.push(() => server.stop());
+  return server;
+}
+
+/**
+ * A client wired the way a surface wires it: manuals registered, then session
+ * recovery installed over the same templates. `log` is captured rather than
+ * printed so a test can assert on the one line a recovery is allowed to emit.
+ */
+async function connectedClient(
+  manuals: Record<string, string>,
+): Promise<{ client: CodeModeUtcpClient; log: string[]; reregistrations: string[] }> {
+  const templates = new Map(
+    Object.entries(manuals).map(([name, url]) => [name, manualTemplate(name, url)] as const),
+  );
+  const client = await CodeModeUtcpClient.create(process.cwd(), null);
+  cleanups.push(() => client.close());
+  for (const template of templates.values()) {
+    const result = await registerManual(client, template);
+    expect(result).toEqual({ ok: true });
+  }
+  const log: string[] = [];
+  const reregistrations: string[] = [];
+  installSessionRecovery(client, {
+    manualTemplate: (name) => templates.get(name),
+    afterReregister: (name) => {
+      reregistrations.push(name);
+    },
+    log: (message) => log.push(message),
+  });
+  return { client, log, reregistrations };
+}
+
+/** Call a tool the way the MCP dispatch surface does. */
+async function callOverMcpSurface(
+  client: CodeModeUtcpClient,
+  manual: string,
+  tool: string,
+  args: Record<string, unknown> = {},
+): Promise<string> {
+  const result = await dispatchToolCall(client, proxiedTool(manual, tool), args);
+  const text = (result.content[0] as { text: string } | undefined)?.text ?? '';
+  if (result.isError) throw new Error(text);
+  return text;
+}
+
+describe('isSessionLoss', () => {
+  it('matches the live shape: a 404 whose body is the JSON-RPC session miss', () => {
+    // Verbatim what the SDK transport throws for the platform's own 404 —
+    // the status lives on `code`, the JSON-RPC code only in the message.
+    const err = new StreamableHTTPError(
+      404,
+      'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
+    );
+    expect(isSessionLoss(err)).toBe(true);
+  });
+
+  it('matches a 404 that carries only the reserved message', () => {
+    expect(isSessionLoss(new StreamableHTTPError(404, 'Session not found'))).toBe(true);
+  });
+
+  it('follows a cause chain to reach the transport error', () => {
+    const wrapped = new Error('MCP operation on \'srv\' failed', {
+      cause: new StreamableHTTPError(404, 'Error POSTing to endpoint: {"error":{"code":-32001}}'),
+    });
+    expect(isSessionLoss(wrapped)).toBe(true);
+  });
+
+  it('does NOT match a request timeout, whose JSON-RPC code is also -32001', () => {
+    // The trap this classifier exists to avoid: `ErrorCode.RequestTimeout` is
+    // -32001 too. Retrying a timeout could execute a mutating tool twice.
+    expect(isSessionLoss(new McpError(ErrorCode.RequestTimeout, 'Request timed out'))).toBe(false);
+    expect(isSessionLoss(new Error("MCP operation on 'srv' timed out after 60s."))).toBe(false);
+  });
+
+  it('does NOT match an auth failure, a tool error, or a refused connection', () => {
+    expect(isSessionLoss(new StreamableHTTPError(401, 'Error POSTing to endpoint: Unauthorized'))).toBe(false);
+    expect(isSessionLoss(new McpError(ErrorCode.InvalidParams, 'Missing required argument "path"'))).toBe(false);
+    expect(isSessionLoss(new McpError(ErrorCode.ConnectionClosed, 'Connection closed'))).toBe(false);
+    expect(isSessionLoss(Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9'), { code: 'ECONNREFUSED' }))).toBe(false);
+  });
+
+  it('does NOT match a 404 that is an ordinary not-found', () => {
+    expect(isSessionLoss(new StreamableHTTPError(404, 'Error POSTing to endpoint: Not Found'))).toBe(false);
+  });
+});
+
+describe('session recovery', () => {
+  it('heals the next call after the platform restarts, telling the caller nothing but a log line', async () => {
+    const platform = await startServer('platform');
+    const { client, log, reregistrations } = await connectedClient({ platform: platform.url });
+
+    expect(await callOverMcpSurface(client, 'platform', 'echo', { text: 'before' })).toContain('before');
+
+    await platform.restart();
+
+    expect(await callOverMcpSurface(client, 'platform', 'echo', { text: 'after' })).toContain('after');
+    expect(reregistrations).toEqual(['platform']);
+    expect(log).toEqual([`[mcp] session lost on 'platform' — re-registered and retried.`]);
+    // The retry is what executed; the lost-session attempt never reached the tool.
+    expect(platform.executions('echo')).toBe(2);
+  }, 20_000);
+
+  it('heals a proxied third-party server independently of the platform manual', async () => {
+    const platform = await startServer('platform');
+    const thirdParty = await startServer('third-party');
+    const { client, reregistrations } = await connectedClient({
+      platform: platform.url,
+      weather: thirdParty.url,
+    });
+
+    await thirdParty.restart();
+
+    expect(await callOverMcpSurface(client, 'weather', 'echo', { text: 'sunny' })).toContain('sunny');
+    expect(reregistrations).toEqual(['weather']);
+    // The platform manual never lost its session, so it was never re-registered.
+    expect(platform.initializations()).toBe(1);
+    expect(thirdParty.initializations()).toBe(2);
+  }, 20_000);
+
+  it('never retries a genuine tool error — a mutating tool executes exactly once', async () => {
+    const platform = await startServer('platform');
+    const { client, log, reregistrations } = await connectedClient({ platform: platform.url });
+
+    platform.failToolCalls('the provider returned 500');
+
+    await expect(callOverMcpSurface(client, 'platform', 'bump')).rejects.toThrow(/provider returned 500/);
+    // The guarantee that makes recovery safe: nothing outside the session-loss
+    // class is retried, so a mutating tool is never executed a second time.
+    expect(platform.executions('bump')).toBe(1);
+    expect(reregistrations).toEqual([]);
+    expect(platform.initializations()).toBe(1);
+    expect(log).toEqual([]);
+  }, 20_000);
+
+  it('never retries an auth failure or a refused connection', async () => {
+    const platform = await startServer('platform');
+    const { client, log, reregistrations } = await connectedClient({ platform: platform.url });
+
+    platform.failWithAuthError(true);
+    await expect(callOverMcpSurface(client, 'platform', 'echo')).rejects.toThrow();
+    expect(reregistrations).toEqual([]);
+    platform.failWithAuthError(false);
+
+    await platform.stop();
+    await expect(callOverMcpSurface(client, 'platform', 'echo')).rejects.toThrow();
+    expect(reregistrations).toEqual([]);
+    expect(log).toEqual([]);
+  }, 20_000);
+
+  it('coalesces concurrent session losses on one manual into a single re-registration', async () => {
+    const platform = await startServer('platform');
+    const { client, reregistrations } = await connectedClient({ platform: platform.url });
+
+    await callOverMcpSurface(client, 'platform', 'echo', { text: 'warm' });
+    await platform.restart();
+
+    const results = await Promise.all(
+      [1, 2, 3, 4, 5].map((n) => callOverMcpSurface(client, 'platform', 'echo', { text: `call-${n}` })),
+    );
+
+    expect(results.map((r) => JSON.parse(r).echoed).sort()).toEqual([
+      'call-1',
+      'call-2',
+      'call-3',
+      'call-4',
+      'call-5',
+    ]);
+    expect(reregistrations).toEqual(['platform']);
+    // One initialize for the original session, one for the recovery. Five
+    // would be the stampede this test exists to forbid.
+    expect(platform.initializations()).toBe(2);
+  }, 20_000);
+
+  it('recovers a tool call made from inside a code-mode chain', async () => {
+    const platform = await startServer('platform');
+    const { client, reregistrations } = await connectedClient({ platform: platform.url });
+
+    await platform.restart();
+
+    // `call_tool_chain` reaches tools through `callTool`, not the streaming
+    // dispatch path — the same wrapper has to cover both.
+    const result = await dispatchMetaTool(client, 'call_tool_chain', {
+      code: `return platform.srv_echo({ text: 'from-chain' });`,
+    });
+    expect(result.isError).toBeFalsy();
+    expect((result.content[0] as { text: string }).text).toContain('from-chain');
+    expect(reregistrations).toEqual(['platform']);
+  }, 30_000);
+
+  it('surfaces a failing retry to the caller, and does not recover a second time', async () => {
+    const platform = await startServer('platform');
+    const { client, reregistrations } = await connectedClient({ platform: platform.url });
+
+    await platform.restart();
+    // Re-registration (a tools/list) still succeeds; the retried CALL does not.
+    platform.failToolCalls('the tool is broken');
+
+    await expect(callOverMcpSurface(client, 'platform', 'echo')).rejects.toThrow(/the tool is broken/);
+    expect(reregistrations).toEqual(['platform']);
+    expect(platform.initializations()).toBe(2);
+    // Only the retry ever reached the tool.
+    expect(platform.executions('echo')).toBe(1);
+  }, 20_000);
+
+  it('surfaces the original failure when the manual is not one this surface holds', async () => {
+    const platform = await startServer('platform');
+    const client = await CodeModeUtcpClient.create(process.cwd(), null);
+    cleanups.push(() => client.close());
+    expect(await registerManual(client, manualTemplate('platform', platform.url))).toEqual({ ok: true });
+    const log: string[] = [];
+    installSessionRecovery(client, { manualTemplate: () => undefined, log: (m) => log.push(m) });
+
+    await platform.restart();
+
+    await expect(callOverMcpSurface(client, 'platform', 'echo')).rejects.toThrow();
+    expect(platform.initializations()).toBe(1);
+    expect(log).toEqual([]);
+  }, 20_000);
+});
+
+describe('session recovery — invariants that only a stubbed client can force', () => {
+  /** A client that fails the first N calls with `err`, then succeeds. */
+  function stubClient(overrides: Partial<Record<string, unknown>>): CodeModeUtcpClient {
+    return {
+      registerManual: async () => ({ success: true }),
+      deregisterManual: async () => true,
+      ...overrides,
+    } as unknown as CodeModeUtcpClient;
+  }
+
+  const sessionLost = (): StreamableHTTPError =>
+    new StreamableHTTPError(404, 'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}');
+
+  it('does not replay a stream that already produced output', async () => {
+    let starts = 0;
+    const client = stubClient({
+      async *callToolStreaming() {
+        starts += 1;
+        yield 'first chunk';
+        throw sessionLost();
+      },
+      async callTool() {
+        throw new Error('unused');
+      },
+    });
+    installSessionRecovery(client, {
+      manualTemplate: () => manualTemplate('platform', 'http://127.0.0.1:1/mcp'),
+      log: () => {},
+    });
+
+    const seen: unknown[] = [];
+    await expect(
+      (async () => {
+        for await (const chunk of client.callToolStreaming('platform.srv.echo', {})) seen.push(chunk);
+      })(),
+    ).rejects.toThrow(/Session not found/);
+    // A session miss is decided before the first byte, so a stream that has
+    // already emitted cannot be one — replaying it would duplicate chunks.
+    expect(seen).toEqual(['first chunk']);
+    expect(starts).toBe(1);
+  });
+
+  it('installs once however many times it is asked, so a retry never stacks', async () => {
+    let calls = 0;
+    let registrations = 0;
+    const client = stubClient({
+      registerManual: async () => {
+        registrations += 1;
+        return { success: true };
+      },
+      async callTool() {
+        calls += 1;
+        throw sessionLost();
+      },
+      // Present only so the wrapper has something to bind; this test drives
+      // the `callTool` path the code-mode chain uses.
+      callToolStreaming: () => {
+        throw new Error('not exercised by this test');
+      },
+    });
+    const options = {
+      manualTemplate: () => manualTemplate('platform', 'http://127.0.0.1:1/mcp'),
+      log: () => {},
+    };
+    installSessionRecovery(client, options);
+    installSessionRecovery(client, options);
+
+    await expect(client.callTool('platform.srv.echo', {})).rejects.toThrow(/Session not found/);
+    // One attempt plus exactly one retry — a second wrapper would have made
+    // it four, and re-registered twice.
+    expect(calls).toBe(2);
+    expect(registrations).toBe(1);
+  });
+});

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -60,6 +60,7 @@ export { registerManual, dispatchToolCall } from './dispatch.js';
 export {
   isSessionLoss,
   installSessionRecovery,
+  noteManualReregistered,
   type SessionRecoveryOptions,
 } from './session-recovery.js';
 

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -16,12 +16,14 @@
  * Everything between "a UTCP client with manuals registered" and "an MCP result"
  * is identical, and lives here: name flattening, the tool-name/schema guards
  * that stop one bad tool blanking a client's whole toolset, streaming dispatch,
- * and the code-mode meta-tools.
+ * the code-mode meta-tools, and recovery from a remote server that restarted
+ * and forgot our session (see `session-recovery.ts`).
  *
  * What is NOT here, on purpose: manual DISCOVERY (who may see which manual is
  * an access-control question the hosted REST surface answers), credential
- * resolution (a vault loader server-side, `process.env` locally), and retry
- * policy (see `registerManual`).
+ * resolution (a vault loader server-side, `process.env` locally), and
+ * REGISTRATION retry policy (see `registerManual`) — which is not the same
+ * thing as session recovery, and stays each surface's own.
  */
 
 export {
@@ -54,6 +56,12 @@ export {
 } from './meta-tools.js';
 
 export { registerManual, dispatchToolCall } from './dispatch.js';
+
+export {
+  isSessionLoss,
+  installSessionRecovery,
+  type SessionRecoveryOptions,
+} from './session-recovery.js';
 
 export {
   type SkillSummary,

--- a/packages/mcp-core/src/session-recovery.ts
+++ b/packages/mcp-core/src/session-recovery.ts
@@ -143,6 +143,12 @@ interface ReregisterOutcome {
   /** True only when the manual now holds a fresh session. */
   ok: boolean;
   /**
+   * True when the fresh session was somebody else's work — this call waited
+   * for a re-registration already under way and inherited its result rather
+   * than dialing a third session.
+   */
+  reused?: boolean;
+  /**
    * Abnormalities met on the way. Folded into the ONE line the recovered call
    * logs rather than printed as they happen: a recovery is a single event, and
    * two lines for one read as two recoveries — which is how a retry loop that
@@ -152,6 +158,28 @@ interface ReregisterOutcome {
 }
 
 const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Per-client re-registration counters, keyed by manual — the same maps the
+ * installed recovery reads, reachable from {@link noteManualReregistered} so a
+ * surface can report a re-registration of its own.
+ */
+const GENERATIONS = new WeakMap<object, Map<string, number>>();
+
+/**
+ * Tell recovery that `manualName`'s session was replaced by something OTHER
+ * than recovery. `hexis-mcp` re-registers the remote manual whenever a renewed
+ * connection key arrives; a call that lost its session around such a swap must
+ * then retry against THAT session instead of deregistering it and dialing a
+ * third one. Without this the two paths each replace a session the other just
+ * made — correct, but a round trip and a discovery pass wasted on every
+ * overlap. No-op when recovery is not installed on `client`.
+ */
+export function noteManualReregistered(client: CodeModeUtcpClient, manualName: string): void {
+  const generations = GENERATIONS.get(client as unknown as object);
+  if (!generations) return;
+  generations.set(manualName, (generations.get(manualName) ?? 0) + 1);
+}
 
 /**
  * Wrap `client`'s tool-call entry points with session recovery, in place.
@@ -185,13 +213,22 @@ export function installSessionRecovery(
    * hold for concurrent calls whether they fail together or in sequence.
    */
   const generations = new Map<string, number>();
+  GENERATIONS.set(client as unknown as object, generations);
   const inflight = new Map<string, Promise<ReregisterOutcome>>();
 
   const generationOf = (manualName: string): number => generations.get(manualName) ?? 0;
 
-  /** Deregister + register once. Reports what happened; the caller does the logging. */
-  async function reregisterNow(manualName: string): Promise<ReregisterOutcome> {
+  /**
+   * Deregister + register once. Reports what happened; the caller does the
+   * logging. `generation` is what the failing call saw before its attempt: if
+   * the counter has moved by the time this runs — a surface gate can hold a
+   * recovery while the surface's own credential swap re-registers the very
+   * same manual — the session has ALREADY been replaced, and replacing it
+   * again would throw away a live session to dial an identical one.
+   */
+  async function reregisterNow(manualName: string, generation: number): Promise<ReregisterOutcome> {
     const notes: string[] = [];
+    if (generationOf(manualName) !== generation) return { ok: true, reused: true, notes };
     const template = await options.manualTemplate(manualName);
     // Not ours to re-register — or not an MCP manual at all, in which case it
     // holds no session and the 404 came from somewhere we must not second-guess.
@@ -230,21 +267,28 @@ export function installSessionRecovery(
    * session-loss error with a recovery-internal one. The answer here is only
    * ever "may we retry?".
    */
-  async function reregister(manualName: string): Promise<ReregisterOutcome> {
+  async function reregister(manualName: string, generation: number): Promise<ReregisterOutcome> {
     try {
       return options.withReregister
-        ? await options.withReregister(manualName, () => reregisterNow(manualName))
-        : await reregisterNow(manualName);
+        ? await options.withReregister(manualName, () => reregisterNow(manualName, generation))
+        : await reregisterNow(manualName, generation);
     } catch (err) {
       return { ok: false, notes: [`re-registration threw: ${messageOf(err)}`] };
     }
   }
 
-  /** Single-flight {@link reregister}: concurrent losers share one attempt. */
-  function reregisterOnce(manualName: string): Promise<ReregisterOutcome> {
+  /**
+   * Single-flight {@link reregister}: concurrent losers share one attempt.
+   *
+   * The generation belongs to whoever started the attempt, and that is right
+   * for the joiners too — {@link recover} sends nobody here whose generation
+   * differs from the current one, so every sharer of this promise failed
+   * against the same session.
+   */
+  function reregisterOnce(manualName: string, generation: number): Promise<ReregisterOutcome> {
     const existing = inflight.get(manualName);
     if (existing) return existing;
-    const tracked = reregister(manualName).finally(() => {
+    const tracked = reregister(manualName, generation).finally(() => {
       if (inflight.get(manualName) === tracked) inflight.delete(manualName);
     });
     inflight.set(manualName, tracked);
@@ -259,13 +303,18 @@ export function installSessionRecovery(
     if (!isSessionLoss(err)) return false;
     const manualName = toolName.split('.')[0];
     if (!manualName) return false;
-    // Someone else re-registered while this call was in flight: the session it
-    // failed against is already gone, so retry against the new one directly.
-    if (generationOf(manualName) !== generation) {
+    /** The session was replaced by someone else — a concurrent call, or the surface. */
+    const alreadyReplaced = (): boolean => {
       log(`[mcp] session lost on '${manualName}' — re-registered by a concurrent call; retrying.`);
       return true;
-    }
-    const outcome = await reregisterOnce(manualName);
+    };
+    // Someone else re-registered while this call was in flight: the session it
+    // failed against is already gone, so retry against the new one directly.
+    if (generationOf(manualName) !== generation) return alreadyReplaced();
+    const outcome = await reregisterOnce(manualName, generation);
+    // The same finding, made too late to skip the queue: the re-registration
+    // landed while this call waited for the surface's gate.
+    if (outcome.reused) return alreadyReplaced();
     // One recovered call, one line — whatever went sideways on the way rides
     // along in it rather than arriving as a line of its own.
     const notes = outcome.notes.length > 0 ? ` (${outcome.notes.join('; ')})` : '';

--- a/packages/mcp-core/src/session-recovery.ts
+++ b/packages/mcp-core/src/session-recovery.ts
@@ -122,9 +122,36 @@ export interface SessionRecoveryOptions {
    * code-mode meta-tools) has to prune it again here.
    */
   afterReregister?: (manualName: string) => Promise<void> | void;
+  /**
+   * Runs one whole re-registration — resolve the template, deregister,
+   * register, clean up — for a surface that has a re-registration path of its
+   * own. `hexis-mcp` renews its connection key by re-registering the remote
+   * manual and holds arriving calls while it does; handing that same gate in
+   * here makes the two ONE serialized operation instead of two that can
+   * interleave (the window between a deregister and its register finds no
+   * manual in the repository) or, worse, wait on each other. Whatever `run`
+   * settles to is what recovery uses; a hook that throws counts as a failed
+   * recovery, never as a failed call. Defaults to running `run` directly.
+   */
+  withReregister?: <T>(manualName: string, run: () => Promise<T>) => Promise<T>;
   /** Where the one-line-per-recovery log goes. Defaults to stderr. */
   log?: (message: string) => void;
 }
+
+/** What one re-registration produced: may we retry, and anything odd worth saying. */
+interface ReregisterOutcome {
+  /** True only when the manual now holds a fresh session. */
+  ok: boolean;
+  /**
+   * Abnormalities met on the way. Folded into the ONE line the recovered call
+   * logs rather than printed as they happen: a recovery is a single event, and
+   * two lines for one read as two recoveries — which is how a retry loop that
+   * never existed gets diagnosed.
+   */
+  notes: string[];
+}
+
+const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
 /**
  * Wrap `client`'s tool-call entry points with session recovery, in place.
@@ -158,50 +185,63 @@ export function installSessionRecovery(
    * hold for concurrent calls whether they fail together or in sequence.
    */
   const generations = new Map<string, number>();
-  const inflight = new Map<string, Promise<boolean>>();
+  const inflight = new Map<string, Promise<ReregisterOutcome>>();
 
   const generationOf = (manualName: string): number => generations.get(manualName) ?? 0;
 
-  /** Deregister + register once. Never throws: the answer is "may we retry?". */
-  async function reregister(manualName: string): Promise<boolean> {
+  /** Deregister + register once. Reports what happened; the caller does the logging. */
+  async function reregisterNow(manualName: string): Promise<ReregisterOutcome> {
+    const notes: string[] = [];
     const template = await options.manualTemplate(manualName);
     // Not ours to re-register — or not an MCP manual at all, in which case it
     // holds no session and the 404 came from somewhere we must not second-guess.
-    if (!template || template.call_template_type !== 'mcp') return false;
+    // Silent on purpose: nothing happened, so there is nothing to report.
+    if (!template || template.call_template_type !== 'mcp') return { ok: false, notes };
     try {
       // Deregistering is what closes the manual's (now dead) session, so the
       // registration below dials a fresh one instead of reusing the cached
       // transport. Best effort: a manual already gone is not a failure here.
       await client.deregisterManual(manualName);
     } catch (err) {
-      log(
-        `[mcp] session lost on '${manualName}': deregistering before re-registration failed ` +
-          `(${err instanceof Error ? err.message : String(err)}); re-registering anyway.`,
-      );
+      notes.push(`deregistering first failed: ${messageOf(err)}`);
     }
     const result = await registerManual(client, template);
     if (!result.ok) {
       // The server is very likely still coming back up. The call fails as it
       // would have anyway; the NEXT one recovers once the server answers.
-      log(`[mcp] session lost on '${manualName}' — re-registration failed: ${result.error}`);
-      return false;
+      notes.push(`re-registration failed: ${result.error}`);
+      return { ok: false, notes };
     }
     generations.set(manualName, generationOf(manualName) + 1);
     if (options.afterReregister) {
       try {
         await options.afterReregister(manualName);
       } catch (err) {
-        log(
-          `[mcp] post-re-registration cleanup for '${manualName}' failed: ` +
-            `${err instanceof Error ? err.message : String(err)}`,
-        );
+        notes.push(`post-re-registration cleanup failed: ${messageOf(err)}`);
       }
     }
-    return true;
+    return { ok: true, notes };
+  }
+
+  /**
+   * {@link reregisterNow} under the surface's own gate, if it has one, and with
+   * every escape route closed. NEVER throws — and that is load-bearing: a
+   * throwing template resolver (or gate) must not replace the caller's real
+   * session-loss error with a recovery-internal one. The answer here is only
+   * ever "may we retry?".
+   */
+  async function reregister(manualName: string): Promise<ReregisterOutcome> {
+    try {
+      return options.withReregister
+        ? await options.withReregister(manualName, () => reregisterNow(manualName))
+        : await reregisterNow(manualName);
+    } catch (err) {
+      return { ok: false, notes: [`re-registration threw: ${messageOf(err)}`] };
+    }
   }
 
   /** Single-flight {@link reregister}: concurrent losers share one attempt. */
-  function reregisterOnce(manualName: string): Promise<boolean> {
+  function reregisterOnce(manualName: string): Promise<ReregisterOutcome> {
     const existing = inflight.get(manualName);
     if (existing) return existing;
     const tracked = reregister(manualName).finally(() => {
@@ -225,8 +265,19 @@ export function installSessionRecovery(
       log(`[mcp] session lost on '${manualName}' — re-registered by a concurrent call; retrying.`);
       return true;
     }
-    if (!(await reregisterOnce(manualName))) return false;
-    log(`[mcp] session lost on '${manualName}' — re-registered and retried.`);
+    const outcome = await reregisterOnce(manualName);
+    // One recovered call, one line — whatever went sideways on the way rides
+    // along in it rather than arriving as a line of its own.
+    const notes = outcome.notes.length > 0 ? ` (${outcome.notes.join('; ')})` : '';
+    if (!outcome.ok) {
+      if (notes) {
+        log(
+          `[mcp] session lost on '${manualName}' — not recovered${notes}; the original failure stands.`,
+        );
+      }
+      return false;
+    }
+    log(`[mcp] session lost on '${manualName}' — re-registered and retried.${notes}`);
     return true;
   }
 

--- a/packages/mcp-core/src/session-recovery.ts
+++ b/packages/mcp-core/src/session-recovery.ts
@@ -221,19 +221,27 @@ export function installSessionRecovery(
   /**
    * Deregister + register once. Reports what happened; the caller does the
    * logging. `generation` is what the failing call saw before its attempt: if
-   * the counter has moved by the time this runs — a surface gate can hold a
-   * recovery while the surface's own credential swap re-registers the very
-   * same manual — the session has ALREADY been replaced, and replacing it
-   * again would throw away a live session to dial an identical one.
+   * the counter has moved, the session has ALREADY been replaced — by the
+   * surface's own credential swap, or by another call — and replacing it again
+   * would throw away a live session to dial an identical one.
+   *
+   * Tested TWICE, because this function has two places it can wait and either
+   * is long enough for a swap to land: the surface's gate (before the call
+   * arrives here) and `manualTemplate`, which a surface may deliberately park
+   * in. The check that matters is the one immediately before the deregister —
+   * the first is only there to skip work nobody needs.
    */
   async function reregisterNow(manualName: string, generation: number): Promise<ReregisterOutcome> {
     const notes: string[] = [];
-    if (generationOf(manualName) !== generation) return { ok: true, reused: true, notes };
+    const reused = { ok: true, reused: true, notes } as const;
+    if (generationOf(manualName) !== generation) return reused;
     const template = await options.manualTemplate(manualName);
     // Not ours to re-register — or not an MCP manual at all, in which case it
     // holds no session and the 404 came from somewhere we must not second-guess.
     // Silent on purpose: nothing happened, so there is nothing to report.
     if (!template || template.call_template_type !== 'mcp') return { ok: false, notes };
+    // Resolving the template is itself a place a surface waits.
+    if (generationOf(manualName) !== generation) return reused;
     try {
       // Deregistering is what closes the manual's (now dead) session, so the
       // registration below dials a fresh one instead of reusing the cached

--- a/packages/mcp-core/src/session-recovery.ts
+++ b/packages/mcp-core/src/session-recovery.ts
@@ -1,0 +1,270 @@
+import type { CodeModeUtcpClient } from '@utcp/code-mode';
+import type { CallTemplate } from '@utcp/sdk';
+import { registerManual } from './dispatch.js';
+
+/**
+ * Client-side recovery from MCP session loss: when a remote MCP server has
+ * forgotten the session our manual holds — almost always because it restarted —
+ * re-register that manual once and retry the call once.
+ *
+ * WHY IT LIVES ON THE CLIENT OBJECT. Two paths reach a tool call in our stack:
+ * `dispatchToolCall` (the MCP surface of the hosted proxy and of the local
+ * server) goes through `callToolStreaming`, and a code-mode chain
+ * (`call_tool_chain`, gate probes) goes through `callTool` — `callToolChain`
+ * bridges every in-isolate tool function to `this.callTool`. Wrapping those two
+ * methods ON THE CLIENT INSTANCE is the one seam both paths cross, so the
+ * policy exists exactly once instead of being copied into each caller.
+ *
+ * WHY ONLY SESSION LOSS. A retry is only safe when the first attempt provably
+ * did nothing. Session loss is decided in the server's ROUTING layer, before
+ * the request is dispatched to a tool, so a mutating tool cannot have run.
+ * Every other failure — a tool error, an auth refusal, a timeout, a reset
+ * connection — could have executed the tool, and is surfaced unchanged. That is
+ * the whole safety argument: it rests on the trigger class, so
+ * {@link isSessionLoss} is deliberately narrow and separately testable.
+ */
+
+/** The JSON-RPC code the Streamable HTTP transport reserves for a missing session. */
+const SESSION_NOT_FOUND_CODE = -32001;
+
+/** How far up a `cause` chain to look before giving up. */
+const MAX_CAUSE_DEPTH = 8;
+
+/** Each error in `err`'s `cause` chain, nearest first, bounded and cycle-safe. */
+function* errorChain(err: unknown): Generator<Record<string, unknown>> {
+  const seen = new Set<unknown>();
+  let current = err;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (current === null || typeof current !== 'object' || seen.has(current)) return;
+    seen.add(current);
+    yield current as Record<string, unknown>;
+    current = (current as { cause?: unknown }).cause;
+  }
+}
+
+/**
+ * The HTTP status an error carries, or undefined when it carries none.
+ *
+ * The MCP SDK's `StreamableHTTPError` puts the HTTP status in `code`, which is
+ * also where `McpError` puts its JSON-RPC code — and those two namespaces
+ * OVERLAP on the very number this module cares about: `-32001` is "Session not
+ * found" on the wire but `ErrorCode.RequestTimeout` in the SDK's own enum. The
+ * range test is what keeps them apart: a JSON-RPC code is negative and can
+ * never be read as a status, so a local request timeout never looks like a
+ * session miss (and is never retried).
+ */
+function httpStatusOf(err: Record<string, unknown>): number | undefined {
+  for (const key of ['code', 'status', 'statusCode'] as const) {
+    const value = err[key];
+    if (typeof value === 'number' && value >= 100 && value <= 599) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Does this error's text carry the session-not-found signal?
+ *
+ * The transport surfaces a failed POST as `Error POSTing to endpoint: <body>`,
+ * so the server's JSON-RPC body rides along in the message and is the only
+ * place the `-32001` is visible. Both halves of the spec's signal are accepted
+ * — the code (structural) and the reserved message — because a server may send
+ * either; requiring the 404 alongside is what keeps this from over-matching.
+ */
+function saysSessionNotFound(message: string): boolean {
+  return (
+    new RegExp(`"code"\\s*:\\s*${SESSION_NOT_FOUND_CODE}\\b`).test(message) ||
+    /\bsession not found\b/i.test(message)
+  );
+}
+
+/**
+ * Is `err` unambiguously "the server has forgotten this session"?
+ *
+ * The signal is HTTP 404 carrying JSON-RPC `-32001` / "Session not found", which
+ * the MCP spec reserves for exactly one meaning: the request presented an
+ * `Mcp-Session-Id` the server no longer holds, and the client should
+ * re-initialize. The presented-a-session-id half is not observable from here,
+ * and does not need to be: a request with NO session id is answered 400 /
+ * `-32000` (a client mistake with nothing to recover), so a 404 in this shape
+ * implies a session id was sent.
+ *
+ * Everything else is false — including a 404 whose body is an ordinary
+ * not-found, an auth refusal, a timeout (see {@link httpStatusOf}), and a
+ * refused connection. Pure and exported so this boundary can be pinned by test
+ * rather than inferred from the recovery path around it.
+ */
+export function isSessionLoss(err: unknown): boolean {
+  for (const candidate of errorChain(err)) {
+    if (httpStatusOf(candidate) !== 404) continue;
+    const message = candidate.message;
+    if (typeof message === 'string' && saysSessionNotFound(message)) return true;
+  }
+  return false;
+}
+
+export interface SessionRecoveryOptions {
+  /**
+   * The template to re-register `manualName` with, or undefined when this
+   * surface holds none — an unknown manual is not recovered, and its failure
+   * surfaces unchanged.
+   *
+   * Resolved at RECOVERY time, not at install time, so a manual whose template
+   * carries a credential that can be rotated (the local server renews its
+   * connection key) re-registers with the current one. May be async, which is
+   * also the hook a surface uses to wait out a re-registration of its own that
+   * is already in flight.
+   */
+  manualTemplate: (manualName: string) => CallTemplate | undefined | Promise<CallTemplate | undefined>;
+  /**
+   * Ran after a successful re-registration. Re-registration REDISCOVERS the
+   * manual, so a surface that prunes something from the registry at first
+   * registration (the local server drops the deployment's copies of the
+   * code-mode meta-tools) has to prune it again here.
+   */
+  afterReregister?: (manualName: string) => Promise<void> | void;
+  /** Where the one-line-per-recovery log goes. Defaults to stderr. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Wrap `client`'s tool-call entry points with session recovery, in place.
+ *
+ * Returns the same client so it can be used as an expression at the
+ * construction site. Installing twice is a no-op: the second call would stack a
+ * second retry on the first, which is precisely the "exactly once" guarantee
+ * this module exists to make.
+ */
+const INSTALLED = Symbol.for('@bevel-software/platform-mcp-core.sessionRecovery');
+
+export function installSessionRecovery(
+  client: CodeModeUtcpClient,
+  options: SessionRecoveryOptions,
+): CodeModeUtcpClient {
+  const marked = client as unknown as Record<symbol, unknown>;
+  if (marked[INSTALLED]) return client;
+  marked[INSTALLED] = true;
+
+  const log = options.log ?? ((message: string) => console.error(message));
+  const callTool = client.callTool.bind(client);
+  const callToolStreaming = client.callToolStreaming.bind(client);
+
+  /**
+   * How many times each manual has been re-registered. A call reads this
+   * BEFORE its attempt; if the number moved while the attempt was in flight,
+   * some other call already replaced the session this one was using and the
+   * retry can go straight through — no second re-registration, and no window
+   * in which a burst of failures that arrive slightly apart each starts its
+   * own. Together with `inflight` below, this is what makes the coalescing
+   * hold for concurrent calls whether they fail together or in sequence.
+   */
+  const generations = new Map<string, number>();
+  const inflight = new Map<string, Promise<boolean>>();
+
+  const generationOf = (manualName: string): number => generations.get(manualName) ?? 0;
+
+  /** Deregister + register once. Never throws: the answer is "may we retry?". */
+  async function reregister(manualName: string): Promise<boolean> {
+    const template = await options.manualTemplate(manualName);
+    // Not ours to re-register — or not an MCP manual at all, in which case it
+    // holds no session and the 404 came from somewhere we must not second-guess.
+    if (!template || template.call_template_type !== 'mcp') return false;
+    try {
+      // Deregistering is what closes the manual's (now dead) session, so the
+      // registration below dials a fresh one instead of reusing the cached
+      // transport. Best effort: a manual already gone is not a failure here.
+      await client.deregisterManual(manualName);
+    } catch (err) {
+      log(
+        `[mcp] session lost on '${manualName}': deregistering before re-registration failed ` +
+          `(${err instanceof Error ? err.message : String(err)}); re-registering anyway.`,
+      );
+    }
+    const result = await registerManual(client, template);
+    if (!result.ok) {
+      // The server is very likely still coming back up. The call fails as it
+      // would have anyway; the NEXT one recovers once the server answers.
+      log(`[mcp] session lost on '${manualName}' — re-registration failed: ${result.error}`);
+      return false;
+    }
+    generations.set(manualName, generationOf(manualName) + 1);
+    if (options.afterReregister) {
+      try {
+        await options.afterReregister(manualName);
+      } catch (err) {
+        log(
+          `[mcp] post-re-registration cleanup for '${manualName}' failed: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return true;
+  }
+
+  /** Single-flight {@link reregister}: concurrent losers share one attempt. */
+  function reregisterOnce(manualName: string): Promise<boolean> {
+    const existing = inflight.get(manualName);
+    if (existing) return existing;
+    const tracked = reregister(manualName).finally(() => {
+      if (inflight.get(manualName) === tracked) inflight.delete(manualName);
+    });
+    inflight.set(manualName, tracked);
+    return tracked;
+  }
+
+  /**
+   * May this failed call be retried? True only for session loss on a manual we
+   * hold a template for, and only after the session has actually been replaced.
+   */
+  async function recover(toolName: string, generation: number, err: unknown): Promise<boolean> {
+    if (!isSessionLoss(err)) return false;
+    const manualName = toolName.split('.')[0];
+    if (!manualName) return false;
+    // Someone else re-registered while this call was in flight: the session it
+    // failed against is already gone, so retry against the new one directly.
+    if (generationOf(manualName) !== generation) {
+      log(`[mcp] session lost on '${manualName}' — re-registered by a concurrent call; retrying.`);
+      return true;
+    }
+    if (!(await reregisterOnce(manualName))) return false;
+    log(`[mcp] session lost on '${manualName}' — re-registered and retried.`);
+    return true;
+  }
+
+  client.callTool = async function recoveringCallTool(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): Promise<unknown> {
+    const generation = generationOf(toolName.split('.')[0] ?? '');
+    try {
+      return await callTool(toolName, toolArgs);
+    } catch (err) {
+      if (!(await recover(toolName, generation, err))) throw err;
+      // Exactly one retry: whatever this produces is what the caller sees,
+      // including a second session loss.
+      return await callTool(toolName, toolArgs);
+    }
+  };
+
+  client.callToolStreaming = async function* recoveringCallToolStreaming(
+    toolName: string,
+    toolArgs: Record<string, unknown>,
+  ): AsyncGenerator<unknown, void, unknown> {
+    const generation = generationOf(toolName.split('.')[0] ?? '');
+    let yielded = false;
+    try {
+      for await (const chunk of callToolStreaming(toolName, toolArgs)) {
+        yielded = true;
+        yield chunk;
+      }
+      return;
+    } catch (err) {
+      // A stream that already produced output is past the point where session
+      // loss can happen (the session is validated before the first byte), and
+      // replaying it would duplicate the chunks the caller already saw.
+      if (yielded || !(await recover(toolName, generation, err))) throw err;
+    }
+    yield* callToolStreaming(toolName, toolArgs);
+  };
+
+  return client;
+}


### PR DESCRIPTION
Ticket: `Data/Engineering/Knowledge/Hexis/Tickets/MCP-Session-Recovery.md`

## Summary

When an MCP server (the platform's own `hexis-mcp` manual, or a proxied third-party server declared in `mcp.json`) restarts and drops its session, the next tool call now recovers transparently instead of failing: the caller sees success (or the tool's own genuine error) and nothing else, with a single log line noting the recovery.

- Added `packages/mcp-core/src/session-recovery.ts`: a shared recovery mechanism used by both entry points — tool calls dispatched over the MCP surface and tool calls made from inside a code-mode chain (`call_tool_chain`). One mechanism, not two.
- Recovery triggers **only** on session-not-found-shaped failures (HTTP 404 + JSON-RPC `-32001` / "Session not found" on a request that carried a session id). Any other failure (genuine tool error, auth failure, timeout, other transport error) is surfaced unchanged and is never retried — pinned by a test.
- Exactly one re-registration and one retry per failed call; if the retry also fails, that failure reaches the caller.
- Concurrent calls that hit session loss on the same manual coalesce into a single re-registration (no re-register stampede).

## Changed packages

`@bevel-software/platform-mcp-core`, `@bevel-software/hexis-mcp`, `@bevel-software/platform-core-backend`

## Tests

- `packages/mcp-core/src/__tests__/session-recovery.test.ts` (new) + `fake-mcp-server.ts` test double
- mcp-core 101/101, hexis-mcp 136/136, core-backend 2357/2357 passing
- typecheck + build clean for all three changed packages
- Covers: platform-restart recovery, third-party-server recovery, non-session errors not retried, single-flight coalescing, chain-path (`call_tool_chain`) recovery, retry-failure surfacing

A changeset is included (`.changeset/mcp-session-recovery.md`).

Unrelated pre-existing failure noted for the record: `packages/core-frontend` vitest fails entirely with `React.act is not a function` (1266 tests) — reproduced with this branch's changes stashed, so it pre-exists and no frontend file was touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes MCP tool calls survive a server restart: when a server drops its session, the next call re-registers the affected manual and retries once instead of failing with the spec's 404 / "Session not found". Previously a redeploy left connected agents' tools erroring until someone reconnected by hand.

**Recovery behavior**
- Only session loss is retried — HTTP 404 with JSON-RPC `-32001` / "Session not found", which a server decides before dispatching to a tool.
- Tool errors, auth failures, and timeouts pass through unchanged and are never retried, so a mutating tool never executes twice.
- Concurrent session losses on one manual share a single re-registration; a failed retry or re-registration surfaces the caller's original error.
- Recovery re-checks the session generation right before deregistering, so a session replaced while it waited is reused, not torn down.
- In `hexis-mcp`, recovery and credential renewal share one re-registration gate; shutdown awaits it before teardown, and calls parked behind it get ConnectionClosed.
- Applies to the hosted proxy, local `hexis-mcp`, and proxied third-party servers, on both the MCP dispatch surface and `call_tool_chain`.

<sup>Written for commit 61d1a5d9fd1124d5771e0510abb1fc22e35778a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

