### PR TITLE
feat: "Everyone" leads the Groups list with what is org-wide

### DIFF
--- a/.changeset/everyone-group.md
+++ b/.changeset/everyone-group.md
@@ -1,0 +1,6 @@
+---
+'@bevel-software/platform-core-backend': minor
+'@bevel-software/platform-core-frontend': minor
+---
+
+Skills & Tools: "Everyone" leads the Groups list, showing what is org-wide — the plugins, skills and tools every signed-in person and their agents can use, with no group or role needed. `GET /api/teams` opens with that entry, computed as the built-in `everyone` principal's own verdict (`canReadAsEveryoneBatch`) and sliced to what the caller already sees, like every group's.

--- a/.changeset/everyone-group.md
+++ b/.changeset/everyone-group.md
@@ -3,4 +3,4 @@
 '@bevel-software/platform-core-frontend': minor
 ---
 
-Skills & Tools: "Everyone" leads the Groups list, showing what is org-wide — the plugins, skills and tools every signed-in person and their agents can use, with no group or role needed. `GET /api/teams` opens with that entry, computed as the built-in `everyone` principal's own verdict (`canReadAsEveryoneBatch`) and sliced to what the caller already sees, like every group's.
+Skills & Tools: "Everyone" leads the Groups list, showing what is org-wide — the plugins, skills and tools every signed-in person and their agents can use, with no group or role needed. `GET /api/teams` opens with that entry, computed as the built-in `everyone` principal's own verdict (`canReadAsEveryoneBatch`) and sliced to what the caller already sees, like every group's. Your own space no longer has a row under Groups — it is a plugin, not a group — and stays reachable from its row on Everything, the Plugins tree and its URL.

--- a/packages/core-backend/src/modules/access/__tests__/access-control.everyone-read.test.ts
+++ b/packages/core-backend/src/modules/access/__tests__/access-control.everyone-read.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import { AccessControlService } from '../access-control.service.js';
+
+/**
+ * `canReadAsEveryoneBatch`: what the org-wide `everyone` principal reads,
+ * asked of nobody in particular. Driven over a real on-disk tree through the
+ * public resolver, like the group-read tests, because the answer has to
+ * agree with what a signed-in person who is in no group and holds no role
+ * gets — and with nothing anyone holds for a reason of their own.
+ */
+
+const KB_DIR = 'knowledge-base';
+
+function stubWorkspaceService(workspaceId: string, workspaceDir: string): WorkspaceService {
+  return {
+    getWorkspacePath: async (id: string) => {
+      if (id !== workspaceId) throw new Error(`unexpected workspace ${id}`);
+      return workspaceDir;
+    },
+    ensureRemotesFetched: async () => undefined,
+  } as unknown as WorkspaceService;
+}
+
+const ROLES_YAML = `roles:
+  Admin:
+    - admin@x.io
+  Engineer:
+    - eng@x.io
+`;
+
+const GROUPS_YAML = `groups:
+  Sales Team:
+    - sam@x.io
+`;
+
+const rules = (body: string) => `---\n${body}---\n`;
+
+describe('canReadAsEveryoneBatch', () => {
+  let root: string;
+  const workspaceId = 'ws-everyone-read-1';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'bevel-everyone-read-'));
+  });
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function makeService(files: Record<string, string>) {
+    const workspaceDir = path.join(root, workspaceId);
+    const repo = path.join(workspaceDir, KB_DIR);
+    for (const [rel, contents] of Object.entries(files)) {
+      const abs = path.join(repo, rel);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, contents);
+    }
+    return new AccessControlService(stubWorkspaceService(workspaceId, workspaceDir), KB_DIR);
+  }
+
+  const TREE = {
+    'roles.yaml': ROLES_YAML,
+    'groups.yaml': GROUPS_YAML,
+    'access.md': rules('write:\n  - Admin\n'),
+    // Org-wide: the plugin's own rules admit everyone.
+    'Plugins/Handbook/plugin.json': '{"name":"handbook"}',
+    'Plugins/Handbook/access.md': rules('read:\n  - everyone\n') + 'read:\n  - everyone\n',
+    // A team's: discoverable by everyone (the file), readable by the group (the folder).
+    'Plugins/GTM/plugin.json': '{"name":"gtm"}',
+    'Plugins/GTM/access.md': rules('read:\n  - everyone\n') + 'read:\n  - Sales Team\n',
+    // A shared skill the public plugin links — reachable through its public principal.
+    'Skills/Shared/access.md': rules('read:\n  - plugin/handbook/read\n'),
+    'Skills/Shared/welcome/SKILL.md': '# Welcome\n',
+    // A shared skill only the team's plugin links.
+    'Skills/Sales/access.md': rules('read:\n  - plugin/gtm/read\n'),
+    'Skills/Sales/deal/SKILL.md': '# Deal\n',
+    // Public by the built-in principal, with a closer carve-out beneath.
+    'Skills/Open/access.md': rules('read:\n  - everyone\n'),
+    'Skills/Open/hello/SKILL.md': '# Hello\n',
+    'Skills/Open/secret/access.md': rules('read:\n  - deny everyone\n  - Engineer\n'),
+    'Skills/Open/secret/SKILL.md': '# Secret\n',
+    // Granted to a role, and to a person: theirs, not the organisation's.
+    'Skills/Eng/access.md': rules('read:\n  - Engineer\n'),
+    'Skills/Eng/deploy/SKILL.md': '# Deploy\n',
+    'Skills/Mine/access.md': rules('read:\n  - Sam <sam@x.io>\n'),
+    'Skills/Mine/notes/SKILL.md': '# Notes\n',
+  };
+
+  const PATHS = [
+    'Plugins/Handbook',
+    'Plugins/Handbook/access.md',
+    'Plugins/GTM',
+    'Plugins/GTM/access.md',
+    'Skills/Shared/welcome/SKILL.md',
+    'Skills/Sales/deal/SKILL.md',
+    'Skills/Open/hello/SKILL.md',
+    'Skills/Open/secret/SKILL.md',
+    'Skills/Eng/deploy/SKILL.md',
+    'Skills/Mine/notes/SKILL.md',
+  ];
+
+  it('answers for the organisation: the built-in grant, a public plugin and what it links, and no one\'s own', async () => {
+    const svc = await makeService(TREE);
+    const verdict = await svc.canReadAsEveryoneBatch(workspaceId, PATHS);
+    expect(Object.fromEntries(verdict)).toEqual({
+      'Plugins/Handbook': true, // admits everyone
+      'Plugins/Handbook/access.md': true,
+      'Plugins/GTM': false, // a team's
+      'Plugins/GTM/access.md': true, // …but discoverable by all
+      'Skills/Shared/welcome/SKILL.md': true, // through the public plugin's principal
+      'Skills/Sales/deal/SKILL.md': false, // through a team plugin's only
+      'Skills/Open/hello/SKILL.md': true, // read: everyone
+      'Skills/Open/secret/SKILL.md': false, // a closer deny everyone wins
+      'Skills/Eng/deploy/SKILL.md': false, // a role's
+      'Skills/Mine/notes/SKILL.md': false, // a person's
+    });
+  });
+
+  it('agrees with what a signed-in person in no group and no role holds, and with nothing more', async () => {
+    const svc = await makeService(TREE);
+    const everyone = await svc.canReadAsEveryoneBatch(workspaceId, PATHS);
+    expect(everyone).toEqual(await svc.canReadBatch(workspaceId, 'nobody@x.io', PATHS));
+    // Members and admins hold more, for reasons of their own: none of it is the organisation's.
+    const sam = await svc.canReadBatch(workspaceId, 'sam@x.io', PATHS);
+    expect(sam.get('Plugins/GTM')).toBe(true);
+    expect(sam.get('Skills/Mine/notes/SKILL.md')).toBe(true);
+    expect(everyone.get('Plugins/GTM')).toBe(false);
+    expect(everyone.get('Skills/Mine/notes/SKILL.md')).toBe(false);
+  });
+
+  it('has no admin rescue: what only Admin may read is not org-wide', async () => {
+    const svc = await makeService({
+      ...TREE,
+      'Skills/Board/access.md': rules('read:\n  - Admin\n'),
+      'Skills/Board/minutes/SKILL.md': '# Minutes\n',
+    });
+    const verdict = await svc.canReadAsEveryoneBatch(workspaceId, ['Skills/Board/minutes/SKILL.md']);
+    expect(verdict.get('Skills/Board/minutes/SKILL.md')).toBe(false);
+  });
+});

