### PR TITLE
fix(library): the sidebar's Create a plugin row draws no arrow over the tree roots

### DIFF
--- a/.changeset/sidebar-create-plugin-arrow.md
+++ b/.changeset/sidebar-create-plugin-arrow.md
@@ -1,0 +1,5 @@
+---
+'@bevel-software/platform-core-frontend': patch
+---
+
+The Advanced sidebar's "Create a plugin" row no longer draws a chalk arrow across the `Skills/` and `Plugins/` roots beneath it on a workspace with no plugins yet.

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -52,9 +52,9 @@ export interface PluginsSidebarProps {
   /** Start a new plugin. The layout owns the dialog; this is only the intent. */
   onCreatePlugin(): void;
   /**
-   * Whether to spell the first plugin out in words, with the chalk arrow. The
-   * hover-revealed `+` is unchanged for everyone; this is only the teaching
-   * mark, and it is an administrator's — see the row itself below.
+   * Whether to spell the first plugin out in words, as a row above the trees.
+   * The hover-revealed `+` is unchanged for everyone; this is only the
+   * teaching mark, and it is an administrator's — see the row itself below.
    *
    * The caller passes a SETTLED verdict, not just a role: the layout derives
    * it from `workspaceHasNoPlugins`, which stays false while plugin discovery

--- a/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
+++ b/packages/core-frontend/src/modules/library/components/PluginsSidebar.tsx
@@ -1,7 +1,6 @@
 import { useState, type MouseEvent, type ReactNode } from 'react';
 import { cn } from '../../../lib/utils';
 import type { LibraryFilter } from '../utils/status';
-import { ChalkArrow } from './plugin-page-parts';
 
 /**
  * Where a right-click landed in the nav, and everything the layout needs to
@@ -330,27 +329,25 @@ export function PluginsSidebar({
                 empty space, or on a folder in the Plugins tree — and a person
                 with no plugins yet is exactly the person who has not learned
                 either. While the workspace holds no plugins AT ALL, the way to
-                the first one is said in words, as a row above the trees —
-                with a chalk arrow from the empty space beneath, the same
-                margin-note voice as the empty plugin page. Administrators
-                only: on an untouched workspace the first plugin is theirs to
-                make, and telling everyone else to make it points them at a
-                decision that is not theirs. (Everything says the same in its
-                plugin band, for whoever never opens this view.) */}
+                the first one is said in words, as a row above the trees.
+                Words only, no chalk arrow: the `Skills/` and `Plugins/` roots
+                render directly beneath this row even when both are empty, so
+                there is no empty space for an arrow to come from — it drew
+                across the two root rows. (The empty plugin page keeps its
+                arrow; it has the room.) Administrators only: on an untouched
+                workspace the first plugin is theirs to make, and telling
+                everyone else to make it points them at a decision that is not
+                theirs. (Everything says the same in its plugin band, for
+                whoever never opens this view.) */}
             {canCreatePlugin && (
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={onCreatePlugin}
-                  className="flex items-center gap-2 rounded-sm px-2.5 py-1.5 text-left text-ui text-ink-faint transition-colors hover:bg-hover hover:text-ink"
-                >
-                  <span aria-hidden="true">+</span>
-                  <span className="truncate">Create a plugin</span>
-                </button>
-                {/* Mirrored, so the tip points up-left at the row's words from
-                    the room beneath it. */}
-                <ChalkArrow className="pointer-events-none absolute left-[22px] top-[30px] h-[52px] w-[64px] -scale-x-100 text-ink-faint" />
-              </div>
+              <button
+                type="button"
+                onClick={onCreatePlugin}
+                className="flex items-center gap-2 rounded-sm px-2.5 py-1.5 text-left text-ui text-ink-faint transition-colors hover:bg-hover hover:text-ink"
+              >
+                <span aria-hidden="true">+</span>
+                <span className="truncate">Create a plugin</span>
+              </button>
             )}
             {skillsTree}
             {pluginsTree}


### PR DESCRIPTION
## What

On a workspace with no plugins yet, the Advanced sidebar view spells out **Create a plugin** as a row above the two file trees. That row also drew a chalk arrow pointing up at it "from the empty space beneath". There is no such space: the `Skills/` and `Plugins/` root rows render directly under it even when both folders are empty, so the arrow was scribbled across those two rows. That is the artefact every new admin sees on their first visit to the Advanced tab.

## Fix

- `PluginsSidebar.tsx`: the row stays, the `ChalkArrow` and its import go. The comment now records why the sidebar has no arrow while the empty plugin page keeps its own (that page has the room).
- Changeset: patch for `@bevel-software/platform-core-frontend`.

No behaviour change beyond the removed drawing: the button, its label, its admin-only gate and the existing sidebar tests are untouched.

## Verification

The file parses with esbuild and has no remaining `ChalkArrow` reference. I could not run `typecheck`, `lint` or `vitest` locally: `pnpm install` fails in this environment because the `xlsx` dependency is pinned to `cdn.sheetjs.com`, which the session's egress policy blocks. CI should cover those three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZE8GrWA2KtYjPh9S79coc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZE8GrWA2KtYjPh9S79coc)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the chalk arrow from the Advanced sidebar's "Create a plugin" row, which previously drew across the `Skills/` and `Plugins/` roots on workspaces with no plugins yet.

- The empty plugin page keeps its arrow, since it has room for one.
- The button, its label, the admin-only gate, and existing tests are unchanged.

<sup>Written for commit cc35e04fc3d12603ba1b7dfa646013737c3f9d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Bevel-Software/Hexis/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

