### PR TITLE
feat(library): a plugin's manifest opens the plugin; the plugin page shows the manifest

### DIFF
--- a/.changeset/manifest-on-plugin-page.md
+++ b/.changeset/manifest-on-plugin-page.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+A plugin's manifest opens the plugin. Clicking `plugin.json` (or the bundle dialect's `plugin.bundle.json`) in the Skills & Tools tree opens the plugin's page rather than the file, and the page carries a collapsible **Manifest** section at the bottom that shows the file's contents; writers get an "Edit the manifest" link there to the raw file.

--- a/packages/core-frontend/src/modules/library/__tests__/PluginExtras.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginExtras.test.tsx
@@ -14,10 +14,11 @@ import {
  * branch (no request at all), the fetch only when it sits elsewhere.
  */
 
-const apiMock = vi.hoisted(() => ({ listFiles: vi.fn() }));
+const apiMock = vi.hoisted(() => ({ listFiles: vi.fn(), readFile: vi.fn() }));
 vi.mock('../../workspace/services/workspace.api', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   listFiles: apiMock.listFiles,
+  readFile: apiMock.readFile,
 }));
 
 const navigateMock = vi.hoisted(() => vi.fn());
@@ -26,7 +27,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
   useNavigate: () => navigateMock,
 }));
 
-import { ClientExtensionsSection } from '../components/PluginExtras';
+import { ClientExtensionsSection, ManifestSection } from '../components/PluginExtras';
 
 const dir = (name: string, children: FileTreeEntry[]): FileTreeEntry =>
   ({ name, relativePath: name, type: 'directory', children }) as FileTreeEntry;