--- a/packages/core-backend/src/modules/access/access-control.interface.ts
+++ b/packages/core-backend/src/modules/access/access-control.interface.ts
@@ -129,6 +129,18 @@ export interface IAccessControl {
   ): Promise<Map<string, boolean> | null>;
 
   /**
+   * Batched read for EVERYONE — what a signed-in person who is in no group
+   * and holds no role reads on each path, through the same walk. This is
+   * the built-in `everyone` principal's own verdict: a `read: everyone`
+   * grant (or a public plugin's) at the closest scope that says anything,
+   * a `deny everyone` there withholds. Nothing person-shaped counts — no
+   * email entry, no role, no admin rescue — so the answer is what the
+   * organisation as a whole can use, which is what the "Everyone" lens
+   * lists.
+   */
+  canReadAsEveryoneBatch(workspaceId: string, relativePaths: string[]): Promise<Map<string, boolean>>;
+
+  /**
    * Batched canWrite for PR diffs and commit-time gating. Returns a map keyed
    * by the input paths, with `true` / `false` for each. Reuses one config
    * load per call.

--- a/packages/core-backend/src/modules/access/access-control.service.ts
+++ b/packages/core-backend/src/modules/access/access-control.service.ts
@@ -498,6 +498,9 @@ function principalKeysOfGroup(model: AccessModel, group: string): Set<string> | 
   return keys;
 }
 
+/** The key set of a caller who holds nothing: `hasPermissionForKeys` then answers as `everyone`. */
+const NO_KEYS: ReadonlySet<string> = new Set();
+
 /**
  * The tier-2 half of `hasPermissionResolved` on its own: a verdict for a set
  * of principal KEYS with no person behind them — no direct-email tier, no
@@ -1158,6 +1161,21 @@ export class AccessControlService implements IAccessControl {
     const result = new Map<string, boolean>();
     relativePaths.forEach((p, i) => {
       result.set(p, hasPermissionForKeys(model, 'read', keys, p, owns[i]));
+    });
+    return result;
+  }
+
+  async canReadAsEveryoneBatch(workspaceId: string, relativePaths: string[]): Promise<Map<string, boolean>> {
+    const model = await this.loadModel(workspaceId);
+    const repoDir = await this.repoDir(workspaceId);
+    const owns = await Promise.all(relativePaths.map((p) => this.cachedOwnEntries(workspaceId, repoDir, p)));
+    const result = new Map<string, boolean>();
+    relativePaths.forEach((p, i) => {
+      // No keys at all: the walk then falls through to each scope's derived
+      // `everyone` verdict — the built-in entry, or a public plugin's grant
+      // or denial, whichever the scope builder settled on — which is exactly
+      // what a caller holding nothing of their own resolves to.
+      result.set(p, hasPermissionForKeys(model, 'read', NO_KEYS, p, owns[i]));
     });
     return result;
   }

--- a/packages/core-backend/src/modules/plugins/__tests__/teams.routes.test.ts
+++ b/packages/core-backend/src/modules/plugins/__tests__/teams.routes.test.ts
@@ -55,8 +55,13 @@ interface HarnessOpts {
   caller?: string[];
   /** What each group reads; a group absent here is "not a group" (null). */
   team?: Record<string, string[]>;
