### PR TITLE
feat(library): a file inside a plugin names its plugin with a link; the manifest opens as the file

### DIFF
--- a/.changeset/plugin-file-note.md
+++ b/.changeset/plugin-file-note.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+A file inside a plugin says which plugin it belongs to. Opening a plugin's `plugin.json`, its `access.md` or any other file of its own in the Skills & Tools tree shows the file, as every file does, with one line above it naming the plugin and an **Open plugin** link to its page. The manifest no longer jumps to the plugin page on its own, which proved unreliable; the page still shows the manifest in its collapsible section.

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { DEFAULT_BRANCH, type FileTreeEntry } from '@bevel-software/platform-shared';
@@ -243,37 +243,32 @@ describe('WorkspaceItemRoute', () => {
     expect(screen.queryByLabelText('skill-page')).not.toBeInTheDocument();
   });
 
-  describe("a plugin's manifest", () => {
-    it('opens the PLUGIN page, by the identity the listed plugin carries — not the file', async () => {
+  describe("a file inside a listed plugin", () => {
+    it("the manifest opens as the file, with a note naming the plugin and a link to its page", async () => {
       vi.mocked(listPlugins).mockResolvedValue([SALES]);
       renderAt(itemUrl('Plugins/Sales/plugin.json'));
-      await waitFor(() =>
-        expect(screen.getByLabelText('pathname')).toHaveTextContent('/skills-and-tools/plugins/sales'),
-      );
-      expect(screen.queryByLabelText('file-view')).not.toBeInTheDocument();
+      await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
+      // The file, at its own URL — no jump to the page.
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Sales/plugin.json'));
+      // The note names the plugin as people know it and links by its identity.
+      expect(await screen.findByText('Sales')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Open plugin' })).toHaveAttribute('href', '/skills-and-tools/plugins/sales');
     });
 
-    it("the bundle dialect's manifest opens the plugin page the same way", async () => {
+    it("the bundle dialect's manifest and the plugin's access.md carry the same note", async () => {
       vi.mocked(listPlugins).mockResolvedValue([{ ...SALES, linksAreManaged: false }]);
       renderAt(itemUrl('Plugins/Sales/plugin.bundle.json'));
-      await waitFor(() =>
-        expect(screen.getByLabelText('pathname')).toHaveTextContent('/skills-and-tools/plugins/sales'),
-      );
+      expect(await screen.findByRole('link', { name: 'Open plugin' })).toHaveAttribute('href', '/skills-and-tools/plugins/sales');
+      cleanup();
+      vi.mocked(listPlugins).mockResolvedValue([SALES]);
+      renderAt(itemUrl('Plugins/Sales/access.md'));
+      expect(await screen.findByRole('link', { name: 'Open plugin' })).toHaveAttribute('href', '/skills-and-tools/plugins/sales');
     });
 
-    it('waits for the plugin list rather than showing the file, then shows the file when no listed plugin holds it', async () => {
-      // No plugin lists this folder (locked to the caller, or a stray file):
-      // once the list has answered, the file is the honest fallback — and
-      // not one frame before, or a manifest would flash as a file on every
-      // page load.
-      let answer: (plugins: PluginSummary[]) => void = () => {};
-      vi.mocked(listPlugins).mockReturnValue(new Promise<PluginSummary[]>((r) => (answer = r)));
+    it('a file in a folder no listed plugin holds gets no note — the file alone', async () => {
       renderAt(itemUrl('Plugins/Nope/plugin.json'));
-      await waitFor(() => expect(screen.getByRole('button', { name: /^Everything/ })).toBeInTheDocument());
-      expect(screen.queryByLabelText('file-view')).not.toBeInTheDocument();
-      answer([]);
       await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
-      expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Nope/plugin.json'));
+      expect(screen.queryByRole('link', { name: 'Open plugin' })).not.toBeInTheDocument();
     });
 
     it("a manifest bundled inside a SKILL stays that skill's file", async () => {
@@ -282,7 +277,14 @@ describe('WorkspaceItemRoute', () => {
       expect(await screen.findByLabelText('skill-page')).toHaveTextContent('create-sales-deck::plugin.json');
     });
 
-    it('router state `rawFile` still opens the manifest as a file — the page’s Manifest button', async () => {
+    it('a sibling folder sharing a prefix with the plugin does not claim the file', async () => {
+      vi.mocked(listPlugins).mockResolvedValue([SALES]);
+      renderAt(itemUrl('Plugins/Sales-Team/plugin.json'));
+      await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
+      expect(screen.queryByRole('link', { name: 'Open plugin' })).not.toBeInTheDocument();
+    });
+
+    it('router state `rawFile` opens the manifest as a file with the same note — the page’s Manifest button', async () => {
       vi.mocked(listPlugins).mockResolvedValue([SALES]);
       render(
         <MemoryRouter initialEntries={[{ pathname: itemUrl('Plugins/Sales/plugin.json'), state: { rawFile: true } }]}>
@@ -297,6 +299,7 @@ describe('WorkspaceItemRoute', () => {
       );
       await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
       expect(screen.getByLabelText('pathname')).toHaveTextContent(itemUrl('Plugins/Sales/plugin.json'));
+      expect(await screen.findByRole('link', { name: 'Open plugin' })).toBeInTheDocument();
     });
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/WorkspaceItemRoute.test.tsx
@@ -265,6 +265,18 @@ describe('WorkspaceItemRoute', () => {
       expect(await screen.findByRole('link', { name: 'Open plugin' })).toHaveAttribute('href', '/skills-and-tools/plugins/sales');
     });
 
+    it('shows the file at once but the note only from a settled plugin list', async () => {
+      // A stale list could name the wrong plugin for a frame; the file waits
+      // for nothing, the note does.
+      let answer: (plugins: PluginSummary[]) => void = () => {};
+      vi.mocked(listPlugins).mockReturnValue(new Promise<PluginSummary[]>((r) => (answer = r)));
+      renderAt(itemUrl('Plugins/Sales/plugin.json'));
+      await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());
+      expect(screen.queryByRole('link', { name: 'Open plugin' })).not.toBeInTheDocument();
+      answer([SALES]);
+      expect(await screen.findByRole('link', { name: 'Open plugin' })).toHaveAttribute('href', '/skills-and-tools/plugins/sales');
+    });
+
     it('a file in a folder no listed plugin holds gets no note — the file alone', async () => {
       renderAt(itemUrl('Plugins/Nope/plugin.json'));
       await waitFor(() => expect(screen.getByLabelText('file-view')).toBeInTheDocument());

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -1,8 +1,9 @@
-import { Navigate, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { Link, Navigate, useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { DEFAULT_BRANCH, PLUGINS_DIR, SKILLS_DIR, type FileTreeEntry } from '@bevel-software/platform-shared';
 import { useWorkspace } from '../../workspace/state/workspace.context';
 import { safeDecode } from '../../workspace/routing/kb-routes';
 import { useLibrary } from '../state/library-data';
+import type { PluginSummary } from '../services/plugins.api';
 import { FileRoute } from '../../workspace/components/FileRoute';
 import { SkillPage } from '../components/skill-page/SkillPage';
 import { ToolPage } from '../components/tool-page/ToolPage';
@@ -74,8 +75,18 @@ export function WorkspaceItemRoute() {
    * redirect would send an id-bearing file (a `.tool`, a note with an `id`)
    * to an id URL, which is no library location — and the surface would
    * switch to Knowledge after all. The path URL is the one the tree gave.
+   *
+   * Above it, when the file sits inside a listed plugin, one line says which
+   * plugin and links to its page: a manifest or an access.md opens as the
+   * file it is (routing the manifest to the page instead proved unreliable),
+   * and the page is one click away for whoever wanted it.
    */
-  const fileView = () => <FileRoute canonicalize={false} />;
+  const fileView = () => (
+    <>
+      <PluginFileNote plugin={pluginHolding(data.pluginSummaries, segments.slice(1).join('/'))} />
+      <FileRoute canonicalize={false} />
+    </>
+  );
 
   // Asked for the raw file by name: no resolution, the editor it is.
   if ((location.state as { rawFile?: boolean } | null)?.rawFile === true) return fileView();
@@ -120,23 +131,6 @@ export function WorkspaceItemRoute() {
     return <Navigate to={LIBRARY_ROOT} replace />;
   }
   const repoRel = `${PLUGINS_DIR}/${plugin}/${tail.join('/')}`;
-
-  // A plugin's MANIFEST is the plugin: clicked in the tree, it opens the
-  // plugin page (whose own collapsible shows the file; the page's Manifest
-  // button asks for the raw file by state, handled above). Matched against
-  // the LISTED plugins' folders — the page keys on the plugin's identity,
-  // which the folder name need not be — so a manifest bundled inside a
-  // skill stays that skill's file, and a plugin the catalog does not list
-  // for this caller (locked, unreadable) falls through to the file itself.
-  if (isManifestFile(last)) {
-    // The list's word, once it has one: while it is (re)loading, the
-    // summaries on hand may be the previous list's, and a manifest whose
-    // identity just changed would open the wrong page from them.
-    if (data.pluginsLoading) return null;
-    const holder = `${PLUGINS_DIR}/${[plugin, ...tail.slice(0, -1)].join('/')}`;
-    const listed = data.pluginSummaries.find((s) => s.folders.includes(holder));
-    if (listed) return <Navigate to={pathForPlugin(listed.name)} replace />;
-  }
 
   // A `.tool` is a tool page wherever it sits. The backend finds manuals at
   // ANY depth below `Plugins/` (`walkFiles` over the whole tree), so a manual
@@ -303,9 +297,36 @@ function folderHasSkillMd(tree: FileTreeEntry | null, workspaceRel: string | nul
   return (folder.children ?? []).some((c) => c.type === 'file' && c.name === 'SKILL.md');
 }
 
-/** The two files that make a folder a plugin: the native manifest and the bundle dialect's. */
-function isManifestFile(segment: string): boolean {
-  return segment === 'plugin.json' || segment === 'plugin.bundle.json';
+/**
+ * The listed plugin whose folder holds `repoRel`, deepest first — null when
+ * no listed plugin does (a file outside every plugin, or inside one the
+ * catalog does not list for this caller). Whole segments only, so a sibling
+ * folder sharing a prefix never claims the file.
+ */
+function pluginHolding(summaries: readonly PluginSummary[], repoRel: string): PluginSummary | null {
+  let best: { plugin: PluginSummary; depth: number } | null = null;
+  for (const plugin of summaries) {
+    for (const folder of plugin.folders) {
+      if (!repoRel.startsWith(`${folder}/`)) continue;
+      if (!best || folder.length > best.depth) best = { plugin, depth: folder.length };
+    }
+  }
+  return best?.plugin ?? null;
+}
+
+/** One line above a file that sits inside a plugin: which plugin, and the way to its page. */
+function PluginFileNote({ plugin }: { plugin: PluginSummary | null }) {
+  if (!plugin) return null;
+  return (
+    <p className="mb-3 flex flex-wrap items-center gap-x-2 text-detail text-ink-muted">
+      <span>
+        Part of the <span className="font-medium text-ink">{plugin.displayName ?? plugin.name}</span> plugin.
+      </span>
+      <Link to={pathForPlugin(plugin.name)} className="font-medium text-ink underline underline-offset-2">
+        Open plugin
+      </Link>
+    </p>
+  );
 }
 
 /** Whether a path segment names a file rather than a folder. */

--- a/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
+++ b/packages/core-frontend/src/modules/library/routes/WorkspaceItemRoute.tsx
@@ -83,7 +83,13 @@ export function WorkspaceItemRoute() {
    */
   const fileView = () => (
     <>
-      <PluginFileNote plugin={pluginHolding(data.pluginSummaries, segments.slice(1).join('/'))} />
+      {/* Only from a SETTLED list: while it is (re)loading the summaries on
+          hand may be the previous list's, and a plugin whose identity just
+          changed would be linked by its old name. The file itself waits for
+          nothing. */}
+      <PluginFileNote
+        plugin={data.pluginsLoading ? null : pluginHolding(data.pluginSummaries, segments.slice(1).join('/'))}
+      />
       <FileRoute canonicalize={false} />
     </>
   );


### PR DESCRIPTION
## What

Razvan's ask: routing `plugin.json` to the plugin page (shipped in 0.16.0) proved unreliable. Reverse it to the plain rule and add the affordance:

- A manifest opens as the file, like every other file in the tree.
- Any file that sits inside a **listed** plugin gets one line above the viewer in the Library frame: "Part of the *Sales* plugin. **Open plugin**", the link going to the plugin page by its identity. Deepest listed folder wins, whole segments only, so a skill's bundled manifest stays the skill's file and a prefix-sharing sibling folder claims nothing. Files in folders the catalog does not list for the caller get no note.
- The plugin page keeps the collapsible Manifest section from 0.16.0.

**Merge after the v0.16.0 release lands on main** — a commit on dev before then forces a re-cut of the tag.

## Tests
`WorkspaceItemRoute.test.tsx`: manifest → file with note and link; bundle manifest and `access.md` the same; unlisted folder → no note; skill-bundled manifest → skill page; prefix-sharing sibling → no note; `rawFile` state → file with note.

Frontend 144 files green; `pnpm ds:check` no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverses the 0.16.0 behavior where opening a plugin's `plugin.json` redirected to the plugin page, which proved unreliable. The manifest now opens as the file it is, and any file inside a listed plugin shows a line above the viewer naming the plugin with an **Open plugin** link to its page.

- The file shows immediately; the plugin note waits for a settled plugin list so a stale list can't link the wrong plugin for a frame.
- Matching uses the deepest listed folder, whole segments only, so a skill's bundled manifest stays the skill's file and a prefix-sharing sibling folder claims nothing.
- Files in folders the catalog does not list for the caller get no note; the plugin page keeps its collapsible Manifest section.
- Merge after the v0.16.0 release lands on main — a commit on dev before that forces a re-cut of the tag.

<sup>Written for commit 6b9e56ec631135ada5ac473a2a194f9e6b018a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

