### PR TITLE
hx-lock-path-identity — File locks coordinate on one canonical file identity, whatever spelling the client sends

### DIFF
--- a/.changeset/lock-path-canonical-identity.md
+++ b/.changeset/lock-path-canonical-identity.md
@@ -1,0 +1,10 @@
+---
+'@bevel-software/platform-shared': patch
+'@bevel-software/platform-core-backend': patch
+---
+
+File locks now coordinate on one canonical file identity, whatever spelling the client sends. `x/a.md`, `./x/a.md` and `x//a.md` are the same lock: a second acquire under any of them is refused exactly as a repeated spelling would be, and release, heartbeat, checkpoint and the lock-status read all find a lock taken under any other spelling. Previously each spelling took a row of its own, so two editors could hold "the" lock on one file at the same time and a release could find nothing to release.
+
+The canonicalisation happens in the lock service, where the row is, so a caller that never goes through the lock routes coordinates on the same identity. A path that escapes the workspace, or that would only become relative by being laundered, is refused by the lock routes with the status the file verbs already answer for that input: 400 for an unusable path, 403 for one that resolves outside the workspace.
+
+A lock row written under a raw spelling before this upgrade is not migrated or dual-matched; it expires on its own heartbeat TTL, so for one deploy an in-flight edit's lock may linger up to a minute.