+  /** What the org-wide `everyone` principal reads. */
+  everyone?: string[];
   email?: string | null;
 }
+
+/** The org-wide entry every answer opens with — empty unless `everyone` says otherwise. */
+const NOTHING_ORG_WIDE = { name: 'Everyone', plugins: [], skills: [], tools: [] };
 
 const servers: Server[] = [];
 afterEach(async () => {
@@ -72,6 +77,7 @@ async function harness(opts: HarnessOpts = {}) {
     canReadAsGroupBatch: vi.fn(async (_w: string, group: string, paths: string[]) =>
       opts.team && group in opts.team ? tableVerdict(opts.team[group], paths) : null,
     ),
+    canReadAsEveryoneBatch: vi.fn(async (_w: string, paths: string[]) => tableVerdict(opts.everyone, paths)),
   } as unknown as IAccessControl;
   const index = { catalog: async () => CATALOG, invalidate: () => undefined } as IPluginIndexService;
   const skills = { listSkills: async () => SKILLS } as unknown as ISkillService;
@@ -119,10 +125,38 @@ describe('GET /api/teams', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       teams: [
+        NOTHING_ORG_WIDE,
         { name: 'Sales Team', plugins: ['gtm'], skills: ['outreach'], tools: ['hubspot'] },
         { name: 'Finance Team', plugins: ['finance'], skills: ['ledger'], tools: ['books'] },
       ],
     });
+  });
+
+  it('opens with Everyone — what the org-wide principal reads, cut to what the caller sees, ahead of every group', async () => {
+    const h = await harness({
+      groups: ['Sales Team'],
+      caller: ['Plugins/GTM', 'Plugins/Finance/access.md', 'Skills/Sales/outreach/SKILL.md', 'Plugins/GTM/mcp.json'],
+      everyone: [
+        'Plugins/GTM',
+        'Plugins/Finance',
+        'Skills/Sales/outreach/SKILL.md',
+        'Skills/Finance/ledger/SKILL.md', // the caller cannot read it — withheld
+        'Plugins/GTM/mcp.json',
+      ],
+      team: { 'Sales Team': ['Plugins/GTM'] },
+    });
+    expect(await (await h.get()).json()).toEqual({
+      teams: [
+        // Finance is org-wide readable and the caller can discover it: listed, like any team's.
+        { name: 'Everyone', plugins: ['gtm', 'finance'], skills: ['outreach'], tools: ['hubspot'] },
+        { name: 'Sales Team', plugins: ['gtm'], skills: [], tools: [] },
+      ],
+    });
+  });
+
+  it('lists Everyone even when nothing is org-wide, and when there are no groups at all', async () => {
+    const h = await harness({ groups: [], caller: EVERYTHING });
+    expect(await (await h.get()).json()).toEqual({ teams: [NOTHING_ORG_WIDE] });
   });
 
   it('withholds what the caller cannot read, whatever the team can', async () => {
@@ -139,7 +173,7 @@ describe('GET /api/teams', () => {
       },
     });
     expect(await (await h.get()).json()).toEqual({
-      teams: [{ name: 'Sales Team', plugins: ['gtm'], skills: ['outreach'], tools: [] }],
+      teams: [NOTHING_ORG_WIDE, { name: 'Sales Team', plugins: ['gtm'], skills: ['outreach'], tools: [] }],
     });
   });
 
@@ -149,36 +183,44 @@ describe('GET /api/teams', () => {
       team: { 'Sales Team': ['Plugins/Finance'] },
     });
     expect(await (await h.get()).json()).toEqual({
-      teams: [{ name: 'Sales Team', plugins: ['finance'], skills: [], tools: [] }],
+      teams: [NOTHING_ORG_WIDE, { name: 'Sales Team', plugins: ['finance'], skills: [], tools: [] }],
     });
   });
 
   it("never offers a personal plugin, or what lives in it, as a team's — whatever the resolver says", async () => {
     // The stub grants EVERYTHING to the team, the personal skill and tool
     // included (a hand-written grant inside a personal folder could): the
-    // route withholds them by where they live, not by the verdict.
+    // route withholds them by where they live, not by the verdict. The same
+    // holds for the org-wide entry.
     const h = await harness({
       caller: EVERYTHING,
+      everyone: EVERYTHING,
       team: { 'Sales Team': EVERYTHING },
     });
+    const all = { plugins: ['gtm', 'finance'], skills: ['outreach', 'ledger'], tools: ['hubspot', 'books'] };
     expect(await (await h.get()).json()).toEqual({
-      teams: [{ name: 'Sales Team', plugins: ['gtm', 'finance'], skills: ['outreach', 'ledger'], tools: ['hubspot', 'books'] }],
+      teams: [
+        { name: 'Everyone', ...all },
+        { name: 'Sales Team', ...all },
+      ],
     });
   });
 
   it('skips a group the resolver no longer knows', async () => {
     const h = await harness({ groups: ['Sales Team', 'Gone'], caller: EVERYTHING, team: { 'Sales Team': [] } });
     expect(await (await h.get()).json()).toEqual({
-      teams: [{ name: 'Sales Team', plugins: [], skills: [], tools: [] }],
+      teams: [NOTHING_ORG_WIDE, { name: 'Sales Team', plugins: [], skills: [], tools: [] }],
     });
   });
 