@@ -58,7 +59,86 @@ function renderSection(workspace: Partial<WorkspaceContextValue>, folder = 'GTM'
 
 beforeEach(() => {
   apiMock.listFiles.mockReset();
+  apiMock.readFile.mockReset();
   navigateMock.mockReset();
+});
+
+describe('ManifestSection', () => {
+  const MANIFEST = '{"name":"gtm","version":"1.2.0","extensions":{"software.bevel.hexis":{"skills":["Skills/Sales"]}}}';
+
+  it('is closed by default and reads nothing until opened; open, it shows the manifest laid out as JSON', async () => {
+    apiMock.readFile.mockResolvedValue(MANIFEST);
+    render(
+      <MemoryRouter>
+        <ManifestSection kbDirName="knowledge-base" folder="GTM" managed canWrite={false} />
+      </MemoryRouter>,
+    );
+    const header = screen.getByRole('button', { name: /^Manifest plugin\.json$/ });
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    expect(apiMock.readFile).not.toHaveBeenCalled();
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(apiMock.readFile).toHaveBeenCalledWith(
+      encodeURIComponent(DEFAULT_BRANCH),
+      'knowledge-base/Plugins/GTM/plugin.json',
+    );
+    await waitFor(() => expect(screen.getByText(/"version": "1\.2\.0"/)).toBeInTheDocument());
+    // A reader gets no editor link.
+    expect(screen.queryByRole('button', { name: 'Edit the manifest' })).not.toBeInTheDocument();
+  });
+
+  it("reads the bundle dialect's file for an unmanaged plugin, and offers no editor even to a writer", async () => {
+    apiMock.readFile.mockResolvedValue('{"name":"example"}');
+    render(
+      <MemoryRouter>
+        <ManifestSection kbDirName="knowledge-base" folder="functional/cluster/example" managed={false} canWrite />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^Manifest plugin\.bundle\.json$/ }));
+    expect(apiMock.readFile).toHaveBeenCalledWith(
+      encodeURIComponent(DEFAULT_BRANCH),
+      'knowledge-base/Plugins/functional/cluster/example/plugin.bundle.json',
+    );
+    await waitFor(() => expect(screen.getByText(/"name": "example"/)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Edit the manifest' })).not.toBeInTheDocument();
+  });
+
+  it('a writer gets "Edit the manifest", which asks for the raw file by state', async () => {
+    apiMock.readFile.mockResolvedValue(MANIFEST);
+    render(
+      <MemoryRouter>
+        <ManifestSection kbDirName="knowledge-base" folder="GTM" managed canWrite />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^Manifest plugin\.json$/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit the manifest' }));
+    expect(navigateMock).toHaveBeenLastCalledWith(
+      expect.stringContaining('Plugins/GTM/plugin.json'),
+      { state: { rawFile: true } },
+    );
+  });
+
+  it('shows the file as written when it is not JSON, and says so when it cannot be read', async () => {
+    apiMock.readFile.mockResolvedValue('not json {');
+    const { unmount } = render(
+      <MemoryRouter>
+        <ManifestSection kbDirName="knowledge-base" folder="GTM" managed canWrite={false} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^Manifest plugin\.json$/ }));
+    await waitFor(() => expect(screen.getByText('not json {')).toBeInTheDocument());
+    unmount();
+
+    apiMock.readFile.mockRejectedValue(new Error('403'));
+    render(
+      <MemoryRouter>
+        <ManifestSection kbDirName="knowledge-base" folder="GTM" managed canWrite={false} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^Manifest plugin\.json$/ }));
+    await waitFor(() => expect(screen.getByText("Couldn't read plugin.json.")).toBeInTheDocument());
+  });
 });
 
 describe('ClientExtensionsSection', () => {

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -263,8 +263,15 @@ describe('WorkspaceItemRoute', () => {
 
     it('waits for the plugin list rather than showing the file, then shows the file when no listed plugin holds it', async () => {
       // No plugin lists this folder (locked to the caller, or a stray file):
-      // once the list has answered, the file is the honest fallback.
+      // once the list has answered, the file is the honest fallback — and
+      // not one frame before, or a manifest would flash as a file on every
+      // page load.
+      let answer: (plugins: PluginSummary[]) => void = () => {};
+      vi.mocked(listPlugins).mockReturnValue(new Promise<PluginSummary[]>((r) => (answer = r)));
       renderAt(itemUrl('Plugins/Nope/plugin.json'));
+      await waitFor(() => expect(screen.getByRole('button', { name: /^Everything/ })).toBeInTheDocument());
+      expect(screen.queryByLabelText('file-view')).not.toBeInTheDocument();
+      answer([]);
       await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
       expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Nope/plugin.json'));
     });

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -47,7 +47,27 @@ vi.mock('../../workspace/components/FileRoute', () => ({
 
 import { LibraryRoutes } from '../routes/LibraryRoutes';
 import { isLibraryLocation } from '../routes/library-paths';
+import { listPlugins, type PluginSummary } from '../services/plugins.api';
 import { withAuth } from './auth-harness';
+
+/** A listed plugin whose folder is `Plugins/Sales` and whose identity is `sales`. */
+const SALES: PluginSummary = {
+  name: 'sales',
+  displayName: 'Sales',
+  folders: ['Plugins/Sales'],
+  canRead: true,
+  canWrite: false,
+  isOwner: false,
+  linksAreManaged: true,
+  skillCount: 1,
+  toolCount: 0,
+  brokenLinks: 0,
+  owners: { roles: [], users: [] },
+  writers: { roles: [], users: [] },
+  readers: { restricted: true, roles: [], users: [] },
+  hasRequested: false,
+  requestNumber: null,
+};
 
 const CATALOG: LibraryData = {
   loading: false,
@@ -138,6 +158,7 @@ const itemUrl = (repoRel: string, branch = DEFAULT_BRANCH) =>
 
 beforeEach(() => {
   dataMock.useLibraryData.mockReturnValue(CATALOG);
+  vi.mocked(listPlugins).mockResolvedValue([]);
 });
 
 describe('WorkspaceItemRoute', () => {
@@ -220,6 +241,56 @@ describe('WorkspaceItemRoute', () => {
     expect(screen.getByLabelText('file-view')).toHaveTextContent('canonicalize:false');
     expect(screen.getByRole('button', { name: /^Everything/ })).toBeInTheDocument();
     expect(screen.queryByLabelText('skill-page')).not.toBeInTheDocument();
+  });
+
+  describe("a plugin's manifest", () => {
+    it('opens the PLUGIN page, by the identity the listed plugin carries — not the file', async () => {
+      vi.mocked(listPlugins).mockResolvedValue([SALES]);
+      renderAt(itemUrl('Plugins/Sales/plugin.json'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent('/skills-and-tools/plugins/sales'),
+      );
+      expect(screen.queryByLabelText('file-view')).not.toBeInTheDocument();
+    });
+
+    it("the bundle dialect's manifest opens the plugin page the same way", async () => {
+      vi.mocked(listPlugins).mockResolvedValue([{ ...SALES, linksAreManaged: false }]);
+      renderAt(itemUrl('Plugins/Sales/plugin.bundle.json'));
+      await waitFor(() =>
+        expect(screen.getByLabelText('pathname')).toHaveTextContent('/skills-and-tools/plugins/sales'),
+      );
+    });
+
+    it('waits for the plugin list rather than showing the file, then shows the file when no listed plugin holds it', async () => {
+      // No plugin lists this folder (locked to the caller, or a stray file):
+      // once the list has answered, the file is the honest fallback.
+      renderAt(itemUrl('Plugins/Nope/plugin.json'));
+      await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Nope/plugin.json'));
+    });
+
+    it("a manifest bundled inside a SKILL stays that skill's file", async () => {
+      vi.mocked(listPlugins).mockResolvedValue([SALES]);
+      renderAt(itemUrl('Plugins/Sales/create-sales-deck/plugin.json'));
+      expect(await screen.findByLabelText('skill-page')).toHaveTextContent('create-sales-deck::plugin.json');
+    });
+
+    it('router state `rawFile` still opens the manifest as a file — the page’s Manifest button', async () => {
+      vi.mocked(listPlugins).mockResolvedValue([SALES]);
+      render(
+        <MemoryRouter initialEntries={[{ pathname: itemUrl('Plugins/Sales/plugin.json'), state: { rawFile: true } }]}>
+          {wrap(
+            <Routes>
+              <Route path="/workspace/*" element={<LibraryRoutes />} />
+            </Routes>,
+            null,
+          )}
+          <LocationProbe />
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Sales/plugin.json'));
+    });
   });
 
   it("a personal space's access.md opens the same way — it has no listed plugin page at all", async () => {

--- a/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { DEFAULT_BRANCH, PLUGINS_DIR, type FileTreeEntry } from '@bevel-software/platform-shared';
+import { ChevronRight } from 'lucide-react';
+import { DEFAULT_BRANCH, PLUGINS_DIR, PLUGIN_MANIFEST_FILE, type FileTreeEntry } from '@bevel-software/platform-shared';
+import { cn } from '../../../lib/utils';
 import { Button } from '../../../shared/components';
-import { listFiles } from '../../workspace/services/workspace.api';
+import { listFiles, readFile } from '../../workspace/services/workspace.api';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 import { findKbRoot } from '../../workspace/utils/fileTree';
 import { kbFileUrl } from '../../workspace/routing/kb-routes';
@@ -57,6 +59,117 @@ export function ManifestButton({
       Manifest
     </Button>
   );
+}
+
+/** The bundle dialect's manifest — read-only here; the file is edited in its own repository. */
+const BUNDLE_MANIFEST_FILE = 'plugin.bundle.json';
+
+/**
+ * The manifest's CONTENTS, at the bottom of the plugin page, behind a
+ * disclosure: closed, it is one line naming the file; open, it is the file —
+ * what the plugin declares (its identifier, version, the skills it links,
+ * the servers it declares) shown as the JSON it is, pretty-printed when it
+ * parses and verbatim when it does not. Read only when opened, so a page
+ * view costs no request for a section most visits never expand. A writer
+ * gets the way to the raw editor from here too.
+ */
+export function ManifestSection({
+  kbDirName,
+  folder,
+  managed,
+  canWrite,
+}: {
+  kbDirName: string | null;
+  folder: string;
+  /** A native manifest (`plugin.json`); false for the bundle dialect's file. */
+  managed: boolean;
+  canWrite: boolean;
+}) {
+  const workspaceId = encodeURIComponent(DEFAULT_BRANCH);
+  const navigate = useNavigate();
+  const panelId = useId();
+  const file = managed ? PLUGIN_MANIFEST_FILE : BUNDLE_MANIFEST_FILE;
+  const path = kbDirName ? `${kbDirName}/${PLUGINS_DIR}/${folder}/${file}` : null;
+  const [open, setOpen] = useState(false);
+  // What was read, KEYED BY THE PATH it was read from: a folder change shows
+  // nothing of the previous plugin's file while the new read is in flight,
+  // with no reset to write — a result for another path is simply not this one.
+  const [loaded, setLoaded] = useState<{ path: string; text: string | null; failed: boolean } | null>(null);
+  const current = loaded?.path === path ? loaded : null;
+
+  useEffect(() => {
+    if (!open || path === null) return;
+    let live = true;
+    readFile(workspaceId, path)
+      .then((text) => {
+        if (live) setLoaded({ path, text, failed: false });
+      })
+      .catch(() => {
+        if (live) setLoaded({ path, text: null, failed: true });
+      });
+    return () => {
+      live = false;
+    };
+  }, [open, workspaceId, path]);
+
+  if (path === null) return null;
+
+  return (
+    <section className="mt-8">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="flex items-center gap-[7px] text-label font-semibold uppercase text-ink-faint transition-colors hover:text-ink"
+      >
+        <span className="flex w-3 flex-none items-center justify-center">
+          <ChevronRight size={11} className={cn('transition-transform duration-150', open && 'rotate-90')} />
+        </span>
+        Manifest
+        <span className="font-mono normal-case tracking-normal text-ink-faint">{file}</span>
+      </button>
+      {open && (
+        <div id={panelId} className="mt-2.5">
+          <p className="mb-2 max-w-[62ch] text-detail text-ink-muted">
+            What the plugin declares: its identifier and version, the skills it links and the
+            servers it names.{' '}
+            {managed
+              ? 'The extensions block is written by the platform; the rest is yours to edit.'
+              : 'Read from the bundle format; it is edited in its own repository.'}
+          </p>
+          {current?.failed ? (
+            <p className="text-detail text-ink-muted">Couldn't read {file}.</p>
+          ) : current?.text == null ? (
+            <p className="text-detail text-ink-faint">Loading…</p>
+          ) : (
+            <pre className="overflow-x-auto rounded-md border border-line bg-sunken px-3.5 py-2.5 font-mono text-detail text-ink">
+              {prettyJson(current.text)}
+            </pre>
+          )}
+          {canWrite && managed && (
+            <Button
+              variant="quiet"
+              size="sm"
+              className="mt-2"
+              onClick={() => navigate(kbFileUrl(DEFAULT_BRANCH, path), { state: { rawFile: true } })}
+            >
+              Edit the manifest
+            </Button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** The file as JSON, laid out — or as written, when it is not JSON. */
+function prettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
 }
 
 interface NamespaceListing {

--- a/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginExtras.tsx
@@ -129,8 +129,12 @@ export function ManifestSection({
         Manifest
         <span className="font-mono normal-case tracking-normal text-ink-faint">{file}</span>
       </button>
-      {open && (
-        <div id={panelId} className="mt-2.5">
+      {/* The panel is always in the tree, so the button's `aria-controls`
+          names an element that exists; only its CONTENT waits for `open`
+          (and so does the read behind it). */}
+      <div id={panelId} className={open ? 'mt-2.5' : undefined}>
+        {open && (
+          <>
           <p className="mb-2 max-w-[62ch] text-detail text-ink-muted">
             What the plugin declares: its identifier and version, the skills it links and the
             servers it names.{' '}
@@ -157,8 +161,9 @@ export function ManifestSection({
               Edit the manifest
             </Button>
           )}
-        </div>
-      )}
+          </>
+        )}
+      </div>
     </section>
   );
 }

--- a/packages/core-frontend/src/modules/library/components/PluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginPage.tsx
@@ -484,13 +484,18 @@ export function PluginPage() {
 
       <ClientExtensionsSection kbDirName={kbDirName} folder={folderBelowRoot} />
       {/* Last, and closed by default: the file behind the page, for whoever
-          wants to see exactly what the plugin declares. */}
-      <ManifestSection
-        kbDirName={kbDirName}
-        folder={folderBelowRoot}
-        managed={summary?.linksAreManaged !== false}
-        canWrite={summary?.canWrite === true}
-      />
+          wants to see exactly what the plugin declares. Only once the SUMMARY
+          is in: it is what says where the plugin's folder is (a nested
+          plugin's is not `Plugins/<identity>`) and which manifest file it
+          carries — before it, `folderBelowRoot` is a guess from the URL. */}
+      {summary && (
+        <ManifestSection
+          kbDirName={kbDirName}
+          folder={folderBelowRoot}
+          managed={summary.linksAreManaged !== false}
+          canWrite={summary.canWrite}
+        />
+      )}
       {manageDialog}
     </div>
   );

--- a/packages/core-frontend/src/modules/library/components/PluginPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginPage.tsx
@@ -14,7 +14,7 @@ import { pluginLabel, primaryFolderOf } from '../utils/plugin-summary';
 import { RenamePluginDialog } from './RenamePluginDialog';
 import { PluginJoinRequests } from './PluginJoinRequests';
 import { useWorkspace } from '../../workspace/state/workspace.context';
-import { ManifestButton, ClientExtensionsSection } from './PluginExtras';
+import { ManifestButton, ClientExtensionsSection, ManifestSection } from './PluginExtras';
 import { ManageAccessDialog } from '../../access/components/ManageAccessDialog';
 import { AddToPluginDialog } from './AddToPluginDialog';
 import { BandControls, EmptySkillsNudge, PluginBreadcrumb, PluginItemSections, PageNote,
@@ -483,6 +483,14 @@ export function PluginPage() {
       )}
 
       <ClientExtensionsSection kbDirName={kbDirName} folder={folderBelowRoot} />
+      {/* Last, and closed by default: the file behind the page, for whoever
+          wants to see exactly what the plugin declares. */}
+      <ManifestSection
+        kbDirName={kbDirName}
+        folder={folderBelowRoot}
+        managed={summary?.linksAreManaged !== false}
+        canWrite={summary?.canWrite === true}
+      />
       {manageDialog}
     </div>
   );

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -121,6 +121,20 @@ export function WorkspaceItemRoute() {
   }
   const repoRel = `${PLUGINS_DIR}/${plugin}/${tail.join('/')}`;
 
+  // A plugin's MANIFEST is the plugin: clicked in the tree, it opens the
+  // plugin page (whose own collapsible shows the file; the page's Manifest
+  // button asks for the raw file by state, handled above). Matched against
+  // the LISTED plugins' folders — the page keys on the plugin's identity,
+  // which the folder name need not be — so a manifest bundled inside a
+  // skill stays that skill's file, and a plugin the catalog does not list
+  // for this caller (locked, unreadable) falls through to the file itself.
+  if (isManifestFile(last)) {
+    const holder = `${PLUGINS_DIR}/${[plugin, ...tail.slice(0, -1)].join('/')}`;
+    const listed = data.pluginSummaries.find((s) => s.folders.includes(holder));
+    if (listed) return <Navigate to={pathForPlugin(listed.name)} replace />;
+    if (data.pluginsLoading) return null;
+  }
+
   // A `.tool` is a tool page wherever it sits. The backend finds manuals at
   // ANY depth below `Plugins/` (`walkFiles` over the whole tree), so a manual
   // filed inside a category folder is a real, listed tool — matching only at
@@ -284,6 +298,11 @@ function folderHasSkillMd(tree: FileTreeEntry | null, workspaceRel: string | nul
   const folder = find(tree);
   if (!folder || folder.type !== 'directory') return undefined;
   return (folder.children ?? []).some((c) => c.type === 'file' && c.name === 'SKILL.md');
+}
+
+/** The two files that make a folder a plugin: the native manifest and the bundle dialect's. */
+function isManifestFile(segment: string): boolean {
+  return segment === 'plugin.json' || segment === 'plugin.bundle.json';
 }
 
 /** Whether a path segment names a file rather than a folder. */

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -129,10 +129,13 @@ export function WorkspaceItemRoute() {
   // skill stays that skill's file, and a plugin the catalog does not list
   // for this caller (locked, unreadable) falls through to the file itself.
   if (isManifestFile(last)) {
+    // The list's word, once it has one: while it is (re)loading, the
+    // summaries on hand may be the previous list's, and a manifest whose
+    // identity just changed would open the wrong page from them.
+    if (data.pluginsLoading) return null;
     const holder = `${PLUGINS_DIR}/${[plugin, ...tail.slice(0, -1)].join('/')}`;
     const listed = data.pluginSummaries.find((s) => s.folders.includes(holder));
     if (listed) return <Navigate to={pathForPlugin(listed.name)} replace />;
-    if (data.pluginsLoading) return null;
   }
 
   // A `.tool` is a tool page wherever it sits. The backend finds manuals at


### PR DESCRIPTION
## What

Two asks from Razvan for the Skills & Tools Advanced view.

- **Clicking `plugin.json` or `plugin.bundle.json` opens the plugin page.** `WorkspaceItemRoute` matches the file's folder against the listed plugins' folders and navigates to `pathForPlugin(<identity>)` — identity, not folder name, since the page keys on the manifest name. A manifest bundled inside a skill stays that skill's file; a plugin the catalog does not list for the caller (locked, unreadable) falls through to the file itself; the route waits while the plugin list is loading. Router state `rawFile` (the page's Manifest button) still opens the raw file.
- **The plugin page shows the manifest at the bottom in a collapsible section.** `ManifestSection` is closed by default and reads the file only when opened (no request per page view), shows it laid out as JSON (verbatim when it is not JSON), reads `plugin.bundle.json` for a dialect plugin, and gives writers an "Edit the manifest" link to the raw editor. Loaded content is keyed by path, so a folder change never shows the previous plugin's file.

## Tests
- `WorkspaceItemRoute.test.tsx`: manifest → plugin page by identity; bundle manifest the same; unlisted folder → the file once the list has answered; a skill's bundled `plugin.json` → the skill page; `rawFile` state → the file.
- `PluginExtras.test.tsx`: closed by default with no read; open reads the right path and renders pretty JSON; bundle path and no editor for an unmanaged plugin; writer's editor link navigates with `rawFile`; non-JSON shown verbatim; a failed read says so.

Frontend 139 files green; `pnpm ds:check` no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a plugin's manifest in the Skills & Tools tree now opens the plugin's page instead of the file, and the plugin page ends with a collapsible Manifest section showing the file's contents.

- Matches the manifest's folder against the listed plugins' folders, so a manifest bundled inside a skill stays that skill's file and a plugin the catalog does not list falls through to the file once the list loads.
- Router state `rawFile` (the page's Manifest button) still opens the raw file.
- The Manifest section appears once the plugin summary is in (it names the folder and manifest dialect), is closed by default, reads only when opened, pretty-prints JSON (verbatim when it is not JSON), and reads `plugin.bundle.json` for the bundle dialect.
- Writers get an "Edit the manifest" link to the raw editor; dialect plugins have none, as they're edited in their own repository.

<sup>Written for commit 186cd39c4307e1a39b1d2d860a1af5c3f750307d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