--- a/packages/core-backend/src/modules/workflow/__tests__/fake-file-lock-db.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/fake-file-lock-db.ts
@@ -70,11 +70,18 @@ const TERM = /"file_locks"\."(\w+)"\s*(<=|>=|=|<|>)\s*\$(\d+)/g;
 function predicateFor(condition: SQL | undefined): (row: LockRow) => boolean {
   if (!condition) return () => true;
   const { sql: text, params } = dialect.sqlToQuery(condition);
-  const terms = [...text.matchAll(TERM)].map(([, column, operator, index]) => ({
-    field: FIELD_FOR_COLUMN[column],
-    operator,
-    value: comparable(params[Number(index) - 1]),
-  }));
+  const terms = [...text.matchAll(TERM)].map(([, column, operator, index]) => {
+    const field = FIELD_FOR_COLUMN[column];
+    // A column the regex matched but FIELD_FOR_COLUMN does not know would
+    // read `row[undefined]` as the string "undefined" and compare it against
+    // a real parameter — excluding every row, silently, which reads in a test
+    // exactly like "no lock is held". Fail closed here too, for the same
+    // reason the unmatched-reference check below fails closed.
+    if (!field) {
+      throw new Error(`fake file_locks db has no field mapped for column "${column}": ${text}`);
+    }
+    return { field, operator, value: comparable(params[Number(index) - 1]) };
+  });
   // Every clause the lock service builds is a conjunction of column
   // comparisons. A term this cannot read would silently widen the match, so
   // say so instead of quietly answering the wrong question.

--- a/packages/core-backend/src/modules/workflow/__tests__/fake-file-lock-db.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/fake-file-lock-db.ts
@@ -1,0 +1,180 @@
+/**
+ * An in-memory stand-in for the `file_locks` table, good enough to run the
+ * real `FileLockService` against.
+ *
+ * The question these tests ask is "how many lock rows does this produce, and
+ * which one does a caller find" — which a spy that only records arguments
+ * cannot answer, because the answer lives in the primary key. So this fake
+ * keeps actual rows behind the composite key `(workspace_id, branch, path)`
+ * and honours the one PostgreSQL behaviour the service leans on: an
+ * `INSERT ... ON CONFLICT DO UPDATE` whose `setWhere` does not match returns
+ * NOTHING rather than raising, which is how a live lock reads as contended.
+ *
+ * WHERE clauses are turned into predicates through drizzle's own
+ * `PgDialect.sqlToQuery`, the same public entry point the driver uses to
+ * render SQL, rather than by reaching into the condition object's internals.
+ * The rendered text is a stable, documented artifact; the internal chunk
+ * shapes are neither.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { Database } from '../../database/connection.js';
+
+export interface LockRow {
+  workspaceId: string;
+  branch: string;
+  path: string;
+  holderUserId: string;
+  holderName: string;
+  mode: string;
+  acquiredAt: Date;
+  lastHeartbeatAt: Date;
+  expiresAt: Date;
+}
+
+/** Rendered column name to the row field drizzle maps it onto. */
+const FIELD_FOR_COLUMN: Record<string, keyof LockRow> = {
+  workspace_id: 'workspaceId',
+  branch: 'branch',
+  path: 'path',
+  holder_user_id: 'holderUserId',
+  holder_name: 'holderName',
+  mode: 'mode',
+  acquired_at: 'acquiredAt',
+  last_heartbeat_at: 'lastHeartbeatAt',
+  expires_at: 'expiresAt',
+};
+
+const COMPARISONS: Record<string, (a: string, b: string) => boolean> = {
+  '=': (a, b) => a === b,
+  '<=': (a, b) => a <= b,
+  '<': (a, b) => a < b,
+  '>': (a, b) => a > b,
+  '>=': (a, b) => a >= b,
+};
+
+/**
+ * Both sides of a comparison as strings. Timestamp parameters come back from
+ * `sqlToQuery` already rendered as ISO-8601, and ISO-8601 in a fixed zone
+ * sorts chronologically, so a plain string compare gives the same answer the
+ * database would.
+ */
+function comparable(value: unknown): string {
+  return value instanceof Date ? value.toISOString() : String(value);
+}
+
+const dialect = new PgDialect();
+const TERM = /"file_locks"\."(\w+)"\s*(<=|>=|=|<|>)\s*\$(\d+)/g;
+
+function predicateFor(condition: SQL | undefined): (row: LockRow) => boolean {
+  if (!condition) return () => true;
+  const { sql: text, params } = dialect.sqlToQuery(condition);
+  const terms = [...text.matchAll(TERM)].map(([, column, operator, index]) => ({
+    field: FIELD_FOR_COLUMN[column],
+    operator,
+    value: comparable(params[Number(index) - 1]),
+  }));
+  // Every clause the lock service builds is a conjunction of column
+  // comparisons. A term this cannot read would silently widen the match, so
+  // say so instead of quietly answering the wrong question.
+  const rendered = text.replace(TERM, '');
+  if (/"file_locks"/.test(rendered)) {
+    throw new Error(`fake file_locks db cannot read this WHERE clause: ${text}`);
+  }
+  return (row) =>
+    terms.every(({ field, operator, value }) =>
+      COMPARISONS[operator](comparable(row[field]), value),
+    );
+}
+
+function keyOf(row: Pick<LockRow, 'workspaceId' | 'branch' | 'path'>): string {
+  return JSON.stringify([row.workspaceId, row.branch, row.path]);
+}
+
+export interface FakeLockDb {
+  db: Database;
+  /** Every row currently stored, in insertion order. */
+  rows: () => LockRow[];
+}
+
+export function makeFakeLockDb(): FakeLockDb {
+  const store = new Map<string, LockRow>();
+
+  const insert = () => ({
+    values: (row: LockRow) => {
+      // `null` is the absorbed conflict: a row is already there and the
+      // `setWhere` refused it, so the statement writes nothing and RETURNING
+      // comes back empty.
+      let pending: LockRow | null = { ...row };
+      const chain = {
+        onConflictDoUpdate: ({
+          set,
+          setWhere,
+        }: {
+          set: Partial<LockRow>;
+          setWhere?: SQL;
+        }) => {
+          const existing = store.get(keyOf(row));
+          if (existing) {
+            pending = predicateFor(setWhere)(existing) ? { ...existing, ...set } : null;
+          }
+          return chain;
+        },
+        returning: async (): Promise<LockRow[]> => {
+          if (pending === null) return [];
+          store.set(keyOf(pending), pending);
+          return [{ ...pending }];
+        },
+      };
+      return chain;
+    },
+  });
+
+  const select = () => ({
+    from: () => {
+      let matches: LockRow[] = [];
+      const chain = {
+        where: (condition?: SQL) => {
+          matches = [...store.values()].filter(predicateFor(condition));
+          return chain;
+        },
+        limit: async (n: number): Promise<LockRow[]> => matches.slice(0, n).map((r) => ({ ...r })),
+        then: (onF: (v: LockRow[]) => unknown, onR?: (e: unknown) => unknown) =>
+          Promise.resolve(matches.map((r) => ({ ...r }))).then(onF, onR),
+      };
+      return chain;
+    },
+  });
+
+  const update = () => ({
+    set: (patch: Partial<LockRow>) => {
+      let updated: LockRow[] = [];
+      const chain = {
+        where: (condition?: SQL) => {
+          const match = predicateFor(condition);
+          updated = [];
+          for (const [key, row] of store) {
+            if (!match(row)) continue;
+            const next = { ...row, ...patch };
+            store.set(key, next);
+            updated.push(next);
+          }
+          return chain;
+        },
+        returning: async (): Promise<LockRow[]> => updated.map((r) => ({ ...r })),
+      };
+      return chain;
+    },
+  });
+
+  const del = () => ({
+    where: async (condition?: SQL): Promise<void> => {
+      const match = predicateFor(condition);
+      for (const [key, row] of [...store]) if (match(row)) store.delete(key);
+    },
+  });
+
+  const db = { insert, select, update, delete: del } as unknown as Database;
+  return { db, rows: () => [...store.values()].map((r) => ({ ...r })) };
+}

--- a/packages/core-backend/src/modules/workflow/__tests__/file-lock.service.path-identity.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/file-lock.service.path-identity.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { AuthUser } from '@bevel-software/platform-shared';
+import { FileLockService } from '../file-lock.service.js';
+import { PathTraversalError, WorkflowValidationError } from '../../../shared/domain-errors.js';
+import { makeFakeLockDb, type FakeLockDb } from './fake-file-lock-db.js';
+
+/**
+ * A lock is only a lock if everyone agrees what it is on. `x/a.md`,
+ * `./x/a.md` and `x//a.md` are three spellings of one file, and before this
+ * each one took a row of its own: two editors could hold "the" lock on the
+ * same file at the same time and overwrite each other, and a release could
+ * find nothing to release.
+ *
+ * These tests drive the SERVICE, not the routes, on purpose. The routes are
+ * one caller among several (the agent's lock-aware filesystem and the roles
+ * admin reach the service directly), so the identity has to be decided at the
+ * row, where the coordination happens.
+ */
+
+const ALICE: AuthUser = { id: '11111111-1111-4111-8111-111111111111', email: 'alice@example.com', name: 'Alice' };
+const BOB: AuthUser = { id: '22222222-2222-4222-8222-222222222222', email: 'bob@example.com', name: 'Bob' };
+
+const WS = 'feat%2Fx';
+const BRANCH = 'feat/x';
+const CANONICAL = 'knowledge-base/x/a.md';
+/** Spellings of CANONICAL: a leading `./`, a doubled separator, and both. */
+const SPELLINGS = [
+  './knowledge-base/x/a.md',
+  'knowledge-base//x/a.md',
+  './knowledge-base//x//a.md',
+];
+
+describe('FileLockService coordinates on one canonical path', () => {
+  let fake: FakeLockDb;
+  let locks: FileLockService;
+
+  beforeEach(() => {
+    fake = makeFakeLockDb();
+    locks = new FileLockService(fake.db);
+  });
+
+  it('stores the canonical spelling even when only a raw one was ever passed', async () => {
+    // The direct-service case: nothing above canonicalised for us here.
+    const result = await locks.acquire(WS, BRANCH, './knowledge-base//x//a.md', ALICE);
+
+    expect(result.acquired).toBe(true);
+    expect(result.lock.path).toBe(CANONICAL);
+    expect(fake.rows().map((r) => r.path)).toEqual([CANONICAL]);
+  });
+
+  it.each(SPELLINGS)('a lock taken as %s refuses a second acquire spelled canonically', async (spelling) => {
+    const first = await locks.acquire(WS, BRANCH, spelling, ALICE);
+    expect(first.acquired).toBe(true);
+
+    const second = await locks.acquire(WS, BRANCH, CANONICAL, BOB);
+
+    // Refused exactly as a same-spelling re-acquire would be: not acquired,
+    // and the holder comes back so the UI can say who has it.
+    expect(second.acquired).toBe(false);
+    expect(second.lock.holderUserId).toBe(ALICE.id);
+    expect(second.lock.path).toBe(CANONICAL);
+    // ONE lock, not two.
+    expect(fake.rows()).toHaveLength(1);
+  });
+
+  it('refuses the same way when the same spelling is used twice (control)', async () => {
+    await locks.acquire(WS, BRANCH, CANONICAL, ALICE);
+    const second = await locks.acquire(WS, BRANCH, CANONICAL, BOB);
+
+    expect(second.acquired).toBe(false);
+    expect(second.lock.holderUserId).toBe(ALICE.id);
+    expect(fake.rows()).toHaveLength(1);
+  });
+
+  it('holds one lock across the branch boundary only (same path, other branch is free)', async () => {
+    await locks.acquire(WS, BRANCH, './knowledge-base//x/a.md', ALICE);
+    const other = await locks.acquire('other%2Fy', 'other/y', CANONICAL, BOB);
+
+    expect(other.acquired).toBe(true);
+    expect(fake.rows()).toHaveLength(2);
+  });
+
+  it.each(SPELLINGS)('heartbeats a canonically-taken lock spelled as %s', async (spelling) => {
+    const acquired = await locks.acquire(WS, BRANCH, CANONICAL, ALICE);
+
+    const beat = await locks.heartbeat(WS, BRANCH, spelling, ALICE);
+
+    expect(beat.path).toBe(CANONICAL);
+    expect(beat.holderUserId).toBe(ALICE.id);
+    expect(new Date(beat.expiresAt).getTime()).toBeGreaterThanOrEqual(
+      new Date(acquired.lock.expiresAt).getTime(),
+    );
+    expect(fake.rows()).toHaveLength(1);
+  });
+
+  it.each(SPELLINGS)('releases a canonically-taken lock spelled as %s', async (spelling) => {
+    await locks.acquire(WS, BRANCH, CANONICAL, ALICE);
+
+    await locks.release(WS, BRANCH, spelling, ALICE);
+
+    expect(fake.rows()).toEqual([]);
+    expect(await locks.get(WS, BRANCH, CANONICAL)).toBeNull();
+  });
+
+  it.each(SPELLINGS)('reads a canonically-taken lock spelled as %s', async (spelling) => {
+    await locks.acquire(WS, BRANCH, CANONICAL, ALICE);
+
+    const read = await locks.get(WS, BRANCH, spelling);
+
+    expect(read?.holderUserId).toBe(ALICE.id);
+    expect(read?.path).toBe(CANONICAL);
+  });
+
+  it('goes the other way too: taken raw, released and read canonically', async () => {
+    await locks.acquire(WS, BRANCH, './knowledge-base//x//a.md', ALICE);
+
+    expect((await locks.get(WS, BRANCH, CANONICAL))?.holderUserId).toBe(ALICE.id);
+    await locks.release(WS, BRANCH, CANONICAL, ALICE);
+    expect(fake.rows()).toEqual([]);
+  });
+
+  /**
+   * A path the canonicaliser refuses to touch must not become a lock row of
+   * its own. The statuses match what the file verbs answer for the same
+   * input: `WorkspaceService.withPathTurn` validates first (400) and checks
+   * workspace containment second (403).
+   */
+  describe('refuses a path the file verbs would refuse', () => {
+    const REFUSED: [string, string, new () => Error][] = [
+      ['climbs out of the workspace', '../etc/passwd', WorkflowValidationError],
+      ['climbs out from inside', 'knowledge-base/../../etc/passwd', WorkflowValidationError],
+      ['launders back inside', 'knowledge-base/x/../y.md', WorkflowValidationError],
+      ['is a bare parent', '..', WorkflowValidationError],
+      ['is the current directory', '.', WorkflowValidationError],
+      ['uses backslashes', 'knowledge-base\\x\\a.md', WorkflowValidationError],
+      ['is absolute', '/etc/passwd', PathTraversalError],
+    ];
+
+    it.each(REFUSED)('acquire refuses a path that %s', async (_why, badPath, error) => {
+      await expect(locks.acquire(WS, BRANCH, badPath, ALICE)).rejects.toBeInstanceOf(error);
+      expect(fake.rows()).toEqual([]);
+    });
+
+    it.each(REFUSED)('heartbeat refuses a path that %s', async (_why, badPath, error) => {
+      await expect(locks.heartbeat(WS, BRANCH, badPath, ALICE)).rejects.toBeInstanceOf(error);
+    });
+
+    it.each(REFUSED)('release refuses a path that %s', async (_why, badPath, error) => {
+      await locks.acquire(WS, BRANCH, CANONICAL, ALICE);
+      await expect(locks.release(WS, BRANCH, badPath, ALICE)).rejects.toBeInstanceOf(error);
+      // Nothing was deleted on the way to the refusal.
+      expect(fake.rows()).toHaveLength(1);
+    });
+
+    it.each(REFUSED)('get refuses a path that %s', async (_why, badPath, error) => {
+      await expect(locks.get(WS, BRANCH, badPath)).rejects.toBeInstanceOf(error);
+    });
+  });
+});

--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.lock-path.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.lock-path.test.ts
@@ -1,0 +1,276 @@
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { AuthUser, Change, IWorkflowService } from '@bevel-software/platform-shared';
+import type { Database } from '../../database/connection.js';
+import type { IAccessControl } from '../../access/access-control.interface.js';
+import type { AuthService } from '../../auth/auth.service.js';
+import type { WorkspaceService } from '../../workspace/workspace.service.js';
+import type { GitService } from '../git/git.service.js';
+import type { PullRequestService } from '../git/pull-request.service.js';
+import type { IReviewWorkflowService } from '../review-workflow/review-workflow.interface.js';
+import { FileLockService } from '../file-lock.service.js';
+import type { PendingCommitsService } from '../pending-commits.service.js';
+import { WorkflowEventBus } from '../event-bus.js';
+import { WorkflowService } from '../workflow.service.js';
+import { createWorkflowRoutes } from '../workflow.routes.js';
+import { makeFakeLockDb, type FakeLockDb } from './fake-file-lock-db.js';
+
+/**
+ * The lock routes over the real service and a real lock store: acquire,
+ * release, checkpoint, heartbeat and the status read all have to find the
+ * same lock whichever spelling of the file the client sends, and refuse the
+ * spellings the file verbs refuse with the same status.
+ *
+ * Wired end to end on purpose. A spy on `IWorkflowService` would only prove
+ * the routes pass a string along, and the whole question is which row that
+ * string lands on.
+ */
+
+const ALICE: AuthUser = { id: '11111111-1111-4111-8111-111111111111', email: 'alice@example.com', name: 'Alice' };
+const BOB: AuthUser = { id: '22222222-2222-4222-8222-222222222222', email: 'bob@example.com', name: 'Bob' };
+
+const WS = 'feat%2Fx';
+const BRANCH = 'feat/x'; // Deliberately not protected: no write gate in the way.
+const KB = 'knowledge-base';
+const CANONICAL = `${KB}/x/a.md`;
+const RAW = `./${KB}//x//a.md`;
+
+const CHANGE: Change = {
+  sha: 'abc1234',
+  authorName: 'Alice',
+  authorEmail: 'alice@example.com',
+  subject: 'edit a.md',
+  committedAt: '2026-04-20T00:00:00.000Z',
+};
+
+interface Harness {
+  server: Server;
+  baseUrl: string;
+  fake: FakeLockDb;
+  enqueue: ReturnType<typeof vi.fn>;
+  commitFile: ReturnType<typeof vi.fn>;
+  /** Whose credentials the next request carries. */
+  actAs: (user: AuthUser) => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const fake = makeFakeLockDb();
+  const enqueue = vi.fn().mockResolvedValue(undefined);
+  const commitFile = vi.fn().mockResolvedValue(CHANGE);
+  const git = {
+    commitFile,
+    push: vi.fn().mockResolvedValue(undefined),
+    discardPath: vi.fn().mockResolvedValue(undefined),
+  } as unknown as GitService;
+  const pending = {
+    enqueue,
+    hasLiveRowFor: vi.fn().mockResolvedValue(false),
+  } as unknown as PendingCommitsService;
+  const events = new WorkflowEventBus();
+  const workflow = new WorkflowService(
+    {} as unknown as Database,
+    git,
+    {} as PullRequestService,
+    {} as IReviewWorkflowService,
+    {} as WorkspaceService,
+    {} as IAccessControl,
+    new FileLockService(fake.db),
+    pending,
+    KB,
+    events,
+  );
+
+  let current = ALICE;
+  const authService = {
+    getUserById: vi.fn(async (id: string) => (id === BOB.id ? BOB : ALICE)),
+  } as unknown as AuthService;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api', (req, _res, next) => {
+    (req as unknown as { userId: string }).userId = current.id;
+    next();
+  });
+  app.use(
+    '/api',
+    createWorkflowRoutes(
+      workflow as unknown as IWorkflowService,
+      {} as unknown as WorkspaceService,
+      authService,
+      events,
+      {} as unknown as IAccessControl,
+      KB,
+    ),
+  );
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const addr = server.address() as AddressInfo;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    fake,
+    enqueue,
+    commitFile,
+    actAs: (user) => {
+      current = user;
+    },
+  };
+}
+
+function close(s: Server): Promise<void> {
+  return new Promise((resolve, reject) => s.close((e) => (e ? reject(e) : resolve())));
+}
+
+describe('lock routes coordinate on one file identity', () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => {
+    await close(h.server);
+  });
+
+  const url = (suffix: string) => `${h.baseUrl}/api/workspace/${WS}/workflow/locks${suffix}`;
+  const send = (method: string, suffix: string, body: unknown) =>
+    fetch(url(suffix), {
+      method,
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  const acquire = (targetPath: string) => send('POST', '', { branch: BRANCH, path: targetPath });
+  const release = (targetPath: string) => send('DELETE', '', { branch: BRANCH, path: targetPath });
+  const heartbeat = (targetPath: string) =>
+    send('POST', '/heartbeat', { branch: BRANCH, path: targetPath });
+  const checkpoint = (targetPath: string) =>
+    send('POST', '/checkpoint', { branch: BRANCH, path: targetPath });
+  const status = (targetPath: string) =>
+    fetch(
+      `${url('')}?branch=${encodeURIComponent(BRANCH)}&path=${encodeURIComponent(targetPath)}`,
+    );
+
+  it('refuses a second acquire spelled differently, as if it were the same spelling', async () => {
+    expect(await (await acquire(RAW)).json()).toMatchObject({ acquired: true });
+
+    h.actAs(BOB);
+    const second = await acquire(CANONICAL);
+
+    expect(second.status).toBe(200);
+    expect(await second.json()).toMatchObject({
+      acquired: false,
+      lock: { holderUserId: ALICE.id, path: CANONICAL },
+    });
+    expect(h.fake.rows()).toHaveLength(1);
+  });
+
+  it('heartbeats across spellings', async () => {
+    await acquire(RAW);
+
+    const beat = await heartbeat(CANONICAL);
+
+    expect(beat.status).toBe(200);
+    expect(await beat.json()).toMatchObject({ holderUserId: ALICE.id, path: CANONICAL });
+  });
+
+  it('checkpoints across spellings, and commits the canonical path', async () => {
+    await acquire(CANONICAL);
+
+    const saved = await checkpoint(RAW);
+
+    expect(saved.status).toBe(200);
+    expect(await saved.json()).toMatchObject({ change: { sha: CHANGE.sha } });
+    // The commit stages the canonical path. Handed the raw spelling, git's
+    // own pathspec guard would have refused it and the checkpoint would have
+    // failed AFTER finding the lock.
+    // Express decodes `:id`, so the service sees the branch spelling.
+    expect(h.commitFile).toHaveBeenCalledWith(BRANCH, ALICE, CANONICAL, undefined);
+    // Checkpoint keeps the lock.
+    expect(h.fake.rows()).toHaveLength(1);
+  });
+
+  it('releases across spellings, and queues the commit for the canonical path', async () => {
+    await acquire(RAW);
+
+    const released = await release(CANONICAL);
+
+    expect(released.status).toBe(200);
+    expect(await released.json()).toEqual({ queued: true });
+    expect(h.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ branch: BRANCH, path: CANONICAL }),
+    );
+    expect(h.fake.rows()).toEqual([]);
+  });
+
+  it('releases the other way round too: taken canonically, released raw', async () => {
+    await acquire(CANONICAL);
+
+    expect((await release(RAW)).status).toBe(200);
+    expect(h.fake.rows()).toEqual([]);
+  });
+
+  it('reads the lock status across spellings', async () => {
+    await acquire(RAW);
+
+    const read = await status(CANONICAL);
+
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({
+      lock: { holderUserId: ALICE.id, path: CANONICAL },
+    });
+  });
+
+  it('reads the status of a raw spelling after a canonical acquire', async () => {
+    await acquire(CANONICAL);
+
+    expect(await (await status(RAW)).json()).toMatchObject({
+      lock: { holderUserId: ALICE.id, path: CANONICAL },
+    });
+  });
+
+  /**
+   * Same statuses `PUT /file` answers for these inputs: 400 for a path that
+   * is not usable as a workspace-relative path, 403 for one that resolves
+   * outside the workspace. See `canonical-file-identity.test.ts`, which pins
+   * that equivalence input by input.
+   */
+  describe('refuses the paths the file verbs refuse', () => {
+    const REFUSED: [string, string, number][] = [
+      ['climbs out', '../etc/passwd', 400],
+      ['climbs out from inside', `${KB}/../../etc/passwd`, 400],
+      ['launders back inside', `${KB}/x/../y.md`, 400],
+      ['uses backslashes', `${KB}\\x\\a.md`, 400],
+      ['is absolute', '/etc/passwd', 403],
+    ];
+
+    it.each(REFUSED)('acquire refuses a path that %s', async (_why, badPath, expected) => {
+      expect((await acquire(badPath)).status).toBe(expected);
+      expect(h.fake.rows()).toEqual([]);
+    });
+
+    it.each(REFUSED)('release refuses a path that %s', async (_why, badPath, expected) => {
+      expect((await release(badPath)).status).toBe(expected);
+      expect(h.enqueue).not.toHaveBeenCalled();
+    });
+
+    it.each(REFUSED)('heartbeat refuses a path that %s', async (_why, badPath, expected) => {
+      expect((await heartbeat(badPath)).status).toBe(expected);
+    });
+
+    it.each(REFUSED)('checkpoint refuses a path that %s', async (_why, badPath, expected) => {
+      expect((await checkpoint(badPath)).status).toBe(expected);
+      expect(h.commitFile).not.toHaveBeenCalled();
+    });
+
+    it.each(REFUSED)('the status read refuses a path that %s', async (_why, badPath, expected) => {
+      expect((await status(badPath)).status).toBe(expected);
+    });
+
+    it('answers an absolute path with the file verbs\' own wording', async () => {
+      const refused = await acquire('/etc/passwd');
+      expect(await refused.json()).toMatchObject({ error: 'Path traversal detected' });
+    });
+  });
+});