-  it('asks the resolver once for the caller and once per group, over one probe set', async () => {
+  it('asks the resolver once for the caller, once for everyone and once per group, over one probe set', async () => {
     const h = await harness({ groups: ['A', 'B'], caller: EVERYTHING, team: { A: [], B: [] } });
     await h.get();
     expect(h.accessControl.canReadBatch).toHaveBeenCalledTimes(1);
+    expect(h.accessControl.canReadAsEveryoneBatch).toHaveBeenCalledTimes(1);
     expect(h.accessControl.canReadAsGroupBatch).toHaveBeenCalledTimes(2);
     const [, , probes] = vi.mocked(h.accessControl.canReadBatch).mock.calls[0]!;
+    expect(vi.mocked(h.accessControl.canReadAsEveryoneBatch).mock.calls[0]![1]).toBe(probes);
     // Personal folders are not probed at all — not as plugins, not for what
     // they hold; everything else is, once: every plugin folder and its
     // access.md, every skill's SKILL.md, every tool's file.

--- a/packages/core-backend/src/modules/plugins/teams.routes.ts
+++ b/packages/core-backend/src/modules/plugins/teams.routes.ts
@@ -23,6 +23,12 @@ import { pluginsWorkspaceId } from './plugins.service.js';
  * when the caller could see it on the index (a member, or able to discover
  * it). The lens never widens what the catalog already shows the caller — it
  * slices it.
+ *
+ * The list opens with `Everyone`: not a group, the built-in org-wide
+ * principal — what a signed-in person in no group at all can use, which is
+ * what `read: everyone` (or a public plugin) reaches. Same slice, same
+ * caller gate, asked of the resolver as `canReadAsEveryoneBatch`. The name
+ * cannot collide with a group's: `everyone` is reserved by the grammar.
  */
 export interface TeamAccess {
   name: string;
@@ -33,6 +39,9 @@ export interface TeamAccess {
   /** Tool slugs. */
   tools: string[];
 }
+
+/** The org-wide entry's name — the built-in `everyone` principal, as the sidebar spells it. */
+export const EVERYONE_TEAM = 'Everyone';
 
 export function createTeamsRoutes(
   accessControl: IAccessControl,
@@ -75,12 +84,10 @@ export function createTeamsRoutes(
       const callerSeesPlugin = (g: PluginCatalogEntry) =>
         g.folders.some((f) => callerReads(f) || callerReads(accessMdOf(f)));
 
-      const teams: TeamAccess[] = [];
-      for (const name of groups) {
-        const team = await accessControl.canReadAsGroupBatch(wsId, name, probes);
-        if (team === null) continue; // gone between the two reads — nothing to say
-        const reads = (p: string) => team.get(p) === true;
-        teams.push({
+      /** One entry: what `verdicts` reads, cut to what the caller sees. */
+      const slice = (name: string, verdicts: Map<string, boolean>): TeamAccess => {
+        const reads = (p: string) => verdicts.get(p) === true;
+        return {
           name,
           plugins: plugins
             .filter((g) => g.folders.some(reads) && callerSeesPlugin(g))
@@ -89,7 +96,16 @@ export function createTeamsRoutes(
             .filter((s) => reads(skillMdOf(s.path)) && callerReads(skillMdOf(s.path)))
             .map((s) => s.name),
           tools: tools.filter((t) => reads(t.path) && callerReads(t.path)).map((t) => t.slug),
-        });
+        };
+      };
+
+      const teams: TeamAccess[] = [
+        slice(EVERYONE_TEAM, await accessControl.canReadAsEveryoneBatch(wsId, probes)),
+      ];
+      for (const name of groups) {
+        const team = await accessControl.canReadAsGroupBatch(wsId, name, probes);
+        if (team === null) continue; // gone between the two reads — nothing to say
+        teams.push(slice(name, team));
       }
       res.json({ teams });
     } catch (err) {

--- a/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
@@ -211,10 +211,9 @@ describe('LibraryRoutes', () => {
   it("/skills-and-tools/yours is the caller's own plugin, as a plugin page", async () => {
     renderAt('/skills-and-tools/yours');
     expect(await screen.findByRole('heading', { name: TEST_PERSONAL_GROUP, level: 1 })).toBeInTheDocument();
-    expect(within(nav()).getByRole('button', { name: new RegExp(`^${TEST_PERSONAL_GROUP}`) })).toHaveAttribute(
-      'aria-current',
-      'true',
-    );
+    // Your own space is not a group: no nav row for it, and nothing else lights up.
+    expect(within(nav()).queryByRole('button', { name: new RegExp(`^${TEST_PERSONAL_GROUP}`) })).toBeNull();
+    expect(within(nav()).queryByRole('button', { current: true })).toBeNull();
     expect(screen.getByRole('heading', { name: 'Skills', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Tools', level: 2 })).toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument();
@@ -236,19 +235,21 @@ describe('LibraryRoutes', () => {
     expect(screen.queryByTestId('library-card-integration-slack')).toBeNull();
   });
 
-  it('Everyone leads the groups, right after your own space, and opens what is org-wide', async () => {
+  it('Everyone leads the groups, right after the lenses, and opens what is org-wide', async () => {
     renderAt('/skills-and-tools');
     // "Everyone Else" is a team in the fixture: the org-wide row is the one
     // whose whole label is the name plus its count.
     await within(nav()).findByRole('button', { name: /^Everyone \d+$/ });
     const rows = within(nav()).getAllByRole('button');
     const names = rows.map((r) => r.textContent ?? '');
-    const own = names.findIndex((n) => n.startsWith(TEST_PERSONAL_GROUP));
+    const owned = names.findIndex((n) => n.startsWith('Owned by me'));
     const everyone = names.findIndex((n) => /^Everyone\d+$/.test(n));
     const gtm = names.findIndex((n) => n.startsWith('GTM Team'));
-    expect(own).toBeGreaterThan(-1);
-    expect(everyone).toBe(own + 1);
+    expect(owned).toBeGreaterThan(-1);
+    expect(everyone).toBe(owned + 1);
     expect(gtm).toBeGreaterThan(everyone);
+    // Your own space is a plugin, not a group: no row for it here.
+    expect(names.some((n) => n.startsWith(TEST_PERSONAL_GROUP))).toBe(false);
 
     fireEvent.click(rows[everyone]!);
     await waitFor(() => expect(pathname()).toBe('/skills-and-tools/teams/Everyone'));
@@ -478,7 +479,7 @@ describe('LibraryRoutes', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load teams.");
     expect(screen.queryByText(/There's no team called/)).toBeNull();
     expect(await screen.findByRole('heading', { name: 'GTM Team', level: 1 })).toBeInTheDocument();
-    expect(within(nav()).getByRole('button', { name: new RegExp(`^${TEST_PERSONAL_GROUP}`) })).toBeInTheDocument();
+    expect(within(nav()).getByRole('button', { name: /^Owned by me/ })).toBeInTheDocument();
     expect(within(nav()).queryByRole('button', { name: /^GTM Team/ })).toBeNull();
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
@@ -263,6 +263,23 @@ describe('LibraryRoutes', () => {
     expect(screen.queryByTestId('library-card-skill-outreach')).toBeNull();
   });
 
+  it('holds the org-wide line until the team list has settled and names Everyone', async () => {
+    let resolve: (teams: typeof TEAMS) => void = () => {};
+    teamsMock.listTeams.mockReturnValue(new Promise<typeof TEAMS>((r) => (resolve = r)));
+    renderAt('/skills-and-tools/teams/Everyone');
+    expect(await screen.findByText('Loading teams…')).toBeInTheDocument();
+    expect(screen.queryByText(/^Org-wide:/)).toBeNull();
+    resolve(TEAMS);
+    expect(await screen.findByText(/^Org-wide:/)).toBeInTheDocument();
+  });
+
+  it('keeps the org-wide line off a failed team list — the error is the whole story', async () => {
+    teamsMock.listTeams.mockRejectedValue(new Error("Couldn't load teams."));
+    renderAt('/skills-and-tools/teams/Everyone');
+    expect(await screen.findByRole('alert')).toHaveTextContent("Couldn't load teams.");
+    expect(screen.queryByText(/^Org-wide:/)).toBeNull();
+  });
+
   it('says so when nothing is shared with everyone yet', async () => {
     teamsMock.listTeams.mockResolvedValue([{ name: 'Everyone', plugins: [], skills: [], tools: [] }]);
     renderAt('/skills-and-tools/teams/Everyone');

--- a/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibraryRoutes.test.tsx
@@ -110,6 +110,8 @@ const PLUGINS: PluginSummary[] = [
 ];
 
 const TEAMS = [
+  // The server opens with the org-wide entry: Product admits everyone here.
+  { name: 'Everyone', plugins: ['Product'], skills: ['roadmap'], tools: ['slack'] },
   { name: 'GTM Team', plugins: ['GTM'], skills: ['outreach'], tools: ['heyreach'] },
   { name: 'Everyone Else', plugins: [], skills: ['scratch'], tools: [] },
 ];
@@ -232,6 +234,38 @@ describe('LibraryRoutes', () => {
     expect(screen.getByTestId('library-card-integration-heyreach')).toBeInTheDocument();
     expect(screen.queryByTestId('library-card-skill-roadmap')).toBeNull();
     expect(screen.queryByTestId('library-card-integration-slack')).toBeNull();
+  });
+
+  it('Everyone leads the groups, right after your own space, and opens what is org-wide', async () => {
+    renderAt('/skills-and-tools');
+    // "Everyone Else" is a team in the fixture: the org-wide row is the one
+    // whose whole label is the name plus its count.
+    await within(nav()).findByRole('button', { name: /^Everyone \d+$/ });
+    const rows = within(nav()).getAllByRole('button');
+    const names = rows.map((r) => r.textContent ?? '');
+    const own = names.findIndex((n) => n.startsWith(TEST_PERSONAL_GROUP));
+    const everyone = names.findIndex((n) => /^Everyone\d+$/.test(n));
+    const gtm = names.findIndex((n) => n.startsWith('GTM Team'));
+    expect(own).toBeGreaterThan(-1);
+    expect(everyone).toBe(own + 1);
+    expect(gtm).toBeGreaterThan(everyone);
+
+    fireEvent.click(rows[everyone]!);
+    await waitFor(() => expect(pathname()).toBe('/skills-and-tools/teams/Everyone'));
+    expect(await screen.findByRole('heading', { name: 'Everyone', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText(/^Org-wide: what every signed-in person/)).toBeInTheDocument();
+    // The server's slice: Product's row, roadmap and slack — nothing of GTM's.
+    expect(await within(main()).findByRole('button', { name: /^Product/ })).toBeInTheDocument();
+    expect(within(main()).queryByRole('button', { name: /^GTM/ })).toBeNull();
+    expect(screen.getByTestId('library-card-skill-roadmap')).toBeInTheDocument();
+    expect(screen.getByTestId('library-card-integration-slack')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-card-skill-outreach')).toBeNull();
+  });
+
+  it('says so when nothing is shared with everyone yet', async () => {
+    teamsMock.listTeams.mockResolvedValue([{ name: 'Everyone', plugins: [], skills: [], tools: [] }]);
+    renderAt('/skills-and-tools/teams/Everyone');
+    expect(await screen.findByText('Nothing is shared with everyone yet.')).toBeInTheDocument();
   });
 
   it('a team deep link with a URL-hostile name lands, and an unknown team says so', async () => {

--- a/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/LibrarySidebarMenu.test.tsx
@@ -69,7 +69,7 @@ vi.mock('../services/teams.api', () => ({ listTeams: teamsMock.listTeams }));
 vi.mock('../../git/components/PullRequestsForMe', () => ({ PullRequestsForMe: () => null }));
 
 import { LibraryRoutes } from '../routes/LibraryRoutes';
-import { withAuth, TEST_PERSONAL_GROUP } from './auth-harness';
+import { withAuth } from './auth-harness';
 
 const CATALOG: LibraryData = {
   loading: false,
@@ -206,7 +206,7 @@ describe('Library sidebar: right-click, end to end', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
 
-    await openMenuOn(new RegExp(`^${TEST_PERSONAL_GROUP}`));
+    await openMenuOn(/^Everything/);
     expect(menuItems()).toEqual(['New plugin', 'Copy link']);
   });
 

--- a/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.contextmenu.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.contextmenu.test.tsx
@@ -21,8 +21,6 @@ function renderSidebar(over: Partial<PluginsSidebarProps> = {}) {
     onSelect,
     ownedCount: 2,
     ownedAttention: 0,
-    personalPluginLabel: "Juan's Plugin",
-    ungroupedCount: 1,
     teams: [
       { name: 'Engineering', count: 4, urgent: 0 },
       { name: 'GTM', count: 3, urgent: 2 },
@@ -67,14 +65,8 @@ describe('PluginsSidebar: right-click', () => {
       label: 'Owned by me',
     });
 
-    rightClick(screen.getByRole('button', { name: /^Juan's Plugin/ }));
-    expect(onContextMenu.mock.calls[1][0]).toMatchObject({
-      filter: { kind: 'ungrouped' },
-      label: "Juan's Plugin",
-    });
-
     rightClick(screen.getByRole('button', { name: /^Everything/ }));
-    expect(onContextMenu.mock.calls[2][0]).toMatchObject({
+    expect(onContextMenu.mock.calls[1][0]).toMatchObject({
       filter: { kind: 'all' },
       label: 'Everything',
     });

--- a/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.test.tsx
+++ b/packages/core-frontend/src/modules/library/__tests__/PluginsSidebar.test.tsx
@@ -4,8 +4,8 @@ import { PluginsSidebar, type PluginsSidebarProps } from '../components/PluginsS
 import type { LibraryFilter } from '../utils/status';
 
 /**
- * The Library nav: two lenses, the caller's teams (their own space first),
- * the two roots as trees. A pure view of the URL — `filter` in, intents out.
+ * The Library nav: two lenses, the groups as the server lists them, the two
+ * roots as trees. A pure view of the URL — `filter` in, intents out.
  */
 
 function renderSidebar(over: Partial<PluginsSidebarProps> = {}) {
@@ -16,8 +16,6 @@ function renderSidebar(over: Partial<PluginsSidebarProps> = {}) {
     onSelect,
     ownedCount: 2,
     ownedAttention: 0,
-    personalPluginLabel: "Juan's Plugin",
-    ungroupedCount: 1,
     teams: [
       { name: 'Engineering', count: 4, urgent: 0 },
       { name: 'GTM', count: 3, urgent: 2 },
@@ -70,14 +68,16 @@ describe('PluginsSidebar', () => {
     expect(screen.queryByText('Library')).not.toBeInTheDocument();
   });
 
-  it("leads the Teams view with the caller's own space, and lists it even when empty", () => {
-    renderSidebar({ filter: { kind: 'ungrouped' }, ungroupedCount: 0 });
+  it("lists the groups in the server's order and nothing else — your own space is not a group", () => {
+    renderSidebar({ filter: { kind: 'ungrouped' } });
     const panel = screen.getByRole('tabpanel', { name: 'Groups' });
-    const own = within(panel).getByRole('button', { name: /^Juan's Plugin/ });
-    const first = within(panel).getByRole('button', { name: /^Engineering/ });
-    expect(own.compareDocumentPosition(first) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(own).toHaveAttribute('aria-current', 'true');
-    expect(own).toHaveAccessibleName("Juan's Plugin");
+    expect(within(panel).getAllByRole('button').map((b) => b.textContent)).toEqual([
+      'Engineering4',
+      'GTM2',
+      'Product',
+    ]);
+    // The own-space page lights no row: it is reached from Everything, not from here.
+    expect(within(panel).queryByRole('button', { current: true })).toBeNull();
   });
 
   it('switches to the Advanced view, which holds the two trees — Skills before Plugins — and no team rows', () => {
@@ -99,7 +99,6 @@ describe('PluginsSidebar', () => {
     // No heading over the trees: the tab already names the view.
     expect(within(panel).queryByText('Files on disk')).toBeNull();
     expect(screen.queryByRole('button', { name: /^Engineering/ })).toBeNull();
-    expect(screen.queryByRole('button', { name: /^Juan's Plugin/ })).toBeNull();
     // The lenses belong to neither view and stay put.
     expect(row(/^Everything/)).toBeInTheDocument();
     expect(row(/^Owned by me/)).toBeInTheDocument();
@@ -180,7 +179,6 @@ describe('PluginsSidebar', () => {
     const expected: [RegExp, LibraryFilter][] = [
       [/^Everything/, { kind: 'all' }],
       [/^Owned by me/, { kind: 'owned' }],
-      [/^Juan's Plugin/, { kind: 'ungrouped' }],
       [/^GTM/, { kind: 'team', group: 'GTM' }],
     ];
     for (const [name, filter] of expected) {

--- a/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryLayout.tsx
@@ -8,7 +8,7 @@ import { useAdmin } from '../../admin/state/admin.context';
 import { attentionOf, useLibrary, workspaceHasNoPlugins } from '../state/library-data';
 import { personalPluginName } from '../utils/personal-plugin';
 import { libraryFilterForPath, pathForLibraryFilter } from '../routes/library-paths';
-import { filterLibraryItems, isUngrouped, pluginsOfItem, type LibraryFilter } from '../utils/status';
+import { filterLibraryItems, pluginsOfItem, type LibraryFilter } from '../utils/status';
 import { pluginEntriesFor } from '../utils/plugin-entries';
 import { LINK_COPIED_TOAST, LINK_COPY_FAILED_TOAST, copyToClipboard } from '../utils/clipboard';
 import { useLibraryToast } from '../state/toast.context';
@@ -31,9 +31,10 @@ import { NewPluginDialog } from './NewPluginDialog';
  * can take its filter as a plain prop and the sidebar can hold no state.
  *
  * The nav lists LENSES and PLACES, never individual plugins: Everything and
- * Owned by me, then the caller's teams (their own space first), then the two
- * roots as file trees. A plugin is reached through the page it is on — its
- * row on Everything or a team's page, its folder in the Plugins tree — so the
+ * Owned by me, then the groups (Everyone first), then the two roots as file
+ * trees. A plugin — the caller's own space included — is reached through the
+ * page it is on: its row on Everything or a team's page, its folder in the
+ * Plugins tree. So the
  * plugin verbs (add to, manage access, delete) live on the plugin page and
  * the tree row, and the nav's own menu keeps only what the nav can answer:
  * a link to the row, and a new plugin.
@@ -89,7 +90,6 @@ export function LibraryLayout() {
     () => items.filter((i) => i.owned && i.status.state !== 'ok').length,
     [items],
   );
-  const ungroupedCount = useMemo(() => items.filter(isUngrouped).length, [items]);
   const attentionCount = useMemo(
     () => items.filter((i) => i.kind === 'integration' && i.status.state !== 'ok').length,
     [items],
@@ -131,8 +131,6 @@ export function LibraryLayout() {
           onSelect={(next) => navigate(pathForLibraryFilter(next))}
           ownedCount={ownedCount}
           ownedAttention={ownedAttention}
-          personalPluginLabel={personalLabel}
-          ungroupedCount={ungroupedCount}
           teams={teamRows}
           attentionCount={attentionCount}
           onFinishSetup={() => navigate('/connect')}

--- a/packages/core-frontend/src/modules/library/components/LibraryPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryPage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../auth/state/auth.context';
 import { useLibrary, type LibraryItem } from '../state/library-data';
 import { urlForLibraryItem } from '../routes/library-paths';
 import { useWorkspace } from '../../workspace/state/workspace.context';
-import { emptyMessageFor, filterLibraryItems, type LibraryFilter } from '../utils/status';
+import { EVERYONE_TEAM, emptyMessageFor, filterLibraryItems, type LibraryFilter } from '../utils/status';
 import { pluginEntriesFor } from '../utils/plugin-entries';
 import { personalPluginName } from '../utils/personal-plugin';
 import { Banner, TextField } from '../../../shared/components';
@@ -105,6 +105,13 @@ export function LibraryPage({ filter }: { filter: LibraryFilter }) {
           <p className="mt-0.5 text-ui text-ink-muted">
             {data.loading ? '…' : `${count} ${count === 1 ? 'item' : 'items'}`}
           </p>
+          {/* Everyone is not a group but the organisation: say what the page
+              holds, because the name alone reads like one more team. */}
+          {filter.kind === 'team' && filter.group === EVERYONE_TEAM && (
+            <p className="mt-2 max-w-prose text-ui text-ink-muted">
+              Org-wide: what every signed-in person and their agents can use, with no group or role needed.
+            </p>
+          )}
         </div>
         <TextField
           className="ml-auto w-64"

--- a/packages/core-frontend/src/modules/library/components/LibraryPage.tsx
+++ b/packages/core-frontend/src/modules/library/components/LibraryPage.tsx
@@ -106,8 +106,10 @@ export function LibraryPage({ filter }: { filter: LibraryFilter }) {
             {data.loading ? '…' : `${count} ${count === 1 ? 'item' : 'items'}`}
           </p>
           {/* Everyone is not a group but the organisation: say what the page
-              holds, because the name alone reads like one more team. */}
-          {filter.kind === 'team' && filter.group === EVERYONE_TEAM && (
+              holds, because the name alone reads like one more team. Only
+              once the list has settled and names it — while it loads, or
+              when it failed, the state below is the whole story. */}
+          {filter.kind === 'team' && filter.group === EVERYONE_TEAM && teamsSettled && !unknownTeam && (
             <p className="mt-2 max-w-prose text-ui text-ink-muted">
               Org-wide: what every signed-in person and their agents can use, with no group or role needed.
             </p>

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -95,9 +95,10 @@ export interface PluginsSidebarProps {
  * home) and Owned by me — then ONE switch between the two views of what is
  * below them:
  *
- *  - TEAMS — the caller's own space first (the one team they are always
- *    in), then every group from the access rules: a team's page is what
- *    being in that group lets a person use;
+ *  - TEAMS (shown as "Groups") — Everyone first, the org-wide entry the
+ *    server leads with, then every group from the access rules: a team's
+ *    page is what being in that group lets a person use. The caller's own
+ *    space is a plugin, not a group, and has no row here;
  *  - ADVANCED — `Skills/` and `Plugins/` as they are on disk.
  *
  * Plugins have no rows of their own here. They are reached through the

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -38,11 +38,9 @@ export interface PluginsSidebarProps {
    * badge; when zero the row shows `ownedCount` in grey instead.
    */
   ownedAttention: number;
-  /** The caller's own space, e.g. `Juan's Plugin` — see `personalPluginName`. */
-  personalPluginLabel: string;
-  ungroupedCount: number;
   /**
-   * The teams — groups from the access rules — each with how much of the
+   * The teams — groups from the access rules, led by the org-wide `Everyone`
+   * entry the server puts first — each with how much of the
    * catalog it can use, and how many of its plugins' links lock its members
    * out of a skill right now. Orange wins the count slot: it is other
    * people's problem, and the count is not the news.
@@ -124,8 +122,6 @@ export function PluginsSidebar({
   onSelect,
   ownedCount,
   ownedAttention,
-  personalPluginLabel,
-  ungroupedCount,
   teams,
   attentionCount,
   onFinishSetup,
@@ -309,8 +305,8 @@ export function PluginsSidebar({
           hidden={view !== 'teams'}
           className="flex flex-col gap-px"
         >
-          {/* Your own space leads the teams: it is the one you are always in. */}
-          {row(personalPluginLabel, { kind: 'ungrouped' }, ungroupedCount)}
+          {/* Groups only: your own space is not a group — it is reached from
+              its row on Everything and its folder in the Plugins tree. */}
           {teams.map(({ name, count, urgent }) =>
             // Orange wins the count slot: members locked out of a skill outrank
             // how much the team can use, which is not the news.

--- a/packages/core-frontend/src/modules/library/routes/LibraryRoutes.tsx
+++ b/packages/core-frontend/src/modules/library/routes/LibraryRoutes.tsx
@@ -53,9 +53,9 @@ export function LibraryRoutes() {
             <Route path="owned" element={<LibraryPage filter={{ kind: 'owned' }} />} />
 
             {/* `yours` is a PLUGIN page, not a gallery filter — the items in no
-                folder, given the same page the folders get. The sidebar still
-                lights it through the `ungrouped` filter, so the URL and the
-                selection stay the pair they were. */}
+                folder, given the same page the folders get. It has no nav row
+                (your own space is not a group); it is reached from its row on
+                Everything, the welcome page and by URL. */}
             <Route path="yours" element={<PersonalPluginPage />} />
 
             {/* A plugin is a PLACE: `plugins/:plugin` is a real page with a real

--- a/packages/core-frontend/src/modules/library/utils/status.ts
+++ b/packages/core-frontend/src/modules/library/utils/status.ts
@@ -230,6 +230,8 @@ export type LibraryFilter =
 /**
  * What one team can use, by id — `GET /api/teams`, one entry per group.
  * Ids only: the names are the catalog's, and the slice is applied to it.
+ * The server opens the list with `EVERYONE_TEAM` — not a group but the
+ * built-in org-wide principal: what a person in no group at all can use.
  */
 export interface TeamAccess {
   name: string;
@@ -237,6 +239,13 @@ export interface TeamAccess {
   skills: string[];
   tools: string[];
 }
+
+/**
+ * The org-wide entry's name, as the server spells it. No group can take
+ * it — `everyone` is a reserved name in the access rules — so a team of
+ * this name IS the organisation, and the page says so.
+ */
+export const EVERYONE_TEAM = 'Everyone';
 
 /**
  * What an empty view says.
@@ -253,6 +262,7 @@ export interface TeamAccess {
 export function emptyMessageFor(filter: LibraryFilter, query: string): string {
   if (query.trim()) return 'Nothing here matches yet.';
   if (filter.kind === 'owned') return "You're not responsible for changes in any skills yet.";
+  if (filter.kind === 'team' && filter.group === EVERYONE_TEAM) return 'Nothing is shared with everyone yet.';
   if (filter.kind === 'team') return `${filter.group} can't use anything you can see yet.`;
   return 'Nothing here matches yet.';
 }


### PR DESCRIPTION
## What

In Skills & Tools, the **Groups** tab now opens with **Everyone**: the plugins, skills and tools every signed-in person and their agents can use, with no group or role needed. Its page is the ordinary team page sliced by the server, with one line saying what it holds ("Org-wide: what every signed-in person and their agents can use…") and its own empty state ("Nothing is shared with everyone yet.").

Your own space no longer has a row under Groups: it is a plugin, not a group. It stays reachable from its row on Everything, its folder in the Plugins tree, the welcome page and its URL; on that page no nav row lights up, like any other plugin page.

## How

- **Backend** — `GET /api/teams` opens with the `Everyone` entry. New resolver method `canReadAsEveryoneBatch(workspaceId, paths)`: the same closeness-first walk as `canReadAsGroupBatch`, run with **no principal keys at all**, so each scope answers with its derived `everyone` state (the built-in `read: everyone` / `deny everyone`, or a public plugin's grant or denial — the state the scope builder already derives for the anonymous caller). No admin rescue, nothing a person or role holds. Cut to what the caller already sees, exactly like every group's entry. `everyone` is a reserved name in the grammar, so no group can take the row.
- **Frontend** — `EVERYONE_TEAM` in `status.ts`; `LibraryPage` adds the org-wide subtitle and empty-state copy for that team; `PluginsSidebar` drops the own-space row and the two props that fed it.

## Tests

- `access-control.everyone-read.test.ts` — real on-disk tree: built-in grant, closer `deny everyone`, a public plugin and a skill reached through its principal, a team plugin's skill withheld, a role's / a person's folder withheld, no admin rescue; and agreement with `canReadBatch` for a signed-in user in no group and no role.
- `teams.routes.test.ts` — Everyone first, caller-gated, listed even when empty or with no groups, one resolver call over the shared probe set.
- `LibraryRoutes.test.tsx` / `PluginsSidebar*.test.tsx` / `LibrarySidebarMenu.test.tsx` — Everyone row right after the lenses, opens `/skills-and-tools/teams/Everyone` with the subtitle and the server's slice; empty-state copy; no own-space row, and nothing current on `/yours`.

Backend and frontend suites, typecheck and lint green locally (one unrelated PDF-extraction test flaked under full-suite load and passes alone).

Merge after the release PR #153 lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