--- a/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.lock-path.test.ts
+++ b/packages/core-backend/src/modules/workflow/__tests__/workflow.routes.lock-path.test.ts
@@ -243,6 +243,11 @@ describe('lock routes coordinate on one file identity', () => {
       ['launders back inside', `${KB}/x/../y.md`, 400],
       ['uses backslashes', `${KB}\\x\\a.md`, 400],
       ['is absolute', '/etc/passwd', 403],
+      // Absolute, but spelled to look contained under the stand-in root
+      // `canonicalFileIdentity` resolves against. A real workspace directory
+      // is `<workspacesRoot>/<id>`, so `PUT /file` resolves this outside it
+      // and answers 403.
+      ['is absolute under a workspace-looking root', '/workspace/a.md', 403],
     ];
 
     it.each(REFUSED)('acquire refuses a path that %s', async (_why, badPath, expected) => {
@@ -271,6 +276,28 @@ describe('lock routes coordinate on one file identity', () => {
     it('answers an absolute path with the file verbs\' own wording', async () => {
       const refused = await acquire('/etc/passwd');
       expect(await refused.json()).toMatchObject({ error: 'Path traversal detected' });
+    });
+
+    /**
+     * A truthy non-string `path` clears the routes' own `!targetPath` guard,
+     * so the service is what has to refuse it. `PUT /file` answers 400 (its
+     * `requestPath` type-guards before canonicalising); unguarded, the
+     * canonicaliser would call `.startsWith` on the number and the resulting
+     * `TypeError` would leave here as a 500.
+     */
+    it('refuses a truthy non-string path with 400 on every lock route', async () => {
+      const body = { branch: BRANCH, path: 123 };
+      const responses = await Promise.all([
+        send('POST', '', body),
+        send('DELETE', '', body),
+        send('POST', '/heartbeat', body),
+        send('POST', '/checkpoint', body),
+      ]);
+
+      expect(responses.map((r) => r.status)).toEqual([400, 400, 400, 400]);
+      expect(h.fake.rows()).toEqual([]);
+      expect(h.enqueue).not.toHaveBeenCalled();
+      expect(h.commitFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core-backend/src/modules/workflow/file-lock.service.ts
+++ b/packages/core-backend/src/modules/workflow/file-lock.service.ts
@@ -11,6 +11,24 @@
  * is the source of truth and any cache would lose its purpose the moment
  * a different replica takes over.
  *
+ * Path identity: every method here canonicalises the path it was handed
+ * before it touches a row, so `./x//a.md` and `x/a.md` are ONE lock no
+ * matter which caller spelled which. It happens HERE rather than in the
+ * routes because the lock row is the coordination point: the routes are only
+ * today's callers, and a caller that reaches this service directly (the
+ * agent's lock-aware filesystem, a future route family) has to land on the
+ * same identity or it is not coordinating with anyone. Canonicalisation also
+ * REFUSES a path that escapes the workspace or that only looks relative, with
+ * the statuses the file verbs answer for the same input, so a lock row can
+ * never be keyed on a path no file verb would accept. See
+ * `canonicalFileIdentity`.
+ *
+ * There is no transition handling for rows written under a raw spelling
+ * before this landed: such a row is now unreachable by name and expires on
+ * its own TTL. For one deploy an in-flight edit's lock can linger up to the
+ * TTL below; nothing migrates and nothing dual-matches, because a dual match
+ * would be a second identity and the whole point is that there is one.
+ *
  * Stale-lock semantics: `get`, `acquire`, and `heartbeat` all treat a row
  * with `expires_at <= now()` as if the lock didn't exist. We purge it
  * lazily on next access rather than running a sweeper — the row count is
@@ -22,6 +40,7 @@ import type { Database } from '../database/connection.js';
 import { fileLocks } from '../database/schema.js';
 import type { AcquireLockResult, AuthUser, FileLock } from '@bevel-software/platform-shared';
 import { WorkflowValidationError } from '../../shared/domain-errors.js';
+import { canonicalFileIdentity } from '../../shared/canonical-file-identity.js';
 
 /**
  * Lock lifetime without a heartbeat. The client is expected to heartbeat
@@ -73,10 +92,11 @@ export class FileLockService {
   async acquire(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
     opts?: { coordination?: boolean },
   ): Promise<AcquireLockResult> {
+    const targetPath = canonicalFileIdentity(rawPath);
     const now = new Date();
     const expiresAt = new Date(now.getTime() + LOCK_TTL_MS);
 
@@ -175,9 +195,10 @@ export class FileLockService {
   async heartbeat(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<FileLock> {
+    const targetPath = canonicalFileIdentity(rawPath);
     const now = new Date();
     const expiresAt = new Date(now.getTime() + LOCK_TTL_MS);
     // The expiry guard (`expiresAt > now`) matters because an expired
@@ -221,9 +242,10 @@ export class FileLockService {
   async release(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<void> {
+    const targetPath = canonicalFileIdentity(rawPath);
     await this.db
       .delete(fileLocks)
       .where(
@@ -244,8 +266,9 @@ export class FileLockService {
   async get(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
   ): Promise<FileLock | null> {
+    const targetPath = canonicalFileIdentity(rawPath);
     const rows = await this.db
       .select()
       .from(fileLocks)

--- a/packages/core-backend/src/modules/workflow/workflow.routes.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.routes.ts
@@ -420,6 +420,14 @@ export function createWorkflowRoutes(
 
   // ── File locks ────────────────────────────────────────────────────────────
 
+  // These routes hand the caller's spelling straight to the workflow service,
+  // which is where ONE file identity is decided (`canonicalFileIdentity`), so
+  // `./x//a.md` and `x/a.md` are the same lock on every verb below. Refusals
+  // arrive here as `WorkflowDomainError`s carrying the status the file verbs
+  // answer for that same input, and `toHttpError` passes it through unchanged.
+  // Nothing is canonicalised at this layer on purpose: a route-level fix would
+  // leave any other caller of the service coordinating on its own identity.
+
   router.post('/workspace/:id/workflow/locks', async (req, res) => {
     const user = await requireUser(req, res);
     if (!user) return;

--- a/packages/core-backend/src/modules/workflow/workflow.service.ts
+++ b/packages/core-backend/src/modules/workflow/workflow.service.ts
@@ -54,6 +54,7 @@ import type { WorkspaceService } from '../workspace/workspace.service.js';
 import { workspaceIdForBranch, branchForWorkspaceId } from '../../shared/workspace-id.js';
 import type { IAccessControl } from '../access/access-control.interface.js';
 import { FileLockService } from './file-lock.service.js';
+import { canonicalFileIdentity } from '../../shared/canonical-file-identity.js';
 import { PendingCommitsService } from './pending-commits.service.js';
 import type { WorkflowEventBus } from './event-bus.js';
 import { sanitizeError } from './sanitize-error.js';
@@ -865,13 +866,26 @@ export class WorkflowService implements IWorkflowService {
 
   // ── File locks ────────────────────────────────────────────────────────────
 
+  // Every method below canonicalises the caller's spelling into ONE file
+  // identity before it does anything with it. `FileLockService` canonicalises
+  // too, and has to: it is the coordination point and a caller can reach it
+  // without coming through here. The reason to do it again at this layer is
+  // that the path does not only key a lock row here. It is also what the
+  // permission gate is evaluated against, what `commitFile` stages, what the
+  // commit queue enqueues, and what rides out on every `lock-*` event. Left
+  // raw, a checkpoint on `./x//a.md` would find its lock and then fail at the
+  // commit, and a release would enqueue a row the worker keys differently from
+  // the lock it just dropped. Canonicalising is idempotent, so the second pass
+  // inside the lock service is free.
+
   async acquireLock(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
     opts?: { coordination?: boolean },
   ): Promise<AcquireLockResult> {
+    const targetPath = canonicalFileIdentity(rawPath);
     // **Permission check at lock acquisition, not at commit time.** Under the
     // "disk is the source of truth" rule, once a write has landed on disk we
     // must never reject the commit that publishes it — otherwise we'd be
@@ -930,9 +944,10 @@ export class WorkflowService implements IWorkflowService {
   async heartbeatLock(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<FileLock> {
+    const targetPath = canonicalFileIdentity(rawPath);
     try {
       const lock = await this.fileLocks.heartbeat(workspaceId, branch, targetPath, user);
       console.log(
@@ -957,10 +972,11 @@ export class WorkflowService implements IWorkflowService {
   async commitFileWhileLocked(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
     summary?: string,
   ): Promise<Change | null> {
+    const targetPath = canonicalFileIdentity(rawPath);
     const lock = await this.fileLocks.get(workspaceId, branch, targetPath);
     if (!lock || lock.holderUserId !== user.id) {
       throw new WorkflowValidationError(
@@ -1084,9 +1100,10 @@ export class WorkflowService implements IWorkflowService {
   async releaseLock(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<void> {
+    const targetPath = canonicalFileIdentity(rawPath);
     // Ownership check — the lock service's `release` is idempotent and
     // would silently no-op for a non-holder, but we'd still enqueue a
     // commit attributed to whoever called us. The guard rejects callers
@@ -1399,9 +1416,10 @@ export class WorkflowService implements IWorkflowService {
   async releaseLockNoCommit(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<void> {
+    const targetPath = canonicalFileIdentity(rawPath);
     // Verify ownership first so the emit only fires when something
     // observable actually changed. `fileLocks.release` silently no-ops
     // when the caller doesn't hold the row (idempotent-by-design), so
@@ -1504,9 +1522,10 @@ export class WorkflowService implements IWorkflowService {
   async releaseLockUntouched(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
     user: AuthUser,
   ): Promise<void> {
+    const targetPath = canonicalFileIdentity(rawPath);
     console.log(
       `[lock] RELEASE-UNTOUCHED start ws=${workspaceId} branch=${branch} path=${targetPath} user=${user.id}`,
     );
@@ -1542,9 +1561,9 @@ export class WorkflowService implements IWorkflowService {
   getLock(
     workspaceId: string,
     branch: string,
-    targetPath: string,
+    rawPath: string,
   ): Promise<FileLock | null> {
-    return this.fileLocks.get(workspaceId, branch, targetPath);
+    return this.fileLocks.get(workspaceId, branch, canonicalFileIdentity(rawPath));
   }
 
   // ── Change Requests ───────────────────────────────────────────────────────

--- a/packages/core-backend/src/modules/workspace/__tests__/workspace.service.test.ts
+++ b/packages/core-backend/src/modules/workspace/__tests__/workspace.service.test.ts
@@ -408,6 +408,13 @@ describe('WorkspaceService.withPathTurn', () => {
       order.push(`${name}:exit`);
     };
 
+    // Warm the workspace lookup first, for the reason the next test gives:
+    // a COLD lookup resolves its callers in disk order rather than call
+    // order, so `b` can reach the queue first and this assertion — which
+    // names `a` as the one that goes first — fails for a scheduling reason
+    // rather than an interleaving one.
+    await svc.withPathTurn(workspaceId, 'knowledge-base/mcp-description.md', async () => undefined);
+
     await Promise.all([
       svc.withPathTurn(workspaceId, 'knowledge-base/mcp-description.md', body('a')),
       svc.withPathTurn(workspaceId, 'knowledge-base/mcp-description.md', body('b')),

--- a/packages/core-backend/src/shared/__tests__/canonical-file-identity.test.ts
+++ b/packages/core-backend/src/shared/__tests__/canonical-file-identity.test.ts
@@ -97,6 +97,32 @@ describe('canonicalFileIdentity', () => {
     expect(() => canonicalFileIdentity('/etc/passwd')).toThrow(PathTraversalError);
   });
 
+  it('refuses an absolute path that the containment stand-in would call contained', () => {
+    // The trap the stand-in root sets for itself: `validateRelativePath`
+    // accepts `/workspace/a.md`, and resolving it against `/workspace`
+    // lands it inside `/workspace` — so containment alone reads it as fine
+    // and it becomes a lock identity. No real workspace directory is ever
+    // literally `/workspace` (it is `<workspacesRoot>/<id>`), so the file
+    // verbs resolve that same path outside their workspace and answer 403.
+    expect(() => canonicalFileIdentity('/workspace/a.md')).toThrow(PathTraversalError);
+    expect(() => canonicalFileIdentity('/workspace')).toThrow(PathTraversalError);
+  });
+
+  it('refuses a non-string path as the client mistake it is, not as a 500', () => {
+    // The routes' guard only tests falsiness, so `{"path": 123}` reaches
+    // here. Unguarded, `canonicalRelativePath` calls `.startsWith` on a
+    // number and the bare `TypeError` becomes a 500; `PUT /file` answers
+    // 400 for that same body.
+    for (const notAPath of [123, true, {}, [], ['a.md'], null, undefined]) {
+      expect(() => canonicalFileIdentity(notAPath as unknown as string)).toThrow(
+        WorkflowValidationError,
+      );
+      expect(() => canonicalFileIdentity(notAPath as unknown as string)).toThrow(
+        'Invalid path: Path is required',
+      );
+    }
+  });
+
   const INPUTS = [
     ONE_FILE,
     `./${ONE_FILE}`,
@@ -111,6 +137,11 @@ describe('canonicalFileIdentity', () => {
     '.',
     './',
     '/etc/passwd',
+    // Absolute, but spelled to look contained under the stand-in root the
+    // implementation resolves against.
+    '/workspace/a.md',
+    '/workspace',
+    '/workspace/',
     '/',
     'knowledge-base\\x\\a.md',
     'C:/Windows/system32',

--- a/packages/core-backend/src/shared/__tests__/canonical-file-identity.test.ts
+++ b/packages/core-backend/src/shared/__tests__/canonical-file-identity.test.ts
@@ -1,0 +1,123 @@
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { assertValidRelativePath } from '@bevel-software/platform-shared';
+import { canonicalFileIdentity } from '../canonical-file-identity.js';
+import { PathTraversalError, WorkflowValidationError } from '../domain-errors.js';
+
+/**
+ * Two properties, and the second is the one worth the file.
+ *
+ * 1. Spellings of one file collapse to one string.
+ * 2. A path the canonicaliser refuses gets the SAME answer the file verbs
+ *    give for that input. The lock routes and `PUT /file` name the same
+ *    file and take the same lock, so answering differently would mean a path
+ *    the editor cannot save to is nonetheless lockable, or the reverse.
+ *
+ * The oracle for (2) is not a hand-written status table. It runs the guard
+ * pair `WorkspaceService.withPathTurn` runs, in its order: the shared
+ * `assertValidRelativePath`, whose `Invalid path: ...` message
+ * `workspace.routes.sendError` maps to 400, then resolution against the
+ * workspace directory, whose `Path traversal detected`
+ * `sendError` maps to 403. The validator is the real one, imported, so a
+ * change to what it accepts moves both sides of the comparison at once.
+ */
+
+const WORKSPACE_DIR = path.resolve('/srv/workspaces/feat%2Fx');
+
+/** The status `PUT /file` answers for `candidate`, or 0 when it accepts it. */
+function fileVerbStatus(candidate: string): number {
+  try {
+    assertValidRelativePath(candidate);
+  } catch {
+    return 400; // `sendError`: a message starting with "Invalid path".
+  }
+  // `WorkspaceService.assertWithinWorkspace`, verbatim.
+  const resolved = path.resolve(WORKSPACE_DIR, candidate);
+  if (!resolved.startsWith(WORKSPACE_DIR + path.sep) && resolved !== WORKSPACE_DIR) {
+    return 403; // `sendError`: the message "Path traversal detected".
+  }
+  return 0;
+}
+
+/** The status the lock surface answers for `candidate`, or 0 when accepted. */
+function lockStatus(candidate: string): number {
+  try {
+    canonicalFileIdentity(candidate);
+    return 0;
+  } catch (err) {
+    return (err as { status: number }).status;
+  }
+}
+
+const ONE_FILE = 'knowledge-base/x/a.md';
+
+describe('canonicalFileIdentity', () => {
+  it.each([
+    ONE_FILE,
+    `./${ONE_FILE}`,
+    'knowledge-base//x/a.md',
+    './knowledge-base//x//a.md',
+    'knowledge-base/x//a.md',
+  ])('reads %s as one file', (spelling) => {
+    expect(canonicalFileIdentity(spelling)).toBe(ONE_FILE);
+  });
+
+  it('is idempotent', () => {
+    const once = canonicalFileIdentity('./knowledge-base//x//a.md');
+    expect(canonicalFileIdentity(once)).toBe(once);
+  });
+
+  it('leaves case alone: on Linux Foo.md and foo.md are two files', () => {
+    expect(canonicalFileIdentity('knowledge-base/Foo.md')).toBe('knowledge-base/Foo.md');
+    expect(canonicalFileIdentity('knowledge-base/Foo.md')).not.toBe(
+      canonicalFileIdentity('knowledge-base/foo.md'),
+    );
+  });
+
+  it('refuses a path that climbs out rather than resolving it away', () => {
+    expect(() => canonicalFileIdentity('../etc/passwd')).toThrow(WorkflowValidationError);
+    expect(() => canonicalFileIdentity('knowledge-base/../../etc/passwd')).toThrow(
+      WorkflowValidationError,
+    );
+  });
+
+  it('refuses a climb that would land back inside, instead of laundering it', () => {
+    // `knowledge-base/x/../y.md` resolves inside the workspace, so a
+    // containment check alone would wave it through under a second identity
+    // for `knowledge-base/y.md`.
+    expect(() => canonicalFileIdentity('knowledge-base/x/../y.md')).toThrow(
+      WorkflowValidationError,
+    );
+  });
+
+  it('refuses an absolute path as traversal, not as a relative one', () => {
+    // Dropping the empty leading segment would turn `/etc/passwd` into the
+    // perfectly ordinary `etc/passwd`, which is exactly the laundering
+    // `canonicalRelativePath` declines to do.
+    expect(() => canonicalFileIdentity('/etc/passwd')).toThrow(PathTraversalError);
+  });
+
+  const INPUTS = [
+    ONE_FILE,
+    `./${ONE_FILE}`,
+    'knowledge-base//x/a.md',
+    'knowledge-base/Some [Approved] Node.md',
+    '../etc/passwd',
+    '../../etc/passwd',
+    'knowledge-base/../../etc/passwd',
+    'knowledge-base/x/../y.md',
+    './..',
+    '..',
+    '.',
+    './',
+    '/etc/passwd',
+    '/',
+    'knowledge-base\\x\\a.md',
+    'C:/Windows/system32',
+    '',
+  ];
+
+  it.each(INPUTS)('answers %j with the status the file verbs answer', (input) => {
+    expect(lockStatus(input)).toBe(fileVerbStatus(input));
+  });
+});

--- a/packages/core-backend/src/shared/canonical-file-identity.ts
+++ b/packages/core-backend/src/shared/canonical-file-identity.ts
@@ -1,0 +1,66 @@
+/**
+ * ONE canonical identity for a workspace file, plus the refusals the file
+ * verbs already answer with, as a single throwing call.
+ *
+ * `canonicalRelativePath` (in `@bevel-software/platform-shared`) collapses the
+ * spellings of one file: `x/a.md`, `./x/a.md` and `x//a.md` are the same file
+ * and all three become `x/a.md`. What it deliberately does NOT do is launder:
+ * a path it cannot canonicalise comes back UNCHANGED, so every gate downstream
+ * still sees what the caller actually sent. That leaves the caller holding an
+ * un-refused path, which is fine for `PUT /file` (the workspace service's own
+ * guards run right after) and wrong for anything that coordinates on the path
+ * WITHOUT ever touching disk. The file-lock service is exactly that: nothing
+ * below it resolves the path against a workspace directory, so a spelling that
+ * escapes or launders would quietly become a lock row of its own.
+ *
+ * This helper is therefore the canonicaliser AND the refusal, in the order the
+ * file verbs run them, so both surfaces answer the same thing for the same
+ * input:
+ *
+ *   1. `validateRelativePath` refuses `.`/`..`/empty segments and backslashes.
+ *      `WorkspaceService.withPathTurn` runs the same check first (via the
+ *      shared `assertValidRelativePath`) and its `Invalid path: ...` message
+ *      is what `workspace.routes.sendError` turns into a 400. Same message
+ *      here, raised as a 400 `WorkflowValidationError`.
+ *   2. Containment. `withPathTurn` then resolves the path against the
+ *      workspace directory and refuses anything landing outside it, which
+ *      `sendError` turns into a 403. Step 1 has already rejected every `..`,
+ *      so the only spelling that can still escape is an absolute one, and
+ *      resolving against a stand-in root decides it without needing a real
+ *      workspace on disk.
+ *
+ * Case is left alone, for the reason `canonicalRelativePath` documents: the
+ * deployment target is Linux, where `Foo.md` and `foo.md` are two files.
+ */
+
+import path from 'node:path';
+import { canonicalRelativePath, validateRelativePath } from '@bevel-software/platform-shared';
+import { PathTraversalError, WorkflowValidationError } from './domain-errors.js';
+
+/**
+ * Stand-in for the workspace directory. Only the containment VERDICT matters
+ * here, and that verdict is the same under any absolute root: a relative path
+ * stays under it, an absolute one wins over it. POSIX resolution because
+ * workspace paths are `/`-separated on every platform we run on.
+ */
+const CONTAINMENT_ROOT = '/workspace';
+
+/**
+ * The canonical spelling of `targetPath`, or a throw carrying the status the
+ * file verbs answer with for that same input.
+ *
+ * @throws {WorkflowValidationError} 400, when the path is not a usable
+ *   workspace-relative path (a `.` or `..` segment, a backslash, empty).
+ * @throws {PathTraversalError} 403, when the path resolves outside the
+ *   workspace (an absolute path).
+ */
+export function canonicalFileIdentity(targetPath: string): string {
+  const canonical = canonicalRelativePath(targetPath);
+  const reason = validateRelativePath(canonical);
+  if (reason) throw new WorkflowValidationError(`Invalid path: ${reason}`);
+  const resolved = path.posix.resolve(CONTAINMENT_ROOT, canonical);
+  if (resolved !== CONTAINMENT_ROOT && !resolved.startsWith(`${CONTAINMENT_ROOT}/`)) {
+    throw new PathTraversalError();
+  }
+  return canonical;
+}

--- a/packages/core-backend/src/shared/canonical-file-identity.ts
+++ b/packages/core-backend/src/shared/canonical-file-identity.ts
@@ -25,9 +25,15 @@
  *   2. Containment. `withPathTurn` then resolves the path against the
  *      workspace directory and refuses anything landing outside it, which
  *      `sendError` turns into a 403. Step 1 has already rejected every `..`,
- *      so the only spelling that can still escape is an absolute one, and
- *      resolving against a stand-in root decides it without needing a real
- *      workspace on disk.
+ *      so the only spelling that can still escape is an absolute one — and an
+ *      absolute path is refused AS one, before any stand-in root is resolved
+ *      against, because a stand-in cannot decide it: `/workspace/a.md`
+ *      resolves to INSIDE the stand-in and would read as contained, while the
+ *      real workspace directory is `<workspacesRoot>/<id>` and never
+ *      literally `/workspace`, so the file verbs resolve that same path
+ *      outside their workspace and answer 403. Left to the stand-in are only
+ *      the relative spellings, which it decides without a real workspace on
+ *      disk.
  *
  * Case is left alone, for the reason `canonicalRelativePath` documents: the
  * deployment target is Linux, where `Foo.md` and `foo.md` are two files.
@@ -47,10 +53,13 @@ import { canonicalRelativePath, validateRelativePath } from '@bevel-software/pla
 import { PathTraversalError, WorkflowValidationError } from './domain-errors.js';
 
 /**
- * Stand-in for the workspace directory. Only the containment VERDICT matters
- * here, and that verdict is the same under any absolute root: a relative path
- * stays under it, an absolute one wins over it. POSIX resolution because
- * workspace paths are `/`-separated on every platform we run on.
+ * Stand-in for the workspace directory, deciding containment for the RELATIVE
+ * spellings only. Their verdict is the same under any absolute root, which is
+ * what lets a stand-in stand in at all. An absolute spelling is NOT its
+ * business — under this root `/workspace/a.md` looks contained and under any
+ * other root it does not — so that one is refused before we get here. POSIX
+ * resolution because workspace paths are `/`-separated on every platform we
+ * run on.
  */
 const CONTAINMENT_ROOT = '/workspace';
 
@@ -59,14 +68,35 @@ const CONTAINMENT_ROOT = '/workspace';
  * file verbs answer with for that same input.
  *
  * @throws {WorkflowValidationError} 400, when the path is not a usable
- *   workspace-relative path (a `.` or `..` segment, a backslash, empty).
+ *   workspace-relative path (not a string at all, a `.` or `..` segment, a
+ *   backslash, empty).
  * @throws {PathTraversalError} 403, when the path resolves outside the
  *   workspace (an absolute path).
  */
 export function canonicalFileIdentity(targetPath: string): string {
+  // A JSON body can hold anything and the lock routes' own guard only tests
+  // falsiness, so a truthy non-string (`{"path": 123}`) arrives here. The
+  // canonicaliser calls `.startsWith` on it and throws a bare `TypeError`,
+  // which `toHttpError` can only read as a 500 — for what is a client
+  // mistake. `PUT /file` answers 400 for that same body (its `requestPath`
+  // type-guards before canonicalising), and this surface answers what that one
+  // answers. The message is the validator's own for a non-string, so the two
+  // 400s read identically as well.
+  if (typeof targetPath !== 'string') {
+    throw new WorkflowValidationError('Invalid path: Path is required');
+  }
   const canonical = canonicalRelativePath(targetPath);
   const reason = validateRelativePath(canonical);
   if (reason) throw new WorkflowValidationError(`Invalid path: ${reason}`);
+  // Absolute first, and on its own terms: `validateRelativePath` ACCEPTS
+  // `/workspace/a.md` (its leading empty segment is filtered out, leaving two
+  // ordinary segments), and resolving that against CONTAINMENT_ROOT lands it
+  // inside the root, so the containment check below would call it contained.
+  // A workspace-relative path is never absolute; refuse it as the escape the
+  // file verbs treat it as.
+  if (path.posix.isAbsolute(canonical)) {
+    throw new PathTraversalError();
+  }
   const resolved = path.posix.resolve(CONTAINMENT_ROOT, canonical);
   if (resolved !== CONTAINMENT_ROOT && !resolved.startsWith(`${CONTAINMENT_ROOT}/`)) {
     throw new PathTraversalError();

--- a/packages/core-backend/src/shared/canonical-file-identity.ts
+++ b/packages/core-backend/src/shared/canonical-file-identity.ts
@@ -31,6 +31,15 @@
  *
  * Case is left alone, for the reason `canonicalRelativePath` documents: the
  * deployment target is Linux, where `Foo.md` and `foo.md` are two files.
+ *
+ * What this deliberately does NOT answer is whether the path reaches its file
+ * through a symbolic link. That question is about what is on disk, not about
+ * how the path is spelled, and it is answered where the disk is:
+ * `WorkspaceService.assertNotThroughLink`, on the verbs that read and write
+ * bytes. A lock row is a coordination key and the lock service holds no
+ * workspace directory to resolve against, so a link can only change which
+ * bytes a WRITE touches, and that write is refused by the verb that performs
+ * it while the lock is merely held.
  */
 
 import path from 'node:path';

--- a/packages/core-backend/src/shared/domain-errors.ts
+++ b/packages/core-backend/src/shared/domain-errors.ts
@@ -196,6 +196,28 @@ export function isMissingRemoteBranchFailure(message: string): boolean {
 }
 
 /**
+ * The caller named a path that resolves outside the workspace it was asked
+ * for. In practice that means an absolute path: a `..` climb is refused one
+ * step earlier, as an invalid path, by the same validator the file verbs run
+ * first.
+ *
+ * 403 carrying the exact message the file verbs answer, because
+ * `WorkspaceService.assertWithinWorkspace` throws a bare `Error` with this
+ * text and `workspace.routes.sendError` maps that text to 403. The lock
+ * service raises this instead of a bare `Error`, because `toHttpError` on the
+ * workflow routes reads the status off the class and would otherwise call it
+ * a 500. Both surfaces then answer identically for the same input. See
+ * `canonicalFileIdentity`.
+ */
+export class PathTraversalError extends WorkflowDomainError {
+  readonly kind = 'path-traversal' as const;
+  constructor() {
+    super('Path traversal detected', 403, { kind: 'path-traversal' });
+    this.name = 'PathTraversalError';
+  }
+}
+
+/**
  * Generic 400 for workflow-input validation (malformed branch names, missing
  * fields, etc.). Carries an optional payload so callers can attach typed
  * discriminators (`kind: '...'`) when the frontend needs to switch on the

--- a/packages/shared/src/workflow/interface.ts
+++ b/packages/shared/src/workflow/interface.ts
@@ -225,6 +225,14 @@ export interface IWorkflowService {
 
   // ── File locks (new — currently NotImplementedWorkflowError) ──────────────
 
+  // Every lock method below coordinates on ONE canonical identity per file:
+  // `x/a.md`, `./x/a.md` and `x//a.md` name the same lock, so a lock acquired
+  // under any of them is contended, heartbeated, checkpointed, released and
+  // read under any other. A path that escapes the workspace, or that only
+  // becomes relative by being laundered, is refused with the same status the
+  // file verbs answer for that input: 400 for an unusable path, 403 for one
+  // that resolves outside the workspace.
+
   /**
    * Try to acquire an edit lock on `(branch, path)` for the caller. Returns
    * `{ acquired: true, lock }` on success; `{ acquired: false, lock }` if


### PR DESCRIPTION
Ticket: `hx-lock-path-identity` — Data/Engineering/Knowledge/Hexis/Tickets/Lock-Path-Canonical-Identity.md

## Summary

The file verbs (open, save, delete, move) canonicalize a path's spelling before coordinating (PR #172), but the explicit lock lifecycle did not: all five lock routes (acquire, release, checkpoint, heartbeat, status) handed the client's raw spelling straight to `FileLockService`, which keyed rows on that raw string. Two spellings of one file (`x/a.md`, `./x//a.md`, …) were therefore two independent lock rows — two editors could both believe they held the file exclusively.

This change canonicalizes every key the lock service stores or looks up, in the service itself (not just the routes), so all five routes — and any future caller that bypasses the routes — coordinate on one identity per file, the same identity the file verbs use.

- Acquire/acquire across spellings is now ONE lock; the second acquire is refused exactly as a repeated spelling would be.
- Release, heartbeat, checkpoint and status each find the lock regardless of which spelling locked it.
- A path that escapes the workspace or launders through canonicalization is refused by the lock routes with the same status `PUT /file` uses for the same input (the verb that takes the same lock — see reviewer note on file-verb status divergence below).
- No migration/dual-matching for pre-existing lock rows: a row stored under a raw spelling before this upgrade is unreachable by its old name and simply expires by its own heartbeat TTL (accepted consequence: an in-flight edit's lock may linger up to one TTL window after deploy).

## New files
- `packages/core-backend/src/shared/canonical-file-identity.ts`
- `packages/core-backend/src/shared/__tests__/canonical-file-identity.test.ts`
- `packages/core-backend/src/modules/workflow/__tests__/fake-file-lock-db.ts`
- `packages/core-backend/src/modules/workflow/__tests__/file-lock.service.path-identity.test.ts`
- `packages/core-backend/src/modules/workflow/__tests__/workflow.routes.lock-path.test.ts`
- `.changeset/lock-path-canonical-identity.md`

## Testing
- `pnpm --filter @bevel-software/platform-core-backend test`: 208 files / 2602 tests passing, 0 failed (66.6s), including the three new test files above.
- Full build-from-source docker compose boot against real Postgres at commit `e4b206aa` (`/api/health` sha-verified): acquire across spellings is one row keyed canonically; release/heartbeat/checkpoint/status each found the lock from the other spelling in both directions; checkpoint on a raw spelling committed under the canonical path and the commit reached the remote; all five lock routes matched `PUT /file`'s status/body for five refused inputs (traversal, absolute path, laundering); a legacy row seeded under a raw spelling did not dual-match and was left to expire by TTL.

## Reviewer notes
1. The file verbs disagree among themselves on refusal status for the same bad input (`PUT` 400 vs `GET`/`DELETE` 403 for `..`; `PUT` 400 vs `GET` 404 vs `DELETE` 400 for a laundering `x/../y.md`). The lock routes were matched to `PUT /file` — the verb that takes the same lock.
2. Pre-existing and **not** fixed here: `GET /file` launders `kb/x/../y.md` to `kb/y.md` and returns 404, evaluating the read gate on a different spelling than the one requested. This deserves its own ticket (filed as a follow-up) — out of scope for this branch, which does not touch `workspace.routes.ts`.
3. The symlink guard (`assertNotThroughLink`) added upstream stays scoped to the disk-touching verbs; documented as a boundary in `canonical-file-identity.ts` rather than pulled into the lock service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
File locks now key on one canonical path identity, so `x/a.md`, `./x/a.md`, and `x//a.md` are the same lock. Previously each spelling created its own lock row, letting two editors hold the same file exclusively at once.

**Lock behavior**
- Canonicalization lives in `FileLockService`, so callers that reach it without going through the routes coordinate on the same identity too.
- All five lock routes — acquire, release, heartbeat, checkpoint, status — find a lock taken under another spelling, and a second acquire is refused exactly as a repeated spelling would be.
- Paths the file verbs refuse get the same status here: 400 for an unusable path (including a non-string `path`, now 400 instead of 500), 403 for one that escapes the workspace — including absolute paths a containment check alone would read as contained.
- Pre-existing lock rows stored under a raw spelling aren't migrated or matched; they expire on their own heartbeat TTL, so an in-flight lock may linger up to one TTL window after deploy.

<sup>Written for commit fe8d83d9abedea6816a3eba2cd4aeb3bd0215e50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

